### PR TITLE
feat(ERC7683Depositor): Initiator of gas-less deposit should specify exclusivity offset, not deadline

### DIFF
--- a/contracts/erc7683/ERC7683Across.sol
+++ b/contracts/erc7683/ERC7683Across.sol
@@ -12,7 +12,7 @@ struct AcrossOrderData {
     uint256 outputAmount;
     uint32 destinationChainId;
     address recipient;
-    uint32 exclusivityDeadline;
+    uint32 exclusivityDeadlineOffset;
     bytes message;
 }
 
@@ -34,7 +34,7 @@ library ERC7683Permit2Lib {
             "uint256 outputAmount,",
             "uint32 destinationChainId,",
             "address recipient,",
-            "uint32 exclusivityDeadline,",
+            "uint32 exclusivityDeadlineOffset,",
             "bytes message)"
         );
 
@@ -85,7 +85,7 @@ library ERC7683Permit2Lib {
                     orderData.outputAmount,
                     orderData.destinationChainId,
                     orderData.recipient,
-                    orderData.exclusivityDeadline,
+                    orderData.exclusivityDeadlineOffset,
                     orderData.message
                 )
             );

--- a/contracts/erc7683/ERC7683Depositor.sol
+++ b/contracts/erc7683/ERC7683Depositor.sol
@@ -27,14 +27,24 @@ abstract contract ERC7683OrderDepositor is ISettlementContract {
     // This is a somewhat arbitrary conversion, but order creators need some way to precompute the quote timestamp.
     uint256 public immutable QUOTE_BEFORE_DEADLINE;
 
+    // The maximum offset that can be added to the timestamp that a deposit is mined to get the exclusivityDeadline.
+    // Set this lower to protect depositors from fillers setting this too high.
+    uint256 public immutable MAX_EXCLUSIVITY_DEADLINE_OFFSET;
+
     /**
      * @notice Construct the Permit2Depositor.
      * @param _permit2 Permit2 contract
      * @param _quoteBeforeDeadline quoteBeforeDeadline is subtracted from the deadline to get the quote timestamp.
+     * @param _maxExclusivityDeadlineOffset The maximum offset that can be added to the timestamp that a deposit is mined to get the exclusivityDeadline.
      */
-    constructor(IPermit2 _permit2, uint256 _quoteBeforeDeadline) {
+    constructor(
+        IPermit2 _permit2,
+        uint256 _quoteBeforeDeadline,
+        uint256 _maxExclusivityDeadlineOffset
+    ) {
         PERMIT2 = _permit2;
         QUOTE_BEFORE_DEADLINE = _quoteBeforeDeadline;
+        MAX_EXCLUSIVITY_DEADLINE_OFFSET = _maxExclusivityDeadlineOffset;
     }
 
     /**
@@ -79,7 +89,7 @@ abstract contract ERC7683OrderDepositor is ISettlementContract {
             // Note: simplifying assumption to avoid quote timestamps that cause orders to expire before the deadline.
             SafeCast.toUint32(order.initiateDeadline - QUOTE_BEFORE_DEADLINE),
             order.fillDeadline,
-            acrossOrderData.exclusivityDeadline,
+            SafeCast.toUint32(getCurrentTime()) + acrossOrderData.exclusivityDeadlineOffset,
             acrossOrderData.message
         );
     }
@@ -156,6 +166,14 @@ abstract contract ERC7683OrderDepositor is ISettlementContract {
         return (abi.decode(orderData, (AcrossOrderData)), abi.decode(fillerData, (AcrossFillerData)));
     }
 
+    /**
+     * @notice Gets the current time.
+     * @return uint for the current timestamp.
+     */
+    function getCurrentTime() public view virtual returns (uint256) {
+        return block.timestamp; // solhint-disable-line not-rely-on-time
+    }
+
     function _processPermit2Order(
         CrossChainOrder memory order,
         AcrossOrderData memory acrossOrderData,
@@ -213,8 +231,9 @@ contract ERC7683OrderDepositorExternal is ERC7683OrderDepositor {
     constructor(
         V3SpokePoolInterface _spokePool,
         IPermit2 _permit2,
-        uint256 _quoteBeforeDeadline
-    ) ERC7683OrderDepositor(_permit2, _quoteBeforeDeadline) {
+        uint256 _quoteBeforeDeadline,
+        uint256 _maxExclusivityDeadlineOffset
+    ) ERC7683OrderDepositor(_permit2, _quoteBeforeDeadline, _maxExclusivityDeadlineOffset) {
         SPOKE_POOL = _spokePool;
     }
 


### PR DESCRIPTION
Similar to #514, this contract is designed to support a user flow where the user and filler communicate off-chain to produce an exclusivity agreement in which a filler gives user's a quote or a commitment that they will fill their deposit, in exchange the user should give the filler exclusive rights to fill for some time.

This PR introduces a way for this contract to set a cap on the exclusivity deadline that any filler can set when they `initiate` a deposit on-chain. In addition, the filler's specified `exclusivityDeadline` is replaced with an `exclusivityDeadlineOffset` which is better UX since they cannot control when the the deposit they `initiate` will be mined.
