### PR TITLE
refactor: Relocate message handler interface

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "./MerkleLib.sol";
 import "./external/interfaces/WETH9Interface.sol";
+import "./interfaces/SpokePoolMessageHandler.sol";
 import "./interfaces/SpokePoolInterface.sol";
 import "./interfaces/V3SpokePoolInterface.sol";
 import "./upgradeable/MultiCallerUpgradeable.sol";
@@ -15,16 +16,6 @@ import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts/utils/math/SignedMath.sol";
-
-// This interface is expected to be implemented by any contract that expects to receive messages from the SpokePool.
-interface AcrossMessageHandler {
-    function handleV3AcrossMessage(
-        address tokenSent,
-        uint256 amount,
-        address relayer,
-        bytes memory message
-    ) external;
-}
 
 /**
  * @title SpokePool

--- a/contracts/handlers/MulticallHandler.sol
+++ b/contracts/handlers/MulticallHandler.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "../SpokePool.sol";
+import "../interfaces/SpokePoolMessageHandler.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";


### PR DESCRIPTION
The MulticallHandler contract currently imports the SpokePool contract and experienced a bytecode change after the following unrelated change:

  86593c6481782bcfc09d06be8a436670b9ed368f

This change resulted in its CREATE2 deployment address changing. The MulticallHandler doesn't actually need any of the SpokePool implementation or its dependencies, and it seems like we'd like the MulticallHandler to be deployed to the same address on as many chains as possible, so factor out the interface to a separate file to insulate it from any unintended changes.