### PR TITLE
improve: Align interface variable names

### DIFF
--- a/contracts/Blast_SpokePool.sol
+++ b/contracts/Blast_SpokePool.sol
@@ -18,7 +18,7 @@ interface IERC20Rebasing {
 
     function getClaimableAmount(address account) external view returns (uint256);
 
-    function configure(YieldMode mode) external returns (uint256);
+    function configure(YieldMode yieldMode) external returns (uint256);
 }
 
 // Interface for blast yield contract on L2.
@@ -29,7 +29,7 @@ interface IBlast {
 
     function configureClaimableGas() external;
 
-    function claimMaxGas(address contractAddress, address recipient) external returns (uint256);
+    function claimMaxGas(address contractAddress, address recipientOfGas) external returns (uint256);
 }
 
 /**

--- a/contracts/erc7683/ERC7683Across.sol
+++ b/contracts/erc7683/ERC7683Across.sol
@@ -43,7 +43,7 @@ library ERC7683Permit2Lib {
     bytes internal constant CROSS_CHAIN_ORDER_TYPE =
         abi.encodePacked(
             "CrossChainOrder(",
-            "address settlerContract,",
+            "address settlementContract,",
             "address swapper,",
             "uint256 nonce,",
             "uint32 originChainId,",


### PR DESCRIPTION
Throughout the codebase, there are several instances of variables having different names than those in the original interface defining them:

- The mode variable from the IERC20Rebasing has a different name than the corresponding variable declared in the [configure](https://blastscan.io/address/0x4ef0d788470e2feb6559b93075ec5be51dba737d#code#F4#L220) function of the USDB implementation contract deployed on the Blast blockchain.
- The recipient variable from the IBlast interface has a different name than the [corresponding variable](https://blastscan.io/address/0xc0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d3c3d30002#code#F1#L49) declared in the Blast implementation contract deployed on the Blast blockchain.
- The settlerContract variable used for the calculation of CROSS_CHAIN_ORDER_TYPE has a different name than its [counterpart](https://github.com/across-protocol/contracts/blob/95c4f923932d597d3e63449718bba5c674b084eb/contracts/erc7683/ERC7683.sol#L30) in the CrossChainOrder struct.
