### PR TITLE
improve(forge-ci): Ignore astId and other non-storage slot related props when diffing storage layouts

### DIFF
--- a/scripts/checkStorageLayout.sh
+++ b/scripts/checkStorageLayout.sh
@@ -8,7 +8,7 @@ if [[ "$1" == "--overwrite" ]]; then
         # Delete any astId keys from the file, which seem to change every time the bytecode changes
         # and the types object which also contains astId changes. We only care about the size and relative
         # location of state variable slots.
-        jq 'del(.storage[] | .astId)' ./storage-layouts/temp.$CONTRACT.json | jq 'del(.types)' > ./storage-layouts/$CONTRACT.json
+        jq 'del(.storage[] | .astId)' ./storage-layouts/temp.$CONTRACT.json | jq 'del(.storage[] | .type)' | jq 'del(.types)' > ./storage-layouts/$CONTRACT.json
         rm ./storage-layouts/temp.$CONTRACT.json
         echo "✅ 'forge inspect' saved new $CONTRACT storage layout at './storage-layouts/$CONTRACT.json'."
     done

--- a/scripts/checkStorageLayout.sh
+++ b/scripts/checkStorageLayout.sh
@@ -4,7 +4,12 @@ CONTRACTS=("Arbitrum_SpokePool" "Optimism_SpokePool" "Polygon_SpokePool" "Linea_
 if [[ "$1" == "--overwrite" ]]; then
     for CONTRACT in "${CONTRACTS[@]}"; do
         echo "Overwrite flag detected. Creating new storage layout snapshot of the $CONTRACT contract"
-        forge inspect $CONTRACT storagelayout > ./storage-layouts/$CONTRACT.json
+        forge inspect $CONTRACT storagelayout > ./storage-layouts/temp.$CONTRACT.json
+        # Delete any astId keys from the file, which seem to change every time the bytecode changes
+        # and the types object which also contains astId changes. We only care about the size and relative
+        # location of state variable slots.
+        jq 'del(.storage[] | .astId)' ./storage-layouts/temp.$CONTRACT.json | jq 'del(.types)' > ./storage-layouts/$CONTRACT.json
+        rm ./storage-layouts/temp.$CONTRACT.json
         echo "✅ 'forge inspect' saved new $CONTRACT storage layout at './storage-layouts/$CONTRACT.json'."
     done
     exit 0

--- a/scripts/checkStorageLayout.sh
+++ b/scripts/checkStorageLayout.sh
@@ -18,7 +18,12 @@ fi
 for CONTRACT in "${CONTRACTS[@]}"; do
     echo "Comparing storage layout snapshot of the $CONTRACT contract at ./storage-layouts/$CONTRACT.json with current storage layout"
     echo "Created temporary storage layout file at ./storage-layouts/proposed.$CONTRACT.json"
-    forge inspect $CONTRACT storagelayout > ./storage-layouts/proposed.$CONTRACT.json
+    forge inspect $CONTRACT storagelayout > ./storage-layouts/temp.$CONTRACT.json
+    # Delete any astId keys from the file, which seem to change every time the bytecode changes
+    # and the types object which also contains astId changes. We only care about the size and relative
+    # location of state variable slots.
+    jq 'del(.storage[] | .astId)' ./storage-layouts/temp.$CONTRACT.json | jq 'del(.storage[] | .type)' | jq 'del(.types)' > ./storage-layouts/proposed.$CONTRACT.json
+    rm ./storage-layouts/temp.$CONTRACT.json
     echo "'forge inspect' command created temp storage layout file!"
     if ! diff -q "./storage-layouts/proposed.$CONTRACT.json" "./storage-layouts/$CONTRACT.json" &>/dev/null; then
         >&2 echo "❌ Diff detected in storage layout for $CONTRACT. Please update the storage layout file in the storage-layouts/ directory."

--- a/storage-layouts/Arbitrum_SpokePool.json
+++ b/storage-layouts/Arbitrum_SpokePool.json
@@ -1,7 +1,6 @@
 {
   "storage": [
     {
-      "astId": 65627,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +8,6 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65630,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +15,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 65609,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +22,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65925,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +29,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65941,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +36,6 @@
       "type": "t_uint256"
     },
     {
-      "astId": 66010,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +43,6 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 18041,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +50,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17773,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +57,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17775,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +64,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17874,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -81,7 +71,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 5938,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
@@ -89,7 +78,6 @@
       "type": "t_address"
     },
     {
-      "astId": 5940,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "hubPool",
       "offset": 0,
@@ -97,15 +85,13 @@
       "type": "t_address"
     },
     {
-      "astId": 5943,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13511"
+      "type": "t_contract(WETH9Interface)8655"
     },
     {
-      "astId": 5945,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
@@ -113,7 +99,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5947,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
@@ -121,7 +106,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5949,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "pausedFills",
       "offset": 28,
@@ -129,7 +113,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 5951,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
@@ -137,15 +120,13 @@
       "type": "t_bool"
     },
     {
-      "astId": 5955,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
     },
     {
-      "astId": 5961,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
@@ -153,7 +134,6 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 5965,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
@@ -161,7 +141,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5969,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
@@ -169,7 +148,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5973,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
@@ -177,7 +155,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5977,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
@@ -185,7 +162,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5981,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
@@ -193,7 +169,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7932,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -201,7 +176,6 @@
       "type": "t_array(t_uint256)999_storage"
     },
     {
-      "astId": 98,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "l2GatewayRouter",
       "offset": 0,
@@ -209,152 +183,11 @@
       "type": "t_address"
     },
     {
-      "astId": 102,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "whitelistedTokens",
       "offset": 0,
       "slot": "3163",
       "type": "t_mapping(t_address,t_address)"
     }
-  ],
-  "types": {
-    "t_address": {
-      "encoding": "inplace",
-      "label": "address",
-      "numberOfBytes": "20"
-    },
-    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
-      "encoding": "dynamic_array",
-      "label": "struct SpokePoolInterface.RootBundle[]",
-      "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14088_storage"
-    },
-    "t_array(t_uint256)1000_storage": {
-      "encoding": "inplace",
-      "label": "uint256[1000]",
-      "numberOfBytes": "32000",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)49_storage": {
-      "encoding": "inplace",
-      "label": "uint256[49]",
-      "numberOfBytes": "1568",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)50_storage": {
-      "encoding": "inplace",
-      "label": "uint256[50]",
-      "numberOfBytes": "1600",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)999_storage": {
-      "encoding": "inplace",
-      "label": "uint256[999]",
-      "numberOfBytes": "31968",
-      "base": "t_uint256"
-    },
-    "t_bool": {
-      "encoding": "inplace",
-      "label": "bool",
-      "numberOfBytes": "1"
-    },
-    "t_bytes32": {
-      "encoding": "inplace",
-      "label": "bytes32",
-      "numberOfBytes": "32"
-    },
-    "t_contract(WETH9Interface)13511": {
-      "encoding": "inplace",
-      "label": "contract WETH9Interface",
-      "numberOfBytes": "20"
-    },
-    "t_mapping(t_address,t_address)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => address)",
-      "numberOfBytes": "32",
-      "value": "t_address"
-    },
-    "t_mapping(t_address,t_mapping(t_uint256,t_bool))": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => mapping(uint256 => bool))",
-      "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_bool)"
-    },
-    "t_mapping(t_address,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_bytes32,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_bytes32",
-      "label": "mapping(bytes32 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_uint256,t_bool)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => bool)",
-      "numberOfBytes": "32",
-      "value": "t_bool"
-    },
-    "t_mapping(t_uint256,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_struct(RootBundle)14088_storage": {
-      "encoding": "inplace",
-      "label": "struct SpokePoolInterface.RootBundle",
-      "numberOfBytes": "96",
-      "members": [
-        {
-          "astId": 14081,
-          "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
-          "label": "slowRelayRoot",
-          "offset": 0,
-          "slot": "0",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14083,
-          "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
-          "label": "relayerRefundRoot",
-          "offset": 0,
-          "slot": "1",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14087,
-          "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
-          "label": "claimedBitmap",
-          "offset": 0,
-          "slot": "2",
-          "type": "t_mapping(t_uint256,t_uint256)"
-        }
-      ]
-    },
-    "t_uint256": {
-      "encoding": "inplace",
-      "label": "uint256",
-      "numberOfBytes": "32"
-    },
-    "t_uint32": {
-      "encoding": "inplace",
-      "label": "uint32",
-      "numberOfBytes": "4"
-    },
-    "t_uint8": {
-      "encoding": "inplace",
-      "label": "uint8",
-      "numberOfBytes": "1"
-    }
-  }
+  ]
 }

--- a/storage-layouts/Arbitrum_SpokePool.json
+++ b/storage-layouts/Arbitrum_SpokePool.json
@@ -4,190 +4,163 @@
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_initialized",
       "offset": 0,
-      "slot": "0",
-      "type": "t_uint8"
+      "slot": "0"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_initializing",
       "offset": 1,
-      "slot": "0",
-      "type": "t_bool"
+      "slot": "0"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "1"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "51",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "51"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_status",
       "offset": 0,
-      "slot": "101",
-      "type": "t_uint256"
+      "slot": "101"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "102",
-      "type": "t_array(t_uint256)49_storage"
+      "slot": "102"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "151",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "151"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
-      "slot": "1151",
-      "type": "t_bytes32"
+      "slot": "1151"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
-      "slot": "1152",
-      "type": "t_bytes32"
+      "slot": "1152"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1153",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "1153"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
-      "slot": "2153",
-      "type": "t_address"
+      "slot": "2153"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "hubPool",
       "offset": 0,
-      "slot": "2154",
-      "type": "t_address"
+      "slot": "2154"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
-      "slot": "2155",
-      "type": "t_contract(WETH9Interface)8655"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "pausedFills",
       "offset": 28,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "rootBundles",
       "offset": 0,
-      "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
+      "slot": "2156"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
-      "slot": "2157",
-      "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
+      "slot": "2157"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
-      "slot": "2158",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2158"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
-      "slot": "2159",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2159"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
-      "slot": "2160",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2160"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
-      "slot": "2161",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2161"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
-      "slot": "2162",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2162"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "2163",
-      "type": "t_array(t_uint256)999_storage"
+      "slot": "2163"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "l2GatewayRouter",
       "offset": 0,
-      "slot": "3162",
-      "type": "t_address"
+      "slot": "3162"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "whitelistedTokens",
       "offset": 0,
-      "slot": "3163",
-      "type": "t_mapping(t_address,t_address)"
+      "slot": "3163"
     }
   ]
 }

--- a/storage-layouts/Base_SpokePool.json
+++ b/storage-layouts/Base_SpokePool.json
@@ -4,211 +4,181 @@
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_initialized",
       "offset": 0,
-      "slot": "0",
-      "type": "t_uint8"
+      "slot": "0"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_initializing",
       "offset": 1,
-      "slot": "0",
-      "type": "t_bool"
+      "slot": "0"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "1"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "51",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "51"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_status",
       "offset": 0,
-      "slot": "101",
-      "type": "t_uint256"
+      "slot": "101"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "102",
-      "type": "t_array(t_uint256)49_storage"
+      "slot": "102"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "151",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "151"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
-      "slot": "1151",
-      "type": "t_bytes32"
+      "slot": "1151"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
-      "slot": "1152",
-      "type": "t_bytes32"
+      "slot": "1152"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1153",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "1153"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
-      "slot": "2153",
-      "type": "t_address"
+      "slot": "2153"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "hubPool",
       "offset": 0,
-      "slot": "2154",
-      "type": "t_address"
+      "slot": "2154"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
-      "slot": "2155",
-      "type": "t_contract(WETH9Interface)8655"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "pausedFills",
       "offset": 28,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "rootBundles",
       "offset": 0,
-      "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
+      "slot": "2156"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
-      "slot": "2157",
-      "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
+      "slot": "2157"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
-      "slot": "2158",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2158"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
-      "slot": "2159",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2159"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
-      "slot": "2160",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2160"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
-      "slot": "2161",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2161"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
-      "slot": "2162",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2162"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "2163",
-      "type": "t_array(t_uint256)999_storage"
+      "slot": "2163"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "l1Gas",
       "offset": 0,
-      "slot": "3162",
-      "type": "t_uint32"
+      "slot": "3162"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "l2Eth",
       "offset": 4,
-      "slot": "3162",
-      "type": "t_address"
+      "slot": "3162"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__deprecated_messenger",
       "offset": 0,
-      "slot": "3163",
-      "type": "t_address"
+      "slot": "3163"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "tokenBridges",
       "offset": 0,
-      "slot": "3164",
-      "type": "t_mapping(t_address,t_address)"
+      "slot": "3164"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "3165",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "3165"
     }
   ]
 }

--- a/storage-layouts/Base_SpokePool.json
+++ b/storage-layouts/Base_SpokePool.json
@@ -1,7 +1,6 @@
 {
   "storage": [
     {
-      "astId": 65627,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +8,6 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65630,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +15,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 65609,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +22,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65925,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +29,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65941,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +36,6 @@
       "type": "t_uint256"
     },
     {
-      "astId": 66010,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +43,6 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 18041,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +50,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17773,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +57,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17775,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +64,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17874,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -81,7 +71,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 5938,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
@@ -89,7 +78,6 @@
       "type": "t_address"
     },
     {
-      "astId": 5940,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "hubPool",
       "offset": 0,
@@ -97,15 +85,13 @@
       "type": "t_address"
     },
     {
-      "astId": 5943,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13511"
+      "type": "t_contract(WETH9Interface)8655"
     },
     {
-      "astId": 5945,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
@@ -113,7 +99,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5947,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
@@ -121,7 +106,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5949,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "pausedFills",
       "offset": 28,
@@ -129,7 +113,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 5951,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
@@ -137,15 +120,13 @@
       "type": "t_bool"
     },
     {
-      "astId": 5955,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
     },
     {
-      "astId": 5961,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
@@ -153,7 +134,6 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 5965,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
@@ -161,7 +141,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5969,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
@@ -169,7 +148,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5973,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
@@ -177,7 +155,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5977,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
@@ -185,7 +162,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5981,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
@@ -193,7 +169,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7932,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -201,7 +176,6 @@
       "type": "t_array(t_uint256)999_storage"
     },
     {
-      "astId": 4147,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "l1Gas",
       "offset": 0,
@@ -209,7 +183,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 4149,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "l2Eth",
       "offset": 4,
@@ -217,7 +190,6 @@
       "type": "t_address"
     },
     {
-      "astId": 4155,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__deprecated_messenger",
       "offset": 0,
@@ -225,7 +197,6 @@
       "type": "t_address"
     },
     {
-      "astId": 4165,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "tokenBridges",
       "offset": 0,
@@ -233,152 +204,11 @@
       "type": "t_mapping(t_address,t_address)"
     },
     {
-      "astId": 4431,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
       "slot": "3165",
       "type": "t_array(t_uint256)1000_storage"
     }
-  ],
-  "types": {
-    "t_address": {
-      "encoding": "inplace",
-      "label": "address",
-      "numberOfBytes": "20"
-    },
-    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
-      "encoding": "dynamic_array",
-      "label": "struct SpokePoolInterface.RootBundle[]",
-      "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14088_storage"
-    },
-    "t_array(t_uint256)1000_storage": {
-      "encoding": "inplace",
-      "label": "uint256[1000]",
-      "numberOfBytes": "32000",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)49_storage": {
-      "encoding": "inplace",
-      "label": "uint256[49]",
-      "numberOfBytes": "1568",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)50_storage": {
-      "encoding": "inplace",
-      "label": "uint256[50]",
-      "numberOfBytes": "1600",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)999_storage": {
-      "encoding": "inplace",
-      "label": "uint256[999]",
-      "numberOfBytes": "31968",
-      "base": "t_uint256"
-    },
-    "t_bool": {
-      "encoding": "inplace",
-      "label": "bool",
-      "numberOfBytes": "1"
-    },
-    "t_bytes32": {
-      "encoding": "inplace",
-      "label": "bytes32",
-      "numberOfBytes": "32"
-    },
-    "t_contract(WETH9Interface)13511": {
-      "encoding": "inplace",
-      "label": "contract WETH9Interface",
-      "numberOfBytes": "20"
-    },
-    "t_mapping(t_address,t_address)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => address)",
-      "numberOfBytes": "32",
-      "value": "t_address"
-    },
-    "t_mapping(t_address,t_mapping(t_uint256,t_bool))": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => mapping(uint256 => bool))",
-      "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_bool)"
-    },
-    "t_mapping(t_address,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_bytes32,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_bytes32",
-      "label": "mapping(bytes32 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_uint256,t_bool)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => bool)",
-      "numberOfBytes": "32",
-      "value": "t_bool"
-    },
-    "t_mapping(t_uint256,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_struct(RootBundle)14088_storage": {
-      "encoding": "inplace",
-      "label": "struct SpokePoolInterface.RootBundle",
-      "numberOfBytes": "96",
-      "members": [
-        {
-          "astId": 14081,
-          "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
-          "label": "slowRelayRoot",
-          "offset": 0,
-          "slot": "0",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14083,
-          "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
-          "label": "relayerRefundRoot",
-          "offset": 0,
-          "slot": "1",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14087,
-          "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
-          "label": "claimedBitmap",
-          "offset": 0,
-          "slot": "2",
-          "type": "t_mapping(t_uint256,t_uint256)"
-        }
-      ]
-    },
-    "t_uint256": {
-      "encoding": "inplace",
-      "label": "uint256",
-      "numberOfBytes": "32"
-    },
-    "t_uint32": {
-      "encoding": "inplace",
-      "label": "uint32",
-      "numberOfBytes": "4"
-    },
-    "t_uint8": {
-      "encoding": "inplace",
-      "label": "uint8",
-      "numberOfBytes": "1"
-    }
-  }
+  ]
 }

--- a/storage-layouts/Ethereum_SpokePool.json
+++ b/storage-layouts/Ethereum_SpokePool.json
@@ -4,197 +4,169 @@
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_initialized",
       "offset": 0,
-      "slot": "0",
-      "type": "t_uint8"
+      "slot": "0"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_initializing",
       "offset": 1,
-      "slot": "0",
-      "type": "t_bool"
+      "slot": "0"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "1"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "51",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "51"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_status",
       "offset": 0,
-      "slot": "101",
-      "type": "t_uint256"
+      "slot": "101"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "102",
-      "type": "t_array(t_uint256)49_storage"
+      "slot": "102"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "151",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "151"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
-      "slot": "1151",
-      "type": "t_bytes32"
+      "slot": "1151"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
-      "slot": "1152",
-      "type": "t_bytes32"
+      "slot": "1152"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1153",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "1153"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
-      "slot": "2153",
-      "type": "t_address"
+      "slot": "2153"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "hubPool",
       "offset": 0,
-      "slot": "2154",
-      "type": "t_address"
+      "slot": "2154"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
-      "slot": "2155",
-      "type": "t_contract(WETH9Interface)8655"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "pausedFills",
       "offset": 28,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "rootBundles",
       "offset": 0,
-      "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
+      "slot": "2156"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
-      "slot": "2157",
-      "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
+      "slot": "2157"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
-      "slot": "2158",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2158"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
-      "slot": "2159",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2159"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
-      "slot": "2160",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2160"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
-      "slot": "2161",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2161"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
-      "slot": "2162",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2162"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "2163",
-      "type": "t_array(t_uint256)999_storage"
+      "slot": "2163"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "3162",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "3162"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_owner",
       "offset": 0,
-      "slot": "3212",
-      "type": "t_address"
+      "slot": "3212"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "3213",
-      "type": "t_array(t_uint256)49_storage"
+      "slot": "3213"
     }
   ]
 }

--- a/storage-layouts/Ethereum_SpokePool.json
+++ b/storage-layouts/Ethereum_SpokePool.json
@@ -1,7 +1,6 @@
 {
   "storage": [
     {
-      "astId": 65627,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +8,6 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65630,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +15,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 65609,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +22,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65925,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +29,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65941,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +36,6 @@
       "type": "t_uint256"
     },
     {
-      "astId": 66010,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +43,6 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 18041,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +50,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17773,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +57,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17775,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +64,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17874,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -81,7 +71,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 5938,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
@@ -89,7 +78,6 @@
       "type": "t_address"
     },
     {
-      "astId": 5940,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "hubPool",
       "offset": 0,
@@ -97,15 +85,13 @@
       "type": "t_address"
     },
     {
-      "astId": 5943,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13511"
+      "type": "t_contract(WETH9Interface)8655"
     },
     {
-      "astId": 5945,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
@@ -113,7 +99,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5947,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
@@ -121,7 +106,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5949,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "pausedFills",
       "offset": 28,
@@ -129,7 +113,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 5951,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
@@ -137,15 +120,13 @@
       "type": "t_bool"
     },
     {
-      "astId": 5955,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
     },
     {
-      "astId": 5961,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
@@ -153,7 +134,6 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 5965,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
@@ -161,7 +141,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5969,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
@@ -169,7 +148,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5973,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
@@ -177,7 +155,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5977,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
@@ -185,7 +162,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5981,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
@@ -193,7 +169,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7932,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -201,7 +176,6 @@
       "type": "t_array(t_uint256)999_storage"
     },
     {
-      "astId": 66881,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -209,7 +183,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65079,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_owner",
       "offset": 0,
@@ -217,145 +190,11 @@
       "type": "t_address"
     },
     {
-      "astId": 65199,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
       "slot": "3213",
       "type": "t_array(t_uint256)49_storage"
     }
-  ],
-  "types": {
-    "t_address": {
-      "encoding": "inplace",
-      "label": "address",
-      "numberOfBytes": "20"
-    },
-    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
-      "encoding": "dynamic_array",
-      "label": "struct SpokePoolInterface.RootBundle[]",
-      "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14088_storage"
-    },
-    "t_array(t_uint256)1000_storage": {
-      "encoding": "inplace",
-      "label": "uint256[1000]",
-      "numberOfBytes": "32000",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)49_storage": {
-      "encoding": "inplace",
-      "label": "uint256[49]",
-      "numberOfBytes": "1568",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)50_storage": {
-      "encoding": "inplace",
-      "label": "uint256[50]",
-      "numberOfBytes": "1600",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)999_storage": {
-      "encoding": "inplace",
-      "label": "uint256[999]",
-      "numberOfBytes": "31968",
-      "base": "t_uint256"
-    },
-    "t_bool": {
-      "encoding": "inplace",
-      "label": "bool",
-      "numberOfBytes": "1"
-    },
-    "t_bytes32": {
-      "encoding": "inplace",
-      "label": "bytes32",
-      "numberOfBytes": "32"
-    },
-    "t_contract(WETH9Interface)13511": {
-      "encoding": "inplace",
-      "label": "contract WETH9Interface",
-      "numberOfBytes": "20"
-    },
-    "t_mapping(t_address,t_mapping(t_uint256,t_bool))": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => mapping(uint256 => bool))",
-      "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_bool)"
-    },
-    "t_mapping(t_address,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_bytes32,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_bytes32",
-      "label": "mapping(bytes32 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_uint256,t_bool)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => bool)",
-      "numberOfBytes": "32",
-      "value": "t_bool"
-    },
-    "t_mapping(t_uint256,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_struct(RootBundle)14088_storage": {
-      "encoding": "inplace",
-      "label": "struct SpokePoolInterface.RootBundle",
-      "numberOfBytes": "96",
-      "members": [
-        {
-          "astId": 14081,
-          "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
-          "label": "slowRelayRoot",
-          "offset": 0,
-          "slot": "0",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14083,
-          "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
-          "label": "relayerRefundRoot",
-          "offset": 0,
-          "slot": "1",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14087,
-          "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
-          "label": "claimedBitmap",
-          "offset": 0,
-          "slot": "2",
-          "type": "t_mapping(t_uint256,t_uint256)"
-        }
-      ]
-    },
-    "t_uint256": {
-      "encoding": "inplace",
-      "label": "uint256",
-      "numberOfBytes": "32"
-    },
-    "t_uint32": {
-      "encoding": "inplace",
-      "label": "uint32",
-      "numberOfBytes": "4"
-    },
-    "t_uint8": {
-      "encoding": "inplace",
-      "label": "uint8",
-      "numberOfBytes": "1"
-    }
-  }
+  ]
 }

--- a/storage-layouts/Linea_SpokePool.json
+++ b/storage-layouts/Linea_SpokePool.json
@@ -1,7 +1,6 @@
 {
   "storage": [
     {
-      "astId": 65627,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +8,6 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65630,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +15,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 65609,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +22,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65925,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +29,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65941,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +36,6 @@
       "type": "t_uint256"
     },
     {
-      "astId": 66010,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +43,6 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 18041,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +50,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17773,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +57,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17775,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +64,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17874,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -81,7 +71,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 5938,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
@@ -89,7 +78,6 @@
       "type": "t_address"
     },
     {
-      "astId": 5940,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "hubPool",
       "offset": 0,
@@ -97,15 +85,13 @@
       "type": "t_address"
     },
     {
-      "astId": 5943,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13511"
+      "type": "t_contract(WETH9Interface)8655"
     },
     {
-      "astId": 5945,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
@@ -113,7 +99,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5947,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
@@ -121,7 +106,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5949,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "pausedFills",
       "offset": 28,
@@ -129,7 +113,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 5951,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
@@ -137,15 +120,13 @@
       "type": "t_bool"
     },
     {
-      "astId": 5955,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
     },
     {
-      "astId": 5961,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
@@ -153,7 +134,6 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 5965,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
@@ -161,7 +141,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5969,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
@@ -169,7 +148,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5973,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
@@ -177,7 +155,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5977,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
@@ -185,7 +162,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5981,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
@@ -193,7 +169,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7932,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -201,176 +176,25 @@
       "type": "t_array(t_uint256)999_storage"
     },
     {
-      "astId": 3224,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "l2MessageService",
       "offset": 0,
       "slot": "3162",
-      "type": "t_contract(IMessageService)13427"
+      "type": "t_contract(IMessageService)8571"
     },
     {
-      "astId": 3228,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "l2TokenBridge",
       "offset": 0,
       "slot": "3163",
-      "type": "t_contract(ITokenBridge)13439"
+      "type": "t_contract(ITokenBridge)8583"
     },
     {
-      "astId": 3232,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "l2UsdcBridge",
       "offset": 0,
       "slot": "3164",
-      "type": "t_contract(IUSDCBridge)13453"
+      "type": "t_contract(IUSDCBridge)8597"
     }
-  ],
-  "types": {
-    "t_address": {
-      "encoding": "inplace",
-      "label": "address",
-      "numberOfBytes": "20"
-    },
-    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
-      "encoding": "dynamic_array",
-      "label": "struct SpokePoolInterface.RootBundle[]",
-      "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14088_storage"
-    },
-    "t_array(t_uint256)1000_storage": {
-      "encoding": "inplace",
-      "label": "uint256[1000]",
-      "numberOfBytes": "32000",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)49_storage": {
-      "encoding": "inplace",
-      "label": "uint256[49]",
-      "numberOfBytes": "1568",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)50_storage": {
-      "encoding": "inplace",
-      "label": "uint256[50]",
-      "numberOfBytes": "1600",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)999_storage": {
-      "encoding": "inplace",
-      "label": "uint256[999]",
-      "numberOfBytes": "31968",
-      "base": "t_uint256"
-    },
-    "t_bool": {
-      "encoding": "inplace",
-      "label": "bool",
-      "numberOfBytes": "1"
-    },
-    "t_bytes32": {
-      "encoding": "inplace",
-      "label": "bytes32",
-      "numberOfBytes": "32"
-    },
-    "t_contract(IMessageService)13427": {
-      "encoding": "inplace",
-      "label": "contract IMessageService",
-      "numberOfBytes": "20"
-    },
-    "t_contract(ITokenBridge)13439": {
-      "encoding": "inplace",
-      "label": "contract ITokenBridge",
-      "numberOfBytes": "20"
-    },
-    "t_contract(IUSDCBridge)13453": {
-      "encoding": "inplace",
-      "label": "contract IUSDCBridge",
-      "numberOfBytes": "20"
-    },
-    "t_contract(WETH9Interface)13511": {
-      "encoding": "inplace",
-      "label": "contract WETH9Interface",
-      "numberOfBytes": "20"
-    },
-    "t_mapping(t_address,t_mapping(t_uint256,t_bool))": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => mapping(uint256 => bool))",
-      "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_bool)"
-    },
-    "t_mapping(t_address,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_bytes32,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_bytes32",
-      "label": "mapping(bytes32 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_uint256,t_bool)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => bool)",
-      "numberOfBytes": "32",
-      "value": "t_bool"
-    },
-    "t_mapping(t_uint256,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_struct(RootBundle)14088_storage": {
-      "encoding": "inplace",
-      "label": "struct SpokePoolInterface.RootBundle",
-      "numberOfBytes": "96",
-      "members": [
-        {
-          "astId": 14081,
-          "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
-          "label": "slowRelayRoot",
-          "offset": 0,
-          "slot": "0",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14083,
-          "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
-          "label": "relayerRefundRoot",
-          "offset": 0,
-          "slot": "1",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14087,
-          "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
-          "label": "claimedBitmap",
-          "offset": 0,
-          "slot": "2",
-          "type": "t_mapping(t_uint256,t_uint256)"
-        }
-      ]
-    },
-    "t_uint256": {
-      "encoding": "inplace",
-      "label": "uint256",
-      "numberOfBytes": "32"
-    },
-    "t_uint32": {
-      "encoding": "inplace",
-      "label": "uint32",
-      "numberOfBytes": "4"
-    },
-    "t_uint8": {
-      "encoding": "inplace",
-      "label": "uint8",
-      "numberOfBytes": "1"
-    }
-  }
+  ]
 }

--- a/storage-layouts/Linea_SpokePool.json
+++ b/storage-layouts/Linea_SpokePool.json
@@ -4,197 +4,169 @@
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_initialized",
       "offset": 0,
-      "slot": "0",
-      "type": "t_uint8"
+      "slot": "0"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_initializing",
       "offset": 1,
-      "slot": "0",
-      "type": "t_bool"
+      "slot": "0"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "1"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "51",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "51"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_status",
       "offset": 0,
-      "slot": "101",
-      "type": "t_uint256"
+      "slot": "101"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "102",
-      "type": "t_array(t_uint256)49_storage"
+      "slot": "102"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "151",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "151"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
-      "slot": "1151",
-      "type": "t_bytes32"
+      "slot": "1151"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
-      "slot": "1152",
-      "type": "t_bytes32"
+      "slot": "1152"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1153",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "1153"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
-      "slot": "2153",
-      "type": "t_address"
+      "slot": "2153"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "hubPool",
       "offset": 0,
-      "slot": "2154",
-      "type": "t_address"
+      "slot": "2154"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
-      "slot": "2155",
-      "type": "t_contract(WETH9Interface)8655"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "pausedFills",
       "offset": 28,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "rootBundles",
       "offset": 0,
-      "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
+      "slot": "2156"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
-      "slot": "2157",
-      "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
+      "slot": "2157"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
-      "slot": "2158",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2158"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
-      "slot": "2159",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2159"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
-      "slot": "2160",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2160"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
-      "slot": "2161",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2161"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
-      "slot": "2162",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2162"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "2163",
-      "type": "t_array(t_uint256)999_storage"
+      "slot": "2163"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "l2MessageService",
       "offset": 0,
-      "slot": "3162",
-      "type": "t_contract(IMessageService)8571"
+      "slot": "3162"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "l2TokenBridge",
       "offset": 0,
-      "slot": "3163",
-      "type": "t_contract(ITokenBridge)8583"
+      "slot": "3163"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "l2UsdcBridge",
       "offset": 0,
-      "slot": "3164",
-      "type": "t_contract(IUSDCBridge)8597"
+      "slot": "3164"
     }
   ]
 }

--- a/storage-layouts/Mode_SpokePool.json
+++ b/storage-layouts/Mode_SpokePool.json
@@ -1,7 +1,6 @@
 {
   "storage": [
     {
-      "astId": 65627,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +8,6 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65630,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +15,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 65609,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +22,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65925,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +29,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65941,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +36,6 @@
       "type": "t_uint256"
     },
     {
-      "astId": 66010,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +43,6 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 18041,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +50,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17773,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +57,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17775,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +64,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17874,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -81,7 +71,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 5938,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
@@ -89,7 +78,6 @@
       "type": "t_address"
     },
     {
-      "astId": 5940,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "hubPool",
       "offset": 0,
@@ -97,15 +85,13 @@
       "type": "t_address"
     },
     {
-      "astId": 5943,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13511"
+      "type": "t_contract(WETH9Interface)8655"
     },
     {
-      "astId": 5945,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
@@ -113,7 +99,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5947,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
@@ -121,7 +106,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5949,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "pausedFills",
       "offset": 28,
@@ -129,7 +113,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 5951,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
@@ -137,15 +120,13 @@
       "type": "t_bool"
     },
     {
-      "astId": 5955,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
     },
     {
-      "astId": 5961,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
@@ -153,7 +134,6 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 5965,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
@@ -161,7 +141,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5969,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
@@ -169,7 +148,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5973,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
@@ -177,7 +155,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5977,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
@@ -185,7 +162,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5981,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
@@ -193,7 +169,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7932,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -201,7 +176,6 @@
       "type": "t_array(t_uint256)999_storage"
     },
     {
-      "astId": 4147,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "l1Gas",
       "offset": 0,
@@ -209,7 +183,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 4149,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "l2Eth",
       "offset": 4,
@@ -217,7 +190,6 @@
       "type": "t_address"
     },
     {
-      "astId": 4155,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__deprecated_messenger",
       "offset": 0,
@@ -225,7 +197,6 @@
       "type": "t_address"
     },
     {
-      "astId": 4165,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "tokenBridges",
       "offset": 0,
@@ -233,152 +204,11 @@
       "type": "t_mapping(t_address,t_address)"
     },
     {
-      "astId": 4431,
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
       "slot": "3165",
       "type": "t_array(t_uint256)1000_storage"
     }
-  ],
-  "types": {
-    "t_address": {
-      "encoding": "inplace",
-      "label": "address",
-      "numberOfBytes": "20"
-    },
-    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
-      "encoding": "dynamic_array",
-      "label": "struct SpokePoolInterface.RootBundle[]",
-      "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14088_storage"
-    },
-    "t_array(t_uint256)1000_storage": {
-      "encoding": "inplace",
-      "label": "uint256[1000]",
-      "numberOfBytes": "32000",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)49_storage": {
-      "encoding": "inplace",
-      "label": "uint256[49]",
-      "numberOfBytes": "1568",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)50_storage": {
-      "encoding": "inplace",
-      "label": "uint256[50]",
-      "numberOfBytes": "1600",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)999_storage": {
-      "encoding": "inplace",
-      "label": "uint256[999]",
-      "numberOfBytes": "31968",
-      "base": "t_uint256"
-    },
-    "t_bool": {
-      "encoding": "inplace",
-      "label": "bool",
-      "numberOfBytes": "1"
-    },
-    "t_bytes32": {
-      "encoding": "inplace",
-      "label": "bytes32",
-      "numberOfBytes": "32"
-    },
-    "t_contract(WETH9Interface)13511": {
-      "encoding": "inplace",
-      "label": "contract WETH9Interface",
-      "numberOfBytes": "20"
-    },
-    "t_mapping(t_address,t_address)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => address)",
-      "numberOfBytes": "32",
-      "value": "t_address"
-    },
-    "t_mapping(t_address,t_mapping(t_uint256,t_bool))": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => mapping(uint256 => bool))",
-      "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_bool)"
-    },
-    "t_mapping(t_address,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_bytes32,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_bytes32",
-      "label": "mapping(bytes32 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_uint256,t_bool)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => bool)",
-      "numberOfBytes": "32",
-      "value": "t_bool"
-    },
-    "t_mapping(t_uint256,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_struct(RootBundle)14088_storage": {
-      "encoding": "inplace",
-      "label": "struct SpokePoolInterface.RootBundle",
-      "numberOfBytes": "96",
-      "members": [
-        {
-          "astId": 14081,
-          "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
-          "label": "slowRelayRoot",
-          "offset": 0,
-          "slot": "0",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14083,
-          "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
-          "label": "relayerRefundRoot",
-          "offset": 0,
-          "slot": "1",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14087,
-          "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
-          "label": "claimedBitmap",
-          "offset": 0,
-          "slot": "2",
-          "type": "t_mapping(t_uint256,t_uint256)"
-        }
-      ]
-    },
-    "t_uint256": {
-      "encoding": "inplace",
-      "label": "uint256",
-      "numberOfBytes": "32"
-    },
-    "t_uint32": {
-      "encoding": "inplace",
-      "label": "uint32",
-      "numberOfBytes": "4"
-    },
-    "t_uint8": {
-      "encoding": "inplace",
-      "label": "uint8",
-      "numberOfBytes": "1"
-    }
-  }
+  ]
 }

--- a/storage-layouts/Mode_SpokePool.json
+++ b/storage-layouts/Mode_SpokePool.json
@@ -4,211 +4,181 @@
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_initialized",
       "offset": 0,
-      "slot": "0",
-      "type": "t_uint8"
+      "slot": "0"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_initializing",
       "offset": 1,
-      "slot": "0",
-      "type": "t_bool"
+      "slot": "0"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "1"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "51",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "51"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_status",
       "offset": 0,
-      "slot": "101",
-      "type": "t_uint256"
+      "slot": "101"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "102",
-      "type": "t_array(t_uint256)49_storage"
+      "slot": "102"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "151",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "151"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
-      "slot": "1151",
-      "type": "t_bytes32"
+      "slot": "1151"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
-      "slot": "1152",
-      "type": "t_bytes32"
+      "slot": "1152"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1153",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "1153"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
-      "slot": "2153",
-      "type": "t_address"
+      "slot": "2153"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "hubPool",
       "offset": 0,
-      "slot": "2154",
-      "type": "t_address"
+      "slot": "2154"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
-      "slot": "2155",
-      "type": "t_contract(WETH9Interface)8655"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "pausedFills",
       "offset": 28,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "rootBundles",
       "offset": 0,
-      "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
+      "slot": "2156"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
-      "slot": "2157",
-      "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
+      "slot": "2157"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
-      "slot": "2158",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2158"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
-      "slot": "2159",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2159"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
-      "slot": "2160",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2160"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
-      "slot": "2161",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2161"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
-      "slot": "2162",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2162"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "2163",
-      "type": "t_array(t_uint256)999_storage"
+      "slot": "2163"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "l1Gas",
       "offset": 0,
-      "slot": "3162",
-      "type": "t_uint32"
+      "slot": "3162"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "l2Eth",
       "offset": 4,
-      "slot": "3162",
-      "type": "t_address"
+      "slot": "3162"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__deprecated_messenger",
       "offset": 0,
-      "slot": "3163",
-      "type": "t_address"
+      "slot": "3163"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "tokenBridges",
       "offset": 0,
-      "slot": "3164",
-      "type": "t_mapping(t_address,t_address)"
+      "slot": "3164"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "3165",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "3165"
     }
   ]
 }

--- a/storage-layouts/Optimism_SpokePool.json
+++ b/storage-layouts/Optimism_SpokePool.json
@@ -4,211 +4,181 @@
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_initialized",
       "offset": 0,
-      "slot": "0",
-      "type": "t_uint8"
+      "slot": "0"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_initializing",
       "offset": 1,
-      "slot": "0",
-      "type": "t_bool"
+      "slot": "0"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "1"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "51",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "51"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_status",
       "offset": 0,
-      "slot": "101",
-      "type": "t_uint256"
+      "slot": "101"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "102",
-      "type": "t_array(t_uint256)49_storage"
+      "slot": "102"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "151",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "151"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
-      "slot": "1151",
-      "type": "t_bytes32"
+      "slot": "1151"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
-      "slot": "1152",
-      "type": "t_bytes32"
+      "slot": "1152"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1153",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "1153"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
-      "slot": "2153",
-      "type": "t_address"
+      "slot": "2153"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "hubPool",
       "offset": 0,
-      "slot": "2154",
-      "type": "t_address"
+      "slot": "2154"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
-      "slot": "2155",
-      "type": "t_contract(WETH9Interface)8655"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "pausedFills",
       "offset": 28,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "rootBundles",
       "offset": 0,
-      "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
+      "slot": "2156"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
-      "slot": "2157",
-      "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
+      "slot": "2157"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
-      "slot": "2158",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2158"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
-      "slot": "2159",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2159"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
-      "slot": "2160",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2160"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
-      "slot": "2161",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2161"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
-      "slot": "2162",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2162"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "2163",
-      "type": "t_array(t_uint256)999_storage"
+      "slot": "2163"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "l1Gas",
       "offset": 0,
-      "slot": "3162",
-      "type": "t_uint32"
+      "slot": "3162"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "l2Eth",
       "offset": 4,
-      "slot": "3162",
-      "type": "t_address"
+      "slot": "3162"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__deprecated_messenger",
       "offset": 0,
-      "slot": "3163",
-      "type": "t_address"
+      "slot": "3163"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "tokenBridges",
       "offset": 0,
-      "slot": "3164",
-      "type": "t_mapping(t_address,t_address)"
+      "slot": "3164"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "3165",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "3165"
     }
   ]
 }

--- a/storage-layouts/Optimism_SpokePool.json
+++ b/storage-layouts/Optimism_SpokePool.json
@@ -1,7 +1,6 @@
 {
   "storage": [
     {
-      "astId": 65627,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +8,6 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65630,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +15,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 65609,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +22,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65925,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +29,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65941,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +36,6 @@
       "type": "t_uint256"
     },
     {
-      "astId": 66010,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +43,6 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 18041,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +50,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17773,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +57,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17775,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +64,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17874,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -81,7 +71,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 5938,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
@@ -89,7 +78,6 @@
       "type": "t_address"
     },
     {
-      "astId": 5940,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "hubPool",
       "offset": 0,
@@ -97,15 +85,13 @@
       "type": "t_address"
     },
     {
-      "astId": 5943,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13511"
+      "type": "t_contract(WETH9Interface)8655"
     },
     {
-      "astId": 5945,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
@@ -113,7 +99,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5947,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
@@ -121,7 +106,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5949,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "pausedFills",
       "offset": 28,
@@ -129,7 +113,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 5951,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
@@ -137,15 +120,13 @@
       "type": "t_bool"
     },
     {
-      "astId": 5955,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
     },
     {
-      "astId": 5961,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
@@ -153,7 +134,6 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 5965,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
@@ -161,7 +141,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5969,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
@@ -169,7 +148,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5973,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
@@ -177,7 +155,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5977,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
@@ -185,7 +162,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5981,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
@@ -193,7 +169,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7932,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -201,7 +176,6 @@
       "type": "t_array(t_uint256)999_storage"
     },
     {
-      "astId": 4147,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "l1Gas",
       "offset": 0,
@@ -209,7 +183,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 4149,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "l2Eth",
       "offset": 4,
@@ -217,7 +190,6 @@
       "type": "t_address"
     },
     {
-      "astId": 4155,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__deprecated_messenger",
       "offset": 0,
@@ -225,7 +197,6 @@
       "type": "t_address"
     },
     {
-      "astId": 4165,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "tokenBridges",
       "offset": 0,
@@ -233,152 +204,11 @@
       "type": "t_mapping(t_address,t_address)"
     },
     {
-      "astId": 4431,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
       "slot": "3165",
       "type": "t_array(t_uint256)1000_storage"
     }
-  ],
-  "types": {
-    "t_address": {
-      "encoding": "inplace",
-      "label": "address",
-      "numberOfBytes": "20"
-    },
-    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
-      "encoding": "dynamic_array",
-      "label": "struct SpokePoolInterface.RootBundle[]",
-      "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14088_storage"
-    },
-    "t_array(t_uint256)1000_storage": {
-      "encoding": "inplace",
-      "label": "uint256[1000]",
-      "numberOfBytes": "32000",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)49_storage": {
-      "encoding": "inplace",
-      "label": "uint256[49]",
-      "numberOfBytes": "1568",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)50_storage": {
-      "encoding": "inplace",
-      "label": "uint256[50]",
-      "numberOfBytes": "1600",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)999_storage": {
-      "encoding": "inplace",
-      "label": "uint256[999]",
-      "numberOfBytes": "31968",
-      "base": "t_uint256"
-    },
-    "t_bool": {
-      "encoding": "inplace",
-      "label": "bool",
-      "numberOfBytes": "1"
-    },
-    "t_bytes32": {
-      "encoding": "inplace",
-      "label": "bytes32",
-      "numberOfBytes": "32"
-    },
-    "t_contract(WETH9Interface)13511": {
-      "encoding": "inplace",
-      "label": "contract WETH9Interface",
-      "numberOfBytes": "20"
-    },
-    "t_mapping(t_address,t_address)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => address)",
-      "numberOfBytes": "32",
-      "value": "t_address"
-    },
-    "t_mapping(t_address,t_mapping(t_uint256,t_bool))": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => mapping(uint256 => bool))",
-      "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_bool)"
-    },
-    "t_mapping(t_address,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_bytes32,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_bytes32",
-      "label": "mapping(bytes32 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_uint256,t_bool)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => bool)",
-      "numberOfBytes": "32",
-      "value": "t_bool"
-    },
-    "t_mapping(t_uint256,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_struct(RootBundle)14088_storage": {
-      "encoding": "inplace",
-      "label": "struct SpokePoolInterface.RootBundle",
-      "numberOfBytes": "96",
-      "members": [
-        {
-          "astId": 14081,
-          "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
-          "label": "slowRelayRoot",
-          "offset": 0,
-          "slot": "0",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14083,
-          "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
-          "label": "relayerRefundRoot",
-          "offset": 0,
-          "slot": "1",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14087,
-          "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
-          "label": "claimedBitmap",
-          "offset": 0,
-          "slot": "2",
-          "type": "t_mapping(t_uint256,t_uint256)"
-        }
-      ]
-    },
-    "t_uint256": {
-      "encoding": "inplace",
-      "label": "uint256",
-      "numberOfBytes": "32"
-    },
-    "t_uint32": {
-      "encoding": "inplace",
-      "label": "uint32",
-      "numberOfBytes": "4"
-    },
-    "t_uint8": {
-      "encoding": "inplace",
-      "label": "uint8",
-      "numberOfBytes": "1"
-    }
-  }
+  ]
 }

--- a/storage-layouts/Polygon_SpokePool.json
+++ b/storage-layouts/Polygon_SpokePool.json
@@ -1,7 +1,6 @@
 {
   "storage": [
     {
-      "astId": 65627,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +8,6 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65630,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +15,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 65609,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +22,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65925,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +29,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65941,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +36,6 @@
       "type": "t_uint256"
     },
     {
-      "astId": 66010,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +43,6 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 18041,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +50,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17773,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +57,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17775,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +64,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17874,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -81,7 +71,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 5938,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
@@ -89,7 +78,6 @@
       "type": "t_address"
     },
     {
-      "astId": 5940,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "hubPool",
       "offset": 0,
@@ -97,15 +85,13 @@
       "type": "t_address"
     },
     {
-      "astId": 5943,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13511"
+      "type": "t_contract(WETH9Interface)8655"
     },
     {
-      "astId": 5945,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
@@ -113,7 +99,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5947,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
@@ -121,7 +106,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5949,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "pausedFills",
       "offset": 28,
@@ -129,7 +113,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 5951,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
@@ -137,15 +120,13 @@
       "type": "t_bool"
     },
     {
-      "astId": 5955,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
     },
     {
-      "astId": 5961,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
@@ -153,7 +134,6 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 5965,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
@@ -161,7 +141,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5969,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
@@ -169,7 +148,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5973,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
@@ -177,7 +155,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5977,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
@@ -185,7 +162,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5981,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
@@ -193,7 +169,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7932,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -201,7 +176,6 @@
       "type": "t_array(t_uint256)999_storage"
     },
     {
-      "astId": 5257,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "fxChild",
       "offset": 0,
@@ -209,158 +183,18 @@
       "type": "t_address"
     },
     {
-      "astId": 5260,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "polygonTokenBridger",
       "offset": 0,
       "slot": "3163",
-      "type": "t_contract(PolygonTokenBridger)4888"
+      "type": "t_contract(PolygonTokenBridger)4690"
     },
     {
-      "astId": 5262,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "callValidated",
       "offset": 20,
       "slot": "3163",
       "type": "t_bool"
     }
-  ],
-  "types": {
-    "t_address": {
-      "encoding": "inplace",
-      "label": "address",
-      "numberOfBytes": "20"
-    },
-    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
-      "encoding": "dynamic_array",
-      "label": "struct SpokePoolInterface.RootBundle[]",
-      "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14088_storage"
-    },
-    "t_array(t_uint256)1000_storage": {
-      "encoding": "inplace",
-      "label": "uint256[1000]",
-      "numberOfBytes": "32000",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)49_storage": {
-      "encoding": "inplace",
-      "label": "uint256[49]",
-      "numberOfBytes": "1568",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)50_storage": {
-      "encoding": "inplace",
-      "label": "uint256[50]",
-      "numberOfBytes": "1600",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)999_storage": {
-      "encoding": "inplace",
-      "label": "uint256[999]",
-      "numberOfBytes": "31968",
-      "base": "t_uint256"
-    },
-    "t_bool": {
-      "encoding": "inplace",
-      "label": "bool",
-      "numberOfBytes": "1"
-    },
-    "t_bytes32": {
-      "encoding": "inplace",
-      "label": "bytes32",
-      "numberOfBytes": "32"
-    },
-    "t_contract(PolygonTokenBridger)4888": {
-      "encoding": "inplace",
-      "label": "contract PolygonTokenBridger",
-      "numberOfBytes": "20"
-    },
-    "t_contract(WETH9Interface)13511": {
-      "encoding": "inplace",
-      "label": "contract WETH9Interface",
-      "numberOfBytes": "20"
-    },
-    "t_mapping(t_address,t_mapping(t_uint256,t_bool))": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => mapping(uint256 => bool))",
-      "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_bool)"
-    },
-    "t_mapping(t_address,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_bytes32,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_bytes32",
-      "label": "mapping(bytes32 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_uint256,t_bool)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => bool)",
-      "numberOfBytes": "32",
-      "value": "t_bool"
-    },
-    "t_mapping(t_uint256,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_struct(RootBundle)14088_storage": {
-      "encoding": "inplace",
-      "label": "struct SpokePoolInterface.RootBundle",
-      "numberOfBytes": "96",
-      "members": [
-        {
-          "astId": 14081,
-          "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
-          "label": "slowRelayRoot",
-          "offset": 0,
-          "slot": "0",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14083,
-          "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
-          "label": "relayerRefundRoot",
-          "offset": 0,
-          "slot": "1",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14087,
-          "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
-          "label": "claimedBitmap",
-          "offset": 0,
-          "slot": "2",
-          "type": "t_mapping(t_uint256,t_uint256)"
-        }
-      ]
-    },
-    "t_uint256": {
-      "encoding": "inplace",
-      "label": "uint256",
-      "numberOfBytes": "32"
-    },
-    "t_uint32": {
-      "encoding": "inplace",
-      "label": "uint32",
-      "numberOfBytes": "4"
-    },
-    "t_uint8": {
-      "encoding": "inplace",
-      "label": "uint8",
-      "numberOfBytes": "1"
-    }
-  }
+  ]
 }

--- a/storage-layouts/Polygon_SpokePool.json
+++ b/storage-layouts/Polygon_SpokePool.json
@@ -4,197 +4,169 @@
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_initialized",
       "offset": 0,
-      "slot": "0",
-      "type": "t_uint8"
+      "slot": "0"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_initializing",
       "offset": 1,
-      "slot": "0",
-      "type": "t_bool"
+      "slot": "0"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "1"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "51",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "51"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_status",
       "offset": 0,
-      "slot": "101",
-      "type": "t_uint256"
+      "slot": "101"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "102",
-      "type": "t_array(t_uint256)49_storage"
+      "slot": "102"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "151",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "151"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
-      "slot": "1151",
-      "type": "t_bytes32"
+      "slot": "1151"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
-      "slot": "1152",
-      "type": "t_bytes32"
+      "slot": "1152"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1153",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "1153"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
-      "slot": "2153",
-      "type": "t_address"
+      "slot": "2153"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "hubPool",
       "offset": 0,
-      "slot": "2154",
-      "type": "t_address"
+      "slot": "2154"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
-      "slot": "2155",
-      "type": "t_contract(WETH9Interface)8655"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "pausedFills",
       "offset": 28,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "rootBundles",
       "offset": 0,
-      "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
+      "slot": "2156"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
-      "slot": "2157",
-      "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
+      "slot": "2157"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
-      "slot": "2158",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2158"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
-      "slot": "2159",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2159"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
-      "slot": "2160",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2160"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
-      "slot": "2161",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2161"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
-      "slot": "2162",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2162"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "2163",
-      "type": "t_array(t_uint256)999_storage"
+      "slot": "2163"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "fxChild",
       "offset": 0,
-      "slot": "3162",
-      "type": "t_address"
+      "slot": "3162"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "polygonTokenBridger",
       "offset": 0,
-      "slot": "3163",
-      "type": "t_contract(PolygonTokenBridger)4690"
+      "slot": "3163"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "callValidated",
       "offset": 20,
-      "slot": "3163",
-      "type": "t_bool"
+      "slot": "3163"
     }
   ]
 }

--- a/storage-layouts/ZkSync_SpokePool.json
+++ b/storage-layouts/ZkSync_SpokePool.json
@@ -1,7 +1,6 @@
 {
   "storage": [
     {
-      "astId": 65627,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +8,6 @@
       "type": "t_uint8"
     },
     {
-      "astId": 65630,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +15,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 65609,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +22,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65925,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +29,6 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 65941,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +36,6 @@
       "type": "t_uint256"
     },
     {
-      "astId": 66010,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +43,6 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 18041,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +50,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 17773,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +57,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17775,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +64,6 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 17874,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -81,7 +71,6 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 5938,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
@@ -89,7 +78,6 @@
       "type": "t_address"
     },
     {
-      "astId": 5940,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "hubPool",
       "offset": 0,
@@ -97,15 +85,13 @@
       "type": "t_address"
     },
     {
-      "astId": 5943,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)13511"
+      "type": "t_contract(WETH9Interface)8655"
     },
     {
-      "astId": 5945,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
@@ -113,7 +99,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5947,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
@@ -121,7 +106,6 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5949,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "pausedFills",
       "offset": 28,
@@ -129,7 +113,6 @@
       "type": "t_bool"
     },
     {
-      "astId": 5951,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
@@ -137,15 +120,13 @@
       "type": "t_bool"
     },
     {
-      "astId": 5955,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)14088_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
     },
     {
-      "astId": 5961,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
@@ -153,7 +134,6 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 5965,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
@@ -161,7 +141,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5969,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
@@ -169,7 +148,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5973,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
@@ -177,7 +155,6 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 5977,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
@@ -185,7 +162,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 5981,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
@@ -193,7 +169,6 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 7932,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -201,7 +176,6 @@
       "type": "t_array(t_uint256)999_storage"
     },
     {
-      "astId": 8661,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "l2Eth",
       "offset": 0,
@@ -209,150 +183,11 @@
       "type": "t_address"
     },
     {
-      "astId": 8664,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "zkErc20Bridge",
       "offset": 0,
       "slot": "3163",
-      "type": "t_contract(ZkBridgeLike)8650"
+      "type": "t_contract(ZkBridgeLike)7938"
     }
-  ],
-  "types": {
-    "t_address": {
-      "encoding": "inplace",
-      "label": "address",
-      "numberOfBytes": "20"
-    },
-    "t_array(t_struct(RootBundle)14088_storage)dyn_storage": {
-      "encoding": "dynamic_array",
-      "label": "struct SpokePoolInterface.RootBundle[]",
-      "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)14088_storage"
-    },
-    "t_array(t_uint256)1000_storage": {
-      "encoding": "inplace",
-      "label": "uint256[1000]",
-      "numberOfBytes": "32000",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)49_storage": {
-      "encoding": "inplace",
-      "label": "uint256[49]",
-      "numberOfBytes": "1568",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)50_storage": {
-      "encoding": "inplace",
-      "label": "uint256[50]",
-      "numberOfBytes": "1600",
-      "base": "t_uint256"
-    },
-    "t_array(t_uint256)999_storage": {
-      "encoding": "inplace",
-      "label": "uint256[999]",
-      "numberOfBytes": "31968",
-      "base": "t_uint256"
-    },
-    "t_bool": {
-      "encoding": "inplace",
-      "label": "bool",
-      "numberOfBytes": "1"
-    },
-    "t_bytes32": {
-      "encoding": "inplace",
-      "label": "bytes32",
-      "numberOfBytes": "32"
-    },
-    "t_contract(WETH9Interface)13511": {
-      "encoding": "inplace",
-      "label": "contract WETH9Interface",
-      "numberOfBytes": "20"
-    },
-    "t_contract(ZkBridgeLike)8650": {
-      "encoding": "inplace",
-      "label": "contract ZkBridgeLike",
-      "numberOfBytes": "20"
-    },
-    "t_mapping(t_address,t_mapping(t_uint256,t_bool))": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => mapping(uint256 => bool))",
-      "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_bool)"
-    },
-    "t_mapping(t_address,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_bytes32,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_bytes32",
-      "label": "mapping(bytes32 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_mapping(t_uint256,t_bool)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => bool)",
-      "numberOfBytes": "32",
-      "value": "t_bool"
-    },
-    "t_mapping(t_uint256,t_uint256)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => uint256)",
-      "numberOfBytes": "32",
-      "value": "t_uint256"
-    },
-    "t_struct(RootBundle)14088_storage": {
-      "encoding": "inplace",
-      "label": "struct SpokePoolInterface.RootBundle",
-      "numberOfBytes": "96",
-      "members": [
-        {
-          "astId": 14081,
-          "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
-          "label": "slowRelayRoot",
-          "offset": 0,
-          "slot": "0",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14083,
-          "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
-          "label": "relayerRefundRoot",
-          "offset": 0,
-          "slot": "1",
-          "type": "t_bytes32"
-        },
-        {
-          "astId": 14087,
-          "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
-          "label": "claimedBitmap",
-          "offset": 0,
-          "slot": "2",
-          "type": "t_mapping(t_uint256,t_uint256)"
-        }
-      ]
-    },
-    "t_uint256": {
-      "encoding": "inplace",
-      "label": "uint256",
-      "numberOfBytes": "32"
-    },
-    "t_uint32": {
-      "encoding": "inplace",
-      "label": "uint32",
-      "numberOfBytes": "4"
-    },
-    "t_uint8": {
-      "encoding": "inplace",
-      "label": "uint8",
-      "numberOfBytes": "1"
-    }
-  }
+  ]
 }

--- a/storage-layouts/ZkSync_SpokePool.json
+++ b/storage-layouts/ZkSync_SpokePool.json
@@ -4,190 +4,163 @@
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_initialized",
       "offset": 0,
-      "slot": "0",
-      "type": "t_uint8"
+      "slot": "0"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_initializing",
       "offset": 1,
-      "slot": "0",
-      "type": "t_bool"
+      "slot": "0"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "1"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "51",
-      "type": "t_array(t_uint256)50_storage"
+      "slot": "51"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_status",
       "offset": 0,
-      "slot": "101",
-      "type": "t_uint256"
+      "slot": "101"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "102",
-      "type": "t_array(t_uint256)49_storage"
+      "slot": "102"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "151",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "151"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
-      "slot": "1151",
-      "type": "t_bytes32"
+      "slot": "1151"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
-      "slot": "1152",
-      "type": "t_bytes32"
+      "slot": "1152"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "1153",
-      "type": "t_array(t_uint256)1000_storage"
+      "slot": "1153"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "crossDomainAdmin",
       "offset": 0,
-      "slot": "2153",
-      "type": "t_address"
+      "slot": "2153"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "hubPool",
       "offset": 0,
-      "slot": "2154",
-      "type": "t_address"
+      "slot": "2154"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
-      "slot": "2155",
-      "type": "t_contract(WETH9Interface)8655"
+      "slot": "2155"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "DEPRECATED_depositQuoteTimeBuffer",
       "offset": 20,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "numberOfDeposits",
       "offset": 24,
-      "slot": "2155",
-      "type": "t_uint32"
+      "slot": "2155"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "pausedFills",
       "offset": 28,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "pausedDeposits",
       "offset": 29,
-      "slot": "2155",
-      "type": "t_bool"
+      "slot": "2155"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "rootBundles",
       "offset": 0,
-      "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)9232_storage)dyn_storage"
+      "slot": "2156"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "enabledDepositRoutes",
       "offset": 0,
-      "slot": "2157",
-      "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
+      "slot": "2157"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "DEPRECATED_relayFills",
       "offset": 0,
-      "slot": "2158",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2158"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "DEPRECATED_fillCounter",
       "offset": 0,
-      "slot": "2159",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2159"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "DEPRECATED_depositCounter",
       "offset": 0,
-      "slot": "2160",
-      "type": "t_mapping(t_address,t_uint256)"
+      "slot": "2160"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "DEPRECATED_refundsRequested",
       "offset": 0,
-      "slot": "2161",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2161"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "fillStatuses",
       "offset": 0,
-      "slot": "2162",
-      "type": "t_mapping(t_bytes32,t_uint256)"
+      "slot": "2162"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
-      "slot": "2163",
-      "type": "t_array(t_uint256)999_storage"
+      "slot": "2163"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "l2Eth",
       "offset": 0,
-      "slot": "3162",
-      "type": "t_address"
+      "slot": "3162"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "zkErc20Bridge",
       "offset": 0,
-      "slot": "3163",
-      "type": "t_contract(ZkBridgeLike)7938"
+      "slot": "3163"
     }
   ]
 }


### PR DESCRIPTION
Remove props like astID and anything in types that are not minimally neccessary to compare storage layouts.

Namely, we care about which slots state variables are using, which are ultimately downstream of `types` and independent of the AST layout
