### PR TITLE
improve: Use dummy CircleCCTPAdapter domain ID for chains not supported by CCTP

### DIFF
--- a/contracts/chain-adapters/Blast_Adapter.sol
+++ b/contracts/chain-adapters/Blast_Adapter.sol
@@ -74,7 +74,10 @@ contract Blast_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPAdapte
         IL1ERC20Bridge l1BlastBridge,
         address l1Dai,
         uint32 l2GasLimit
-    ) CrossDomainEnabled(_crossDomainMessenger) CircleCCTPAdapter(_l1Usdc, _cctpTokenMessenger, CircleDomainIds.Base) {
+    )
+        CrossDomainEnabled(_crossDomainMessenger)
+        CircleCCTPAdapter(_l1Usdc, _cctpTokenMessenger, CircleDomainIds.UNINTIALIZED)
+    {
         L1_WETH = _l1Weth;
         L1_STANDARD_BRIDGE = _l1StandardBridge;
         L1_BLAST_BRIDGE = l1BlastBridge;

--- a/contracts/chain-adapters/Blast_Adapter.sol
+++ b/contracts/chain-adapters/Blast_Adapter.sol
@@ -63,20 +63,19 @@ contract Blast_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPAdapte
      * @param _crossDomainMessenger XDomainMessenger Blast system contract.
      * @param _l1StandardBridge Standard bridge contract.
      * @param _l1Usdc USDC address on L1.
-     * @param _cctpTokenMessenger TokenMessenger contract to bridge via CCTP.
      */
     constructor(
         WETH9Interface _l1Weth,
         address _crossDomainMessenger,
         IL1StandardBridge _l1StandardBridge,
         IERC20 _l1Usdc,
-        ITokenMessenger _cctpTokenMessenger,
         IL1ERC20Bridge l1BlastBridge,
         address l1Dai,
         uint32 l2GasLimit
     )
         CrossDomainEnabled(_crossDomainMessenger)
-        CircleCCTPAdapter(_l1Usdc, _cctpTokenMessenger, CircleDomainIds.UNINTIALIZED)
+        // Hardcode cctp messenger to 0x0 to disable CCTP bridging.
+        CircleCCTPAdapter(_l1Usdc, ITokenMessenger(address(0)), CircleDomainIds.UNINTIALIZED)
     {
         L1_WETH = _l1Weth;
         L1_STANDARD_BRIDGE = _l1StandardBridge;

--- a/contracts/chain-adapters/Mode_Adapter.sol
+++ b/contracts/chain-adapters/Mode_Adapter.sol
@@ -38,17 +38,20 @@ contract Mode_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPAdapter
      * @param _crossDomainMessenger XDomainMessenger Mode system contract.
      * @param _l1StandardBridge Standard bridge contract.
      * @param _l1Usdc USDC address on L1.
-     * @param _cctpTokenMessenger TokenMessenger contract to bridge via CCTP.
      */
     constructor(
         WETH9Interface _l1Weth,
         address _crossDomainMessenger,
         IL1StandardBridge _l1StandardBridge,
-        IERC20 _l1Usdc,
-        ITokenMessenger _cctpTokenMessenger
+        IERC20 _l1Usdc
     )
         CrossDomainEnabled(_crossDomainMessenger)
-        CircleCCTPAdapter(_l1Usdc, _cctpTokenMessenger, CircleDomainIds.UNINTIALIZED) // CCTP is not enabled on this chain so Ethereum is a placeholder
+        CircleCCTPAdapter(
+            _l1Usdc,
+            // Hardcode cctp messenger to 0x0 to disable CCTP bridging.
+            ITokenMessenger(address(0)),
+            CircleDomainIds.UNINTIALIZED
+        )
     {
         L1_WETH = _l1Weth;
         L1_STANDARD_BRIDGE = _l1StandardBridge;

--- a/contracts/chain-adapters/Mode_Adapter.sol
+++ b/contracts/chain-adapters/Mode_Adapter.sol
@@ -48,7 +48,7 @@ contract Mode_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPAdapter
         ITokenMessenger _cctpTokenMessenger
     )
         CrossDomainEnabled(_crossDomainMessenger)
-        CircleCCTPAdapter(_l1Usdc, _cctpTokenMessenger, CircleDomainIds.Ethereum) // CCTP is not enabled on this chain so Ethereum is a placeholder
+        CircleCCTPAdapter(_l1Usdc, _cctpTokenMessenger, CircleDomainIds.UNINTIALIZED) // CCTP is not enabled on this chain so Ethereum is a placeholder
     {
         L1_WETH = _l1Weth;
         L1_STANDARD_BRIDGE = _l1StandardBridge;

--- a/contracts/libraries/CircleCCTPAdapter.sol
+++ b/contracts/libraries/CircleCCTPAdapter.sol
@@ -11,6 +11,9 @@ library CircleDomainIds {
     uint32 public constant Arbitrum = 3;
     uint32 public constant Base = 6;
     uint32 public constant Polygon = 7;
+    // Use this value for placeholder purposes only for adapters that extend this adapter but haven't yet been
+    // assigned a domain ID by Circle.
+    uint32 public constant UNINTIALIZED = type(uint32).max;
 }
 
 abstract contract CircleCCTPAdapter {


### PR DESCRIPTION
Avoid any accidental enabling of CCTP for chains like Blast and Mode which are not enabled by Circle