### PR TITLE
fix(ERC7683Permit2Lib): Comply with EIP712

### DIFF
--- a/contracts/erc7683/ERC7683Across.sol
+++ b/contracts/erc7683/ERC7683Across.sol
@@ -61,7 +61,7 @@ library ERC7683Permit2Lib {
     function hashOrder(CrossChainOrder memory order, bytes32 orderDataHash) internal pure returns (bytes32) {
         return
             keccak256(
-                abi.encodePacked(
+                abi.encode(
                     CROSS_CHAIN_ORDER_TYPE_HASH,
                     order.settlementContract,
                     order.swapper,
@@ -86,7 +86,7 @@ library ERC7683Permit2Lib {
                     orderData.destinationChainId,
                     orderData.recipient,
                     orderData.exclusivityDeadline,
-                    orderData.message
+                    keccak256(orderData.message)
                 )
             );
     }

--- a/contracts/erc7683/ERC7683Across.sol
+++ b/contracts/erc7683/ERC7683Across.sol
@@ -77,7 +77,7 @@ library ERC7683Permit2Lib {
     function hashOrderData(AcrossOrderData memory orderData) internal pure returns (bytes32) {
         return
             keccak256(
-                abi.encodePacked(
+                abi.encode(
                     ACROSS_ORDER_DATA_TYPE_HASH,
                     orderData.inputToken,
                     orderData.inputAmount,


### PR DESCRIPTION
- should use abi.encode instead of abi.encodePacked when encoding data into a hash
- Should keccak256 any `bytes` member like `message` in the `AcrossOrderData` struct
