### PR TITLE
fix: Optimism StandardBridge bridgeERC20To() prototype

### DIFF
--- a/contracts/Blast_SpokePool.sol
+++ b/contracts/Blast_SpokePool.sol
@@ -32,17 +32,6 @@ interface IBlast {
     function claimMaxGas(address contractAddress, address recipientOfGas) external returns (uint256);
 }
 
-interface IUSDBL2Bridge {
-    function bridgeERC20To(
-        address _localToken,
-        address _remoteToken,
-        address _to,
-        uint256 _amount,
-        uint32 _minGasLimit,
-        bytes calldata _extraData
-    ) external;
-}
-
 /**
  * @notice Blast Spoke pool.
  */
@@ -141,7 +130,7 @@ contract Blast_SpokePool is Ovm_SpokePool {
         }
         // If the token is USDB then use the L2BlastBridge
         if (l2TokenAddress == USDB) {
-            IUSDBL2Bridge(L2_BLAST_BRIDGE).bridgeERC20To(
+            IL2ERC20Bridge(L2_BLAST_BRIDGE).bridgeERC20To(
                 l2TokenAddress, // _l2Token. Address of the L2 token to bridge over.
                 L1_USDB,
                 hubPool, // _to. Withdraw, over the bridge, to the l1 pool contract.

--- a/contracts/Ovm_SpokePool.sol
+++ b/contracts/Ovm_SpokePool.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts-upgradeable/crosschain/optimism/LibOptimismUpgra
 import "@eth-optimism/contracts/libraries/constants/Lib_PredeployAddresses.sol";
 
 // https://github.com/ethereum-optimism/optimism/blob/bf51c4935261634120f31827c3910aa631f6bf9c/packages/contracts-bedrock/contracts/L2/L2StandardBridge.sol
+// https://github.com/ethereum-optimism/optimism/blob/bf51c4935261634120f31827c3910aa631f6bf9c/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
 interface IL2ERC20Bridge {
     function withdrawTo(
         address _l2Token,
@@ -23,7 +24,7 @@ interface IL2ERC20Bridge {
         address _remoteToken,
         address _to,
         uint256 _amount,
-        uint256 _minGasLimit,
+        uint32 _minGasLimit,
         bytes calldata _extraData
     ) external;
 }

--- a/contracts/test/MockBedrockStandardBridge.sol
+++ b/contracts/test/MockBedrockStandardBridge.sol
@@ -20,7 +20,7 @@ contract MockBedrockL2StandardBridge is IL2ERC20Bridge {
         address _remoteToken,
         address _to,
         uint256 _amount,
-        uint256 _minGasLimit,
+        uint32 _minGasLimit,
         bytes calldata _extraData
     ) external {
         // Check that caller has approved this contract to pull funds, mirroring mainnet's behavior

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
The Optimism standard L2 bridge inherits from the StandardBridge, which defines bridgeERC20{to}() _minGasLimit as a uint32, not a uint256.