### PR TITLE
[WIP] feat: Define in-place alternative to depositId that preserves deposit hash uniqueness while allowing deterministic fill hash computations for honest depositors

### DIFF
--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -155,8 +155,8 @@ contract MockSpokePool is SpokePool, MockV2SpokePoolInterface, OwnableUpgradeabl
         bytes memory message,
         uint256 // maxCount
     ) public payable virtual nonReentrant unpausedDeposits {
-        // Increment count of deposits so that deposit ID for this spoke pool is unique.
-        uint32 newDepositId = numberOfDeposits++;
+        uint32 newDepositId = depositCount(msg.sender);
+        depositorDepositCount[msg.sender]++;
 
         if (originToken == address(wrappedNativeToken) && msg.value > 0) {
             require(msg.value == amount);

--- a/storage-layouts/Arbitrum_SpokePool.json
+++ b/storage-layouts/Arbitrum_SpokePool.json
@@ -86,7 +86,7 @@
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
-      "label": "numberOfDeposits",
+      "label": "DEPOSIT_COUNTER_START",
       "offset": 24,
       "slot": "2155"
     },
@@ -146,9 +146,15 @@
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
-      "label": "__gap",
+      "label": "depositorDepositCount",
       "offset": 0,
       "slot": "2163"
+    },
+    {
+      "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2164"
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",

--- a/storage-layouts/Base_SpokePool.json
+++ b/storage-layouts/Base_SpokePool.json
@@ -86,7 +86,7 @@
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
-      "label": "numberOfDeposits",
+      "label": "DEPOSIT_COUNTER_START",
       "offset": 24,
       "slot": "2155"
     },
@@ -146,9 +146,15 @@
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
-      "label": "__gap",
+      "label": "depositorDepositCount",
       "offset": 0,
       "slot": "2163"
+    },
+    {
+      "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2164"
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",

--- a/storage-layouts/Blast_SpokePool.json
+++ b/storage-layouts/Blast_SpokePool.json
@@ -86,7 +86,7 @@
     },
     {
       "contract": "contracts/Blast_SpokePool.sol:Blast_SpokePool",
-      "label": "numberOfDeposits",
+      "label": "DEPOSIT_COUNTER_START",
       "offset": 24,
       "slot": "2155"
     },
@@ -146,9 +146,15 @@
     },
     {
       "contract": "contracts/Blast_SpokePool.sol:Blast_SpokePool",
-      "label": "__gap",
+      "label": "depositorDepositCount",
       "offset": 0,
       "slot": "2163"
+    },
+    {
+      "contract": "contracts/Blast_SpokePool.sol:Blast_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2164"
     },
     {
       "contract": "contracts/Blast_SpokePool.sol:Blast_SpokePool",

--- a/storage-layouts/Ethereum_SpokePool.json
+++ b/storage-layouts/Ethereum_SpokePool.json
@@ -86,7 +86,7 @@
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
-      "label": "numberOfDeposits",
+      "label": "DEPOSIT_COUNTER_START",
       "offset": 24,
       "slot": "2155"
     },
@@ -146,9 +146,15 @@
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
-      "label": "__gap",
+      "label": "depositorDepositCount",
       "offset": 0,
       "slot": "2163"
+    },
+    {
+      "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2164"
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",

--- a/storage-layouts/Linea_SpokePool.json
+++ b/storage-layouts/Linea_SpokePool.json
@@ -86,7 +86,7 @@
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
-      "label": "numberOfDeposits",
+      "label": "DEPOSIT_COUNTER_START",
       "offset": 24,
       "slot": "2155"
     },
@@ -146,9 +146,15 @@
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
-      "label": "__gap",
+      "label": "depositorDepositCount",
       "offset": 0,
       "slot": "2163"
+    },
+    {
+      "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2164"
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",

--- a/storage-layouts/Mode_SpokePool.json
+++ b/storage-layouts/Mode_SpokePool.json
@@ -86,7 +86,7 @@
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
-      "label": "numberOfDeposits",
+      "label": "DEPOSIT_COUNTER_START",
       "offset": 24,
       "slot": "2155"
     },
@@ -146,9 +146,15 @@
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
-      "label": "__gap",
+      "label": "depositorDepositCount",
       "offset": 0,
       "slot": "2163"
+    },
+    {
+      "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2164"
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",

--- a/storage-layouts/Optimism_SpokePool.json
+++ b/storage-layouts/Optimism_SpokePool.json
@@ -86,7 +86,7 @@
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
-      "label": "numberOfDeposits",
+      "label": "DEPOSIT_COUNTER_START",
       "offset": 24,
       "slot": "2155"
     },
@@ -146,9 +146,15 @@
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
-      "label": "__gap",
+      "label": "depositorDepositCount",
       "offset": 0,
       "slot": "2163"
+    },
+    {
+      "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2164"
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",

--- a/storage-layouts/Polygon_SpokePool.json
+++ b/storage-layouts/Polygon_SpokePool.json
@@ -86,7 +86,7 @@
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
-      "label": "numberOfDeposits",
+      "label": "DEPOSIT_COUNTER_START",
       "offset": 24,
       "slot": "2155"
     },
@@ -146,9 +146,15 @@
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
-      "label": "__gap",
+      "label": "depositorDepositCount",
       "offset": 0,
       "slot": "2163"
+    },
+    {
+      "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2164"
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",

--- a/storage-layouts/ZkSync_SpokePool.json
+++ b/storage-layouts/ZkSync_SpokePool.json
@@ -86,7 +86,7 @@
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
-      "label": "numberOfDeposits",
+      "label": "DEPOSIT_COUNTER_START",
       "offset": 24,
       "slot": "2155"
     },
@@ -146,9 +146,15 @@
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
-      "label": "__gap",
+      "label": "depositorDepositCount",
       "offset": 0,
       "slot": "2163"
+    },
+    {
+      "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2164"
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",

--- a/test/SpokePool.Admin.ts
+++ b/test/SpokePool.Admin.ts
@@ -17,7 +17,7 @@ describe("SpokePool Admin Functions", async function () {
       [1, owner.address, owner.address],
       { kind: "uups", unsafeAllow: ["delegatecall"], constructorArgs: [owner.address] }
     );
-    expect(await spokePool.numberOfDeposits()).to.equal(1);
+    expect(await spokePool.depositCount(owner.address)).to.equal(1);
   });
   it("Enable token path", async function () {
     await expect(spokePool.connect(owner).setEnableRoute(erc20.address, destinationChainId, true))

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -107,7 +107,7 @@ describe("SpokePool Depositor Logic", async function () {
     expect(await erc20.balanceOf(spokePool.address)).to.equal(amountToDeposit);
 
     // Deposit nonce should increment.
-    expect(await spokePool.numberOfDeposits()).to.equal(1);
+    expect(await spokePool.depositCount(depositor.address)).to.equal(1);
   });
 
   it("DepositFor overrrides the depositor", async function () {
@@ -621,7 +621,7 @@ describe("SpokePool Depositor Logic", async function () {
     });
     it("deposit ID state variable incremented", async function () {
       await spokePool.connect(depositor).depositV3(...depositArgs);
-      expect(await spokePool.numberOfDeposits()).to.equal(1);
+      expect(await spokePool.depositCount(depositor.address)).to.equal(1);
     });
     it("tokens are always pulled from caller, even if different from specified depositor", async function () {
       const balanceBefore = await erc20.balanceOf(depositor.address);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8103,12 +8103,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.12.1, follow-redirects@^1.14.0, follow-redirects@^1.15.0:
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
-  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
-
-follow-redirects@^1.15.6:
+follow-redirects@^1.12.1, follow-redirects@^1.14.0, follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==


### PR DESCRIPTION
## Summary

This PR replaces the contract-wide counter of `depositId` with a per-depositor deposit counter.

## Motivation

The motivation for this PR is to allow honest depositors to broadcast ahead of their deposit transaction to fillers that they want to work with and pre-compute their next deposit hash. This would allow depositors to share with fillers off-chain a Permit2 signed ERC7683 intent + Across deposit and then let the filler submit the deposit txn + immediately fill the user because they would know the precomputed relay hash.

The major benefit of this PR is that re-org risk is completely eliminated for any deposits submitted by "honest" depositors who choose not to try to grief fillers by front-running their fill transactions. This PR accompanied with some sort of off-chain infrastructure where depositors can credibly commit to submitting a deposit (e.g. via an account locking system or by staking collateral) would be the ideal end use case.

A nice property of this PR is that certain properties of Across' order flow system are kept intact:
- deposit ID's are always increasing *for a specific depositor address*
- locating a historical deposit using deposit ID's using a binary search is still efficient assuming you know which depositor you are looking up a deposit for
- All deposits produce unique relay hashes, since the combination of {depositor, depositId} is guaranteed unique

## Gas cost implications

Every first time deposit for a depositor incurs a 20,000 SSTORE cost, and every subsequent deposit for that depositor incurs only a 5,000 SSTORE cost

We assume that most depositors re-use `depositor` addresses so the amortized gas cost is only trivially increased by this PR due to one additional ADD operation
