### PR TITLE
fix: fix bridgeERC20To interface for all OP Stack chains 

### DIFF
--- a/contracts/Blast_SpokePool.sol
+++ b/contracts/Blast_SpokePool.sol
@@ -32,17 +32,6 @@ interface IBlast {
     function claimMaxGas(address contractAddress, address recipientOfGas) external returns (uint256);
 }
 
-interface IUSDBL2Bridge {
-    function bridgeERC20To(
-        address _localToken,
-        address _remoteToken,
-        address _to,
-        uint256 _amount,
-        uint32 _minGasLimit,
-        bytes calldata _extraData
-    ) external;
-}
-
 /**
  * @notice Blast Spoke pool.
  */
@@ -141,7 +130,7 @@ contract Blast_SpokePool is Ovm_SpokePool {
         }
         // If the token is USDB then use the L2BlastBridge
         if (l2TokenAddress == USDB) {
-            IUSDBL2Bridge(L2_BLAST_BRIDGE).bridgeERC20To(
+            IL2ERC20Bridge(L2_BLAST_BRIDGE).bridgeERC20To(
                 l2TokenAddress, // _l2Token. Address of the L2 token to bridge over.
                 L1_USDB,
                 hubPool, // _to. Withdraw, over the bridge, to the l1 pool contract.

--- a/contracts/Ovm_SpokePool.sol
+++ b/contracts/Ovm_SpokePool.sol
@@ -23,7 +23,7 @@ interface IL2ERC20Bridge {
         address _remoteToken,
         address _to,
         uint256 _amount,
-        uint256 _minGasLimit,
+        uint32 _minGasLimit,
         bytes calldata _extraData
     ) external;
 }


### PR DESCRIPTION
The interface for bridgeERC20To has been incorrect presumably since Across originally integrated Optimism. Since this function is never used outside of Blast, it has only recently created an issue.

This PR corrects the interface, but may not be deployed until the next major Across upgrade.