### PR TITLE
improve: Use pre-increment to save gas on loops

### DIFF
--- a/contracts/handlers/MulticallHandler.sol
+++ b/contracts/handlers/MulticallHandler.sol
@@ -77,7 +77,7 @@ contract MulticallHandler is AcrossMessageHandler, ReentrancyGuard {
 
     function attemptCalls(Call[] memory calls) external onlySelf {
         uint256 length = calls.length;
-        for (uint256 i = 0; i < length; i++) {
+        for (uint256 i = 0; i < length; ++i) {
             Call memory call = calls[i];
             (bool success, ) = call.target.call{ value: call.value }(call.callData);
             if (!success) revert CallReverted(i, calls);

--- a/contracts/upgradeable/MultiCallerUpgradeable.sol
+++ b/contracts/upgradeable/MultiCallerUpgradeable.sol
@@ -59,7 +59,7 @@ contract MultiCallerUpgradeable {
         results = new Result[](dataLength);
 
         //slither-disable-start calls-loop
-        for (uint256 i = 0; i < dataLength; i++) {
+        for (uint256 i = 0; i < dataLength; ++i) {
             // The delegatecall here is safe for the same reasons outlined in the first multicall function.
             Result memory result = results[i];
             //slither-disable-start low-level-calls


### PR DESCRIPTION
This optimization skips storing the value before the incremental
operation as the return value of the expression is ignored.
