### PR TITLE
feat(SpokePool): Add depositExclusive() function to support exclusive order routing

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -687,6 +687,73 @@ abstract contract SpokePool is
     }
 
     /**
+     * @notice Submits deposit and sets exclusivityDeadline to current time plus some offset. This function is
+     * designed to be called by users who want to set an exclusive relayer for some amount of time after their deposit
+     * transaction is mined.
+     * @notice If exclusivtyDeadlineOffset > 0, then exclusiveRelayer must be set to a valid address, which is a
+     * requirement imposed by depositV3().
+     * @param depositor The account credited with the deposit who can request to "speed up" this deposit by modifying
+     * the output amount, recipient, and message.
+     * @param recipient The account receiving funds on the destination chain. Can be an EOA or a contract. If
+     * the output token is the wrapped native token for the chain, then the recipient will receive native token if
+     * an EOA or wrapped native token if a contract.
+     * @param inputToken The token pulled from the caller's account and locked into this contract to
+     * initiate the deposit. The equivalent of this token on the relayer's repayment chain of choice will be sent
+     * as a refund. If this is equal to the wrapped native token then the caller can optionally pass in native token as
+     * msg.value, as long as msg.value = inputTokenAmount.
+     * @param outputToken The token that the relayer will send to the recipient on the destination chain. Must be an
+     * ERC20.
+     * @param inputAmount The amount of input tokens to pull from the caller's account and lock into this contract.
+     * This amount will be sent to the relayer on their repayment chain of choice as a refund following an optimistic
+     * challenge window in the HubPool, plus a system fee.
+     * @param outputAmount The amount of output tokens that the relayer will send to the recipient on the destination.
+     * @param destinationChainId The destination chain identifier. Must be enabled along with the input token
+     * as a valid deposit route from this spoke pool or this transaction will revert.
+     * @param exclusiveRelayer The relayer that will be exclusively allowed to fill this deposit before the
+     * exclusivity deadline timestamp.
+     * @param quoteTimestamp The HubPool timestamp that is used to determine the system fee paid by the depositor.
+     *  This must be set to some time between [currentTime - depositQuoteTimeBuffer, currentTime]
+     * where currentTime is block.timestamp on this chain or this transaction will revert.
+     * @param fillDeadline The deadline for the relayer to fill the deposit. After this destination chain timestamp,
+     * the fill will revert on the destination chain. Must be set between [currentTime, currentTime + fillDeadlineBuffer]
+     * where currentTime is block.timestamp on this chain or this transaction will revert.
+     * @param exclusivityDeadlineOffset Added to the current time to set the exclusive reayer deadline,
+     * which is the deadline for the exclusiveRelayer to fill the deposit. After this destination chain timestamp,
+     * anyone can fill the deposit.
+     * @param message The message to send to the recipient on the destination chain if the recipient is a contract.
+     * If the message is not empty, the recipient contract must implement handleV3AcrossMessage() or the fill will revert.
+     */
+    function depositExclusive(
+        address depositor,
+        address recipient,
+        address inputToken,
+        address outputToken,
+        uint256 inputAmount,
+        uint256 outputAmount,
+        uint256 destinationChainId,
+        address exclusiveRelayer,
+        uint32 quoteTimestamp,
+        uint32 fillDeadline,
+        uint32 exclusivityDeadlineOffset,
+        bytes calldata message
+    ) public payable {
+        depositV3(
+            depositor,
+            recipient,
+            inputToken,
+            outputToken,
+            inputAmount,
+            outputAmount,
+            destinationChainId,
+            exclusiveRelayer,
+            quoteTimestamp,
+            fillDeadline,
+            uint32(getCurrentTime()) + exclusivityDeadlineOffset,
+            message
+        );
+    }
+
+    /**
      * @notice Depositor can use this function to signal to relayer to use updated output amount, recipient,
      * and/or message.
      * @dev the depositor and depositId must match the params in a V3FundsDeposited event that the depositor

--- a/storage-layouts/Arbitrum_SpokePool.json
+++ b/storage-layouts/Arbitrum_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 65577,
+      "astId": 65627,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65580,
+      "astId": 65630,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 65559,
+      "astId": 65609,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65875,
+      "astId": 65925,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65891,
+      "astId": 65941,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 65960,
+      "astId": 66010,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 17991,
+      "astId": 18041,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17723,
+      "astId": 17773,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17725,
+      "astId": 17775,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17824,
+      "astId": 17874,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13461"
+      "type": "t_contract(WETH9Interface)13511"
     },
     {
       "astId": 5945,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14038_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
     },
     {
       "astId": 5961,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7882,
+      "astId": 7932,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -223,11 +223,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)14038_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14038_storage"
+      "base": "t_struct(RootBundle)14088_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -263,7 +263,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(WETH9Interface)13461": {
+    "t_contract(WETH9Interface)13511": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -310,13 +310,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)14038_storage": {
+    "t_struct(RootBundle)14088_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 14031,
+          "astId": 14081,
           "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -324,7 +324,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14033,
+          "astId": 14083,
           "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -332,7 +332,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14037,
+          "astId": 14087,
           "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/Base_SpokePool.json
+++ b/storage-layouts/Base_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 65577,
+      "astId": 65627,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65580,
+      "astId": 65630,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 65559,
+      "astId": 65609,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65875,
+      "astId": 65925,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65891,
+      "astId": 65941,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 65960,
+      "astId": 66010,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 17991,
+      "astId": 18041,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17723,
+      "astId": 17773,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17725,
+      "astId": 17775,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17824,
+      "astId": 17874,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13461"
+      "type": "t_contract(WETH9Interface)13511"
     },
     {
       "astId": 5945,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14038_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
     },
     {
       "astId": 5961,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7882,
+      "astId": 7932,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -247,11 +247,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)14038_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14038_storage"
+      "base": "t_struct(RootBundle)14088_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -287,7 +287,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(WETH9Interface)13461": {
+    "t_contract(WETH9Interface)13511": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -334,13 +334,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)14038_storage": {
+    "t_struct(RootBundle)14088_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 14031,
+          "astId": 14081,
           "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -348,7 +348,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14033,
+          "astId": 14083,
           "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -356,7 +356,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14037,
+          "astId": 14087,
           "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/Ethereum_SpokePool.json
+++ b/storage-layouts/Ethereum_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 65577,
+      "astId": 65627,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65580,
+      "astId": 65630,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 65559,
+      "astId": 65609,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65875,
+      "astId": 65925,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65891,
+      "astId": 65941,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 65960,
+      "astId": 66010,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 17991,
+      "astId": 18041,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17723,
+      "astId": 17773,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17725,
+      "astId": 17775,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17824,
+      "astId": 17874,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13461"
+      "type": "t_contract(WETH9Interface)13511"
     },
     {
       "astId": 5945,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14038_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
     },
     {
       "astId": 5961,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7882,
+      "astId": 7932,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_array(t_uint256)999_storage"
     },
     {
-      "astId": 66831,
+      "astId": 66881,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65029,
+      "astId": 65079,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_owner",
       "offset": 0,
@@ -217,7 +217,7 @@
       "type": "t_address"
     },
     {
-      "astId": 65149,
+      "astId": 65199,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -231,11 +231,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)14038_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14038_storage"
+      "base": "t_struct(RootBundle)14088_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -271,7 +271,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(WETH9Interface)13461": {
+    "t_contract(WETH9Interface)13511": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -311,13 +311,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)14038_storage": {
+    "t_struct(RootBundle)14088_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 14031,
+          "astId": 14081,
           "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -325,7 +325,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14033,
+          "astId": 14083,
           "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -333,7 +333,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14037,
+          "astId": 14087,
           "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/Linea_SpokePool.json
+++ b/storage-layouts/Linea_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 65577,
+      "astId": 65627,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65580,
+      "astId": 65630,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 65559,
+      "astId": 65609,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65875,
+      "astId": 65925,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65891,
+      "astId": 65941,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 65960,
+      "astId": 66010,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 17991,
+      "astId": 18041,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17723,
+      "astId": 17773,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17725,
+      "astId": 17775,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17824,
+      "astId": 17874,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13461"
+      "type": "t_contract(WETH9Interface)13511"
     },
     {
       "astId": 5945,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14038_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
     },
     {
       "astId": 5961,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7882,
+      "astId": 7932,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -206,7 +206,7 @@
       "label": "l2MessageService",
       "offset": 0,
       "slot": "3162",
-      "type": "t_contract(IMessageService)13377"
+      "type": "t_contract(IMessageService)13427"
     },
     {
       "astId": 3228,
@@ -214,7 +214,7 @@
       "label": "l2TokenBridge",
       "offset": 0,
       "slot": "3163",
-      "type": "t_contract(ITokenBridge)13389"
+      "type": "t_contract(ITokenBridge)13439"
     },
     {
       "astId": 3232,
@@ -222,7 +222,7 @@
       "label": "l2UsdcBridge",
       "offset": 0,
       "slot": "3164",
-      "type": "t_contract(IUSDCBridge)13403"
+      "type": "t_contract(IUSDCBridge)13453"
     }
   ],
   "types": {
@@ -231,11 +231,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)14038_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14038_storage"
+      "base": "t_struct(RootBundle)14088_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -271,22 +271,22 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(IMessageService)13377": {
+    "t_contract(IMessageService)13427": {
       "encoding": "inplace",
       "label": "contract IMessageService",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenBridge)13389": {
+    "t_contract(ITokenBridge)13439": {
       "encoding": "inplace",
       "label": "contract ITokenBridge",
       "numberOfBytes": "20"
     },
-    "t_contract(IUSDCBridge)13403": {
+    "t_contract(IUSDCBridge)13453": {
       "encoding": "inplace",
       "label": "contract IUSDCBridge",
       "numberOfBytes": "20"
     },
-    "t_contract(WETH9Interface)13461": {
+    "t_contract(WETH9Interface)13511": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -326,13 +326,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)14038_storage": {
+    "t_struct(RootBundle)14088_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 14031,
+          "astId": 14081,
           "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -340,7 +340,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14033,
+          "astId": 14083,
           "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -348,7 +348,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14037,
+          "astId": 14087,
           "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/Mode_SpokePool.json
+++ b/storage-layouts/Mode_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 65577,
+      "astId": 65627,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65580,
+      "astId": 65630,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 65559,
+      "astId": 65609,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65875,
+      "astId": 65925,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65891,
+      "astId": 65941,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 65960,
+      "astId": 66010,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 17991,
+      "astId": 18041,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17723,
+      "astId": 17773,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17725,
+      "astId": 17775,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17824,
+      "astId": 17874,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13461"
+      "type": "t_contract(WETH9Interface)13511"
     },
     {
       "astId": 5945,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14038_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
     },
     {
       "astId": 5961,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7882,
+      "astId": 7932,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -247,11 +247,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)14038_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14038_storage"
+      "base": "t_struct(RootBundle)14088_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -287,7 +287,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(WETH9Interface)13461": {
+    "t_contract(WETH9Interface)13511": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -334,13 +334,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)14038_storage": {
+    "t_struct(RootBundle)14088_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 14031,
+          "astId": 14081,
           "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -348,7 +348,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14033,
+          "astId": 14083,
           "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -356,7 +356,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14037,
+          "astId": 14087,
           "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/Optimism_SpokePool.json
+++ b/storage-layouts/Optimism_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 65577,
+      "astId": 65627,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65580,
+      "astId": 65630,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 65559,
+      "astId": 65609,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65875,
+      "astId": 65925,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65891,
+      "astId": 65941,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 65960,
+      "astId": 66010,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 17991,
+      "astId": 18041,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17723,
+      "astId": 17773,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17725,
+      "astId": 17775,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17824,
+      "astId": 17874,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13461"
+      "type": "t_contract(WETH9Interface)13511"
     },
     {
       "astId": 5945,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14038_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
     },
     {
       "astId": 5961,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7882,
+      "astId": 7932,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -247,11 +247,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)14038_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14038_storage"
+      "base": "t_struct(RootBundle)14088_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -287,7 +287,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(WETH9Interface)13461": {
+    "t_contract(WETH9Interface)13511": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -334,13 +334,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)14038_storage": {
+    "t_struct(RootBundle)14088_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 14031,
+          "astId": 14081,
           "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -348,7 +348,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14033,
+          "astId": 14083,
           "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -356,7 +356,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14037,
+          "astId": 14087,
           "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/Polygon_SpokePool.json
+++ b/storage-layouts/Polygon_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 65577,
+      "astId": 65627,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65580,
+      "astId": 65630,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 65559,
+      "astId": 65609,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65875,
+      "astId": 65925,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65891,
+      "astId": 65941,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 65960,
+      "astId": 66010,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 17991,
+      "astId": 18041,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17723,
+      "astId": 17773,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17725,
+      "astId": 17775,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17824,
+      "astId": 17874,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13461"
+      "type": "t_contract(WETH9Interface)13511"
     },
     {
       "astId": 5945,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14038_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
     },
     {
       "astId": 5961,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7882,
+      "astId": 7932,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -231,11 +231,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)14038_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14038_storage"
+      "base": "t_struct(RootBundle)14088_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -276,7 +276,7 @@
       "label": "contract PolygonTokenBridger",
       "numberOfBytes": "20"
     },
-    "t_contract(WETH9Interface)13461": {
+    "t_contract(WETH9Interface)13511": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -316,13 +316,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)14038_storage": {
+    "t_struct(RootBundle)14088_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 14031,
+          "astId": 14081,
           "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -330,7 +330,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14033,
+          "astId": 14083,
           "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -338,7 +338,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14037,
+          "astId": 14087,
           "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/ZkSync_SpokePool.json
+++ b/storage-layouts/ZkSync_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 65577,
+      "astId": 65627,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65580,
+      "astId": 65630,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 65559,
+      "astId": 65609,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65875,
+      "astId": 65925,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65891,
+      "astId": 65941,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 65960,
+      "astId": 66010,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 17991,
+      "astId": 18041,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17723,
+      "astId": 17773,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17725,
+      "astId": 17775,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17824,
+      "astId": 17874,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13461"
+      "type": "t_contract(WETH9Interface)13511"
     },
     {
       "astId": 5945,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14038_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
     },
     {
       "astId": 5961,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7882,
+      "astId": 7932,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_array(t_uint256)999_storage"
     },
     {
-      "astId": 8611,
+      "astId": 8661,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "l2Eth",
       "offset": 0,
@@ -209,12 +209,12 @@
       "type": "t_address"
     },
     {
-      "astId": 8614,
+      "astId": 8664,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "zkErc20Bridge",
       "offset": 0,
       "slot": "3163",
-      "type": "t_contract(ZkBridgeLike)8600"
+      "type": "t_contract(ZkBridgeLike)8650"
     }
   ],
   "types": {
@@ -223,11 +223,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)14038_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14038_storage"
+      "base": "t_struct(RootBundle)14088_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -263,12 +263,12 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(WETH9Interface)13461": {
+    "t_contract(WETH9Interface)13511": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
     },
-    "t_contract(ZkBridgeLike)8600": {
+    "t_contract(ZkBridgeLike)8650": {
       "encoding": "inplace",
       "label": "contract ZkBridgeLike",
       "numberOfBytes": "20"
@@ -308,13 +308,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)14038_storage": {
+    "t_struct(RootBundle)14088_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 14031,
+          "astId": 14081,
           "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -322,7 +322,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14033,
+          "astId": 14083,
           "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -330,7 +330,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14037,
+          "astId": 14087,
           "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -562,6 +562,43 @@ describe("SpokePool Depositor Logic", async function () {
           relayData.message
         );
     });
+    it("depositExclusive sets exclusive deadline correctly", async function () {
+      const currentTime = (await spokePool.getCurrentTime()).toNumber();
+      const exclusivityDeadlineOffset = 1000;
+      await expect(
+        spokePool.connect(depositor).depositExclusive(
+          relayData.depositor,
+          relayData.recipient,
+          relayData.inputToken,
+          relayData.outputToken,
+          relayData.inputAmount,
+          relayData.outputAmount,
+          destinationChainId,
+          relayData.depositor, // non-zero exclusive relayer
+          currentTime,
+          relayData.fillDeadline,
+          exclusivityDeadlineOffset,
+          relayData.message
+        )
+      )
+        .to.emit(spokePool, "V3FundsDeposited")
+        .withArgs(
+          relayData.inputToken,
+          relayData.outputToken,
+          relayData.inputAmount,
+          relayData.outputAmount,
+          destinationChainId,
+          // deposit ID is 0 for first deposit
+          0,
+          currentTime, // quoteTimestamp should be current time
+          relayData.fillDeadline,
+          currentTime + exclusivityDeadlineOffset, // should be current time + offset
+          relayData.depositor,
+          relayData.recipient,
+          relayData.depositor, // non-zero exclusive relayer
+          relayData.message
+        );
+    });
     it("emits V3FundsDeposited event with correct deposit ID", async function () {
       await expect(spokePool.connect(depositor).depositV3(...depositArgs))
         .to.emit(spokePool, "V3FundsDeposited")


### PR DESCRIPTION
We want to support a user flow where a depositor can be paired off-chain with an `exclusiveRelayer` and give them a very short exclusivity window (think ~2-4 seconds) but we don't want the depositor to have to consider the latency between their deposit txn being submitted to the mempool and when it is mined. Instead, good depositor UX essentially requires that an offset can be specified so that a depositor can specify the amout of exclusivity the filler can get after a deposit is mined.
