### PR TITLE
chore: Bump constants for Scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {
@@ -32,7 +32,7 @@
     "prepublish": "yarn build && hardhat export --export-all ./cache/massExport.json && ts-node ./scripts/processHardhatExport.ts && prettier --write ./deployments/deployments.json && yarn generate-contract-types"
   },
   "dependencies": {
-    "@across-protocol/constants": "^3.1.5",
+    "@across-protocol/constants": "^3.1.9",
     "@defi-wonderland/smock": "^2.3.4",
     "@eth-optimism/contracts": "^0.5.40",
     "@ethersproject/abstract-provider": "5.7.0",

--- a/tasks/enableL1TokenAcrossEcosystem.ts
+++ b/tasks/enableL1TokenAcrossEcosystem.ts
@@ -1,9 +1,10 @@
 import { task } from "hardhat/config";
 import assert from "assert";
 import { askYesNoQuestion, minimalSpokePoolInterface } from "./utils";
-import { TOKEN_SYMBOLS_MAP, CHAIN_IDs } from "../utils/constants";
+import { CHAIN_IDs, MAINNET_CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../utils/constants";
 
-const enabledChainIds = [1, 10, 137, 42161, 324, 1135, 8453, 34443, 59144, 81457]; // Supported mainnet chain IDs.
+// Supported mainnet chain IDs.
+const enabledChainIds = Object.values(MAINNET_CHAIN_IDs);
 
 const getChainsFromList = (taskArgInput: string): number[] =>
   taskArgInput

--- a/tasks/enableL1TokenAcrossEcosystem.ts
+++ b/tasks/enableL1TokenAcrossEcosystem.ts
@@ -3,8 +3,7 @@ import assert from "assert";
 import { askYesNoQuestion, minimalSpokePoolInterface } from "./utils";
 import { CHAIN_IDs, MAINNET_CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../utils/constants";
 
-// Supported mainnet chain IDs.
-const enabledChainIds = Object.values(MAINNET_CHAIN_IDs);
+const enabledChainIds = Object.values(MAINNET_CHAIN_IDs); // Supported mainnet chain IDs.
 
 const getChainsFromList = (taskArgInput: string): number[] =>
   taskArgInput

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,4 +1,4 @@
-export { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
+export { CHAIN_IDs, MAINNET_CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
 
 export const FillStatus = {
   Unfilled: 0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@across-protocol/constants@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.5.tgz#58cdd06816518b5cf1d92d94a4bc175ab0bc9d0c"
-  integrity sha512-3bqBNdYhVnpNwd9zwxmDWewM0ixRxTiL0SCHmOWlmDEx9xqPFHx5t+GLJWOa18wIoPP5KWv/TyI+fdwi3Tg5Bw==
+"@across-protocol/constants@^3.1.9":
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.9.tgz#dfc40c37cea5b7357ffb5cf92054f761da0a74dd"
+  integrity sha512-9KDDsBgUDyXmLBy9bnj+ZSQAN1ob0XgavMJ6mjE4O80F1TyxspY252qcr0z7bBGcoUfUmH10AZzutpmd5Msh8g==
 
 "@across-protocol/contracts@^0.1.4":
   version "0.1.4"


### PR DESCRIPTION
While here, update the enableL1TokenAcrossEcosystem task to automatically inherit the predefined mainnet chain IDs from the constants repo.