### PR TITLE
fix: deployment of release beta version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts-v2",
-  "version": "2.5.0",
+  "version": "2.5.0-beta.0",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
We had a failing action to get `2.5.0-beta.0` to npmjs.

https://github.com/across-protocol/contracts-v2/actions/runs/7757225115