### PR TITLE
feat: add Lisk adapter/spoke pool

### DIFF
--- a/contracts/Lisk_SpokePool.sol
+++ b/contracts/Lisk_SpokePool.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+import "@eth-optimism/contracts/libraries/constants/Lib_PredeployAddresses.sol";
+
+import "./Ovm_SpokePool.sol";
+import "./external/interfaces/CCTPInterfaces.sol";
+
+/**
+ * @notice Lisk Spoke pool.
+ */
+contract Lisk_SpokePool is Ovm_SpokePool {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(
+        address _wrappedNativeTokenAddress,
+        uint32 _depositQuoteTimeBuffer,
+        uint32 _fillDeadlineBuffer,
+        IERC20 _l2Usdc,
+        ITokenMessenger _cctpTokenMessenger
+    )
+        Ovm_SpokePool(
+            _wrappedNativeTokenAddress,
+            _depositQuoteTimeBuffer,
+            _fillDeadlineBuffer,
+            _l2Usdc,
+            _cctpTokenMessenger
+        )
+    {} // solhint-disable-line no-empty-blocks
+
+    /**
+     * @notice Construct the OVM Lisk SpokePool.
+     * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
+     * relay hash collisions.
+     * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
+     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     */
+    function initialize(
+        uint32 _initialDepositId,
+        address _crossDomainAdmin,
+        address _hubPool
+    ) public initializer {
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, Lib_PredeployAddresses.OVM_ETH);
+    }
+}

--- a/contracts/Lisk_SpokePool.sol
+++ b/contracts/Lisk_SpokePool.sol
@@ -7,6 +7,7 @@ import "./external/interfaces/CCTPInterfaces.sol";
 
 /**
  * @notice Lisk Spoke pool.
+ * @custom:security-contact bugs@umaproject.org
  */
 contract Lisk_SpokePool is Ovm_SpokePool {
     /// @custom:oz-upgrades-unsafe-allow constructor

--- a/contracts/chain-adapters/Lisk_Adapter.sol
+++ b/contracts/chain-adapters/Lisk_Adapter.sol
@@ -21,6 +21,7 @@ import "../external/interfaces/CCTPInterfaces.sol";
  * called via delegatecall, which will execute this contract's logic within the context of the originating contract.
  * For example, the HubPool will delegatecall these functions, therefore its only necessary that the HubPool's methods
  * that call this contract's logic guard against reentrancy.
+ * @custom:security-contact bugs@umaproject.org
  */
 
 // solhint-disable-next-line contract-name-camelcase

--- a/contracts/chain-adapters/Lisk_Adapter.sol
+++ b/contracts/chain-adapters/Lisk_Adapter.sol
@@ -16,7 +16,7 @@ import "../libraries/CircleCCTPAdapter.sol";
 import "../external/interfaces/CCTPInterfaces.sol";
 
 /**
- * @notice Contract containing logic to send messages from L1 to Mode. This is a clone of the Base adapter
+ * @notice Contract containing logic to send messages from L1 to Lisk. This is a clone of the Base/Mode adapter
  * @dev Public functions calling external contracts do not guard against reentrancy because they are expected to be
  * called via delegatecall, which will execute this contract's logic within the context of the originating contract.
  * For example, the HubPool will delegatecall these functions, therefore its only necessary that the HubPool's methods
@@ -24,7 +24,7 @@ import "../external/interfaces/CCTPInterfaces.sol";
  */
 
 // solhint-disable-next-line contract-name-camelcase
-contract Mode_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPAdapter {
+contract Lisk_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPAdapter {
     using SafeERC20 for IERC20;
     uint32 public constant L2_GAS_LIMIT = 200_000;
 
@@ -35,7 +35,7 @@ contract Mode_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPAdapter
     /**
      * @notice Constructs new Adapter.
      * @param _l1Weth WETH address on L1.
-     * @param _crossDomainMessenger XDomainMessenger Mode system contract.
+     * @param _crossDomainMessenger XDomainMessenger Lisk system contract.
      * @param _l1StandardBridge Standard bridge contract.
      * @param _l1Usdc USDC address on L1.
      */
@@ -58,8 +58,8 @@ contract Mode_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPAdapter
     }
 
     /**
-     * @notice Send cross-chain message to target on Mode.
-     * @param target Contract on Mode that will receive message.
+     * @notice Send cross-chain message to target on Lisk.
+     * @param target Contract on Lisk that will receive message.
      * @param message Data to send to target.
      */
     function relayMessage(address target, bytes calldata message) external payable override {
@@ -68,7 +68,7 @@ contract Mode_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPAdapter
     }
 
     /**
-     * @notice Bridge tokens to Mode.
+     * @notice Bridge tokens to Lisk.
      * @param l1Token L1 token to deposit.
      * @param l2Token L2 token to receive.
      * @param amount Amount of L1 tokens to deposit and L2 tokens to receive.

--- a/deploy/042_deploy_lisk_adapter.ts
+++ b/deploy/042_deploy_lisk_adapter.ts
@@ -1,0 +1,32 @@
+import { ZERO_ADDRESS } from "@uma/common";
+import { L1_ADDRESS_MAP } from "./consts";
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId, network } = hre;
+  const { deploy } = deployments;
+
+  const { deployer } = await getNamedAccounts();
+
+  const chainId = parseInt(await getChainId());
+
+  await deploy("Lisk_Adapter", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+    args: [
+      L1_ADDRESS_MAP[chainId].weth,
+      L1_ADDRESS_MAP[chainId].liskCrossDomainMessenger,
+      L1_ADDRESS_MAP[chainId].liskStandardBridge,
+      L1_ADDRESS_MAP[chainId].usdc,
+      // L1_ADDRESS_MAP[chainId].cctpTokenMessenger,
+      // For now, we are not using the CCTP bridge and can disable by setting
+      // the cctpTokenMessenger to the zero address.
+      ZERO_ADDRESS,
+    ],
+  });
+};
+
+module.exports = func;
+func.tags = ["LiskAdapter", "mainnet"];

--- a/deploy/043_deploy_lisk_spokepool.ts
+++ b/deploy/043_deploy_lisk_spokepool.ts
@@ -1,0 +1,34 @@
+import { deployNewProxy, getSpokePoolDeploymentInfo } from "../utils/utils.hre";
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { ZERO_ADDRESS } from "@uma/common";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { hubPool, spokeChainId } = await getSpokePoolDeploymentInfo(hre);
+
+  const initArgs = [
+    1,
+    // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
+    hubPool.address,
+    hubPool.address,
+  ];
+  // Construct this spokepool with a:
+  //    * A WETH address of the WETH address
+  //    * A depositQuoteTimeBuffer of 1 hour
+  //    * A fillDeadlineBuffer of 6 hours
+  //    * Native USDC address on L2
+  //    * CCTP token messenger address on L2
+  const constructorArgs = [
+    "0x4200000000000000000000000000000000000006",
+    3600,
+    21600,
+    ZERO_ADDRESS,
+    // L2_ADDRESS_MAP[spokeChainId].cctpTokenMessenger,
+    // For now, we are not using the CCTP bridge and can disable by setting
+    // the cctpTokenMessenger to the zero address.
+    ZERO_ADDRESS,
+  ];
+  await deployNewProxy("Lisk_SpokePool", constructorArgs, initArgs, spokeChainId === 1135);
+};
+module.exports = func;
+func.tags = ["LiskSpokePool", "mode"];

--- a/deploy/consts.ts
+++ b/deploy/consts.ts
@@ -33,6 +33,8 @@ export const L1_ADDRESS_MAP: { [key: number]: { [contractName: string]: string }
     scrollGasPriceOracle: "0x987e300fDfb06093859358522a79098848C33852",
     modeCrossDomainMessenger: "0x95bDCA6c8EdEB69C98Bd5bd17660BaCef1298A6f",
     modeStandardBridge: "0x735aDBbE72226BD52e818E7181953f42E3b0FF21",
+    liskCrossDomainMessenger: "0x31B72D76FB666844C41EdF08dF0254875Dbb7edB",
+    liskStandardBridge: "0x2658723Bf70c7667De6B25F99fcce13A16D25d08",
   },
   4: {
     weth: "0xc778417E063141139Fce010982780140Aa0cD5Ab",


### PR DESCRIPTION
This commit adds the Lisk Adapter/Spoke pool contracts as well as their deployment scripts. Since Lisk is a standard OP stack chain, both contracts are clones of the corresponding Base/Mode contracts. Once merged, a following PR will be added to deploy the contracts to mainnet.