### PR TITLE
fix(MulticallHandler): revert transaction when calling an EOA with calldata

### DIFF
--- a/test/foundry/local/MulticallHandler.t.sol
+++ b/test/foundry/local/MulticallHandler.t.sol
@@ -11,16 +11,19 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 contract MulticallHandlerTest is Test {
     MulticallHandler handler;
     MulticallHandler.Instructions instructions;
-    address testTarget = address(0x123);
-    bytes testBytes = abi.encode(uint256(7));
+    address testEoa = address(0x123);
+    bytes testBytes = abi.encodeWithSelector(TestTarget.callMe.selector, new bytes(7));
     uint256 testValue = 1;
     address testFallbackRecipient = address(0x456);
     address testToken = address(0x789);
     bytes handlerBalanceCall;
     bytes handlerTransferCall;
 
+    TestTarget testTarget;
+
     function setUp() public {
         handler = new MulticallHandler();
+        testTarget = new TestTarget();
 
         handlerBalanceCall = abi.encodeWithSelector(IERC20.balanceOf.selector, address(handler));
         handlerTransferCall = abi.encodeWithSelector(IERC20.transfer.selector, testFallbackRecipient, 5);
@@ -31,30 +34,51 @@ contract MulticallHandlerTest is Test {
 
     function testNoFallback() public {
         vm.deal(address(handler), testValue * 2);
-        instructions.calls.push(MulticallHandler.Call({ value: testValue, target: testTarget, callData: testBytes }));
+        instructions.calls.push(
+            MulticallHandler.Call({ value: testValue, target: address(testTarget), callData: testBytes })
+        );
         instructions.fallbackRecipient = address(0);
 
-        vm.expectCall(testTarget, testValue, testBytes);
+        vm.expectCall(address(testTarget), testValue, testBytes);
         handler.handleV3AcrossMessage(testToken, 0, address(0), abi.encode(instructions));
 
-        vm.mockCallRevert(testTarget, testValue, testBytes, "");
+        vm.mockCallRevert(address(testTarget), testValue, testBytes, "");
         vm.expectRevert(abi.encodeWithSelector(MulticallHandler.CallReverted.selector, 0, instructions.calls));
         handler.handleV3AcrossMessage(testToken, 0, address(0), abi.encode(instructions));
     }
 
     function testFallback() public {
         vm.deal(address(handler), testValue * 2);
-        instructions.calls.push(MulticallHandler.Call({ value: testValue, target: testTarget, callData: testBytes }));
+        instructions.calls.push(
+            MulticallHandler.Call({ value: testValue, target: address(testTarget), callData: testBytes })
+        );
         instructions.fallbackRecipient = testFallbackRecipient;
 
-        vm.expectCall(testTarget, testValue, testBytes);
+        vm.expectCall(address(testTarget), testValue, testBytes);
         vm.expectCall(testToken, handlerTransferCall);
         handler.handleV3AcrossMessage(testToken, 5, address(0), abi.encode(instructions));
 
-        vm.mockCallRevert(testTarget, testValue, testBytes, "");
+        vm.mockCallRevert(address(testTarget), testValue, testBytes, "");
         vm.expectCall(testToken, handlerTransferCall);
         vm.expectEmit(false, false, false, true, address(handler));
         emit MulticallHandler.CallsFailed(instructions.calls, testFallbackRecipient);
         handler.handleV3AcrossMessage(testToken, 0, address(0), abi.encode(instructions));
+    }
+
+    function testInvalidCall() public {
+        vm.deal(address(handler), testValue * 2);
+        instructions.calls.push(MulticallHandler.Call({ value: testValue, target: testEoa, callData: testBytes }));
+        instructions.fallbackRecipient = address(0);
+
+        vm.expectRevert(abi.encodeWithSelector(MulticallHandler.InvalidCall.selector, 0, instructions.calls));
+        handler.handleV3AcrossMessage(testToken, 0, address(0), abi.encode(instructions));
+    }
+}
+
+contract TestTarget {
+    constructor() {}
+
+    function callMe(bytes calldata data) public payable returns (bytes memory) {
+        return data;
     }
 }


### PR DESCRIPTION
> The `attemptCalls` function of the `MulticallHandler` contract enables users to specify and execute custom operations on a target blockchain right after tokens are bridged. It performs these operations by doing a series of low-level calls to the target addresses with the given data. If any of these calls fails, the entire chain of transactions is reverted in order to
protect users from losing their assets.

> In Solidity, whenever high-level calls are made to an address without any code, the execution reverts. However, when low-level calls are made to an empty address, they are considered successful. It means that if a user mistakenly specifies an address not containing any code as a target, their transaction will succeed, whereas it would have failed if high-level calls had been made. This may cause users to lose their assets.

> In order to illustrate this, consider an example where a user bridges token A from Ethereum to Blast and wants to immediately swap it to token B and send the received amount of B to their own account. In addition, suppose that the DEX they want to use has different address on these two blockchains. If a user mistakenly specifies the DEX address from Ethereum, the call made to this address (with no code) on Blast will be treated as successful and the subsequent transaction will send zero amount of B tokens to the user's account. All bridged A tokens will still remain in the contract, available to be stolen by anyone.

> Therefore, we should validate the code size of a target address for each call with non-empty calldata in the `attemptCalls` function and revert in case it equals 0.