### PR TITLE
chore(license): update license

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@across-protocol/contracts-v2",
   "version": "2.0.1",
   "author": "UMA Team",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/across-protocol/across-smart-contracts-v2.git"


### PR DESCRIPTION
**Scope**
This change updates the `package.json` license to GPL-3.0. 

**Motivation**
The original SPDX-identifier for the GNU Affero GPL 3.0 license (`AGPL-3.0`) has been deprecated. 

![image](https://user-images.githubusercontent.com/96435344/206530552-bf86d219-1ace-4a56-b6b1-26ca27f934bc.png)

The more current SPDX identifier for the Affero GPL 3.0 is `AGPL-3.0-only`