### PR TITLE
improve(deploy): Improve SpokePool deployment UX

### DIFF
--- a/deploy/003_deploy_optimism_spokepool.ts
+++ b/deploy/003_deploy_optimism_spokepool.ts
@@ -28,7 +28,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     L2_ADDRESS_MAP[spokeChainId].l2Usdc,
     L2_ADDRESS_MAP[spokeChainId].cctpTokenMessenger,
   ];
-  await deployNewProxy("Optimism_SpokePool", constructorArgs, initArgs, spokeChainId === 10);
+  await deployNewProxy("Optimism_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
 func.tags = ["OptimismSpokePool", "optimism"];

--- a/deploy/005_deploy_arbitrum_spokepool.ts
+++ b/deploy/005_deploy_arbitrum_spokepool.ts
@@ -29,7 +29,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     L2_ADDRESS_MAP[spokeChainId].l2Usdc,
     L2_ADDRESS_MAP[spokeChainId].cctpTokenMessenger,
   ];
-  await deployNewProxy("Arbitrum_SpokePool", constructorArgs, initArgs, spokeChainId === 42161);
+  await deployNewProxy("Arbitrum_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
 func.tags = ["ArbitrumSpokePool", "arbitrum"];

--- a/deploy/007_deploy_ethereum_spokepool.ts
+++ b/deploy/007_deploy_ethereum_spokepool.ts
@@ -1,13 +1,11 @@
-import { DeployFunction } from "hardhat-deploy/types";
-import { deployNewProxy } from "../utils/utils.hre";
-import { L1_ADDRESS_MAP } from "./consts";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { deployNewProxy, getSpokePoolDeploymentInfo } from "../utils/utils.hre";
+import { L1_ADDRESS_MAP } from "./consts";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployments, getChainId } = hre;
-  const chainId = await getChainId();
-  const hubPool = await deployments.get("HubPool");
-  console.log(`Using chain ${chainId} HubPool @ ${hubPool.address}`);
+  const { hubPool, spokeChainId } = await getSpokePoolDeploymentInfo(hre);
+  console.log(`Using HubPool @ ${hubPool.address}`);
 
   // Initialize deposit counter to very high number of deposits to avoid duplicate deposit ID's
   // with deprecated spoke pool.
@@ -17,8 +15,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   //    * A WETH address of the WETH address
   //    * A depositQuoteTimeBuffer of 1 hour
   //    * A fillDeadlineBuffer of 6 hours
-  const constructorArgs = [L1_ADDRESS_MAP[chainId].weth, 3600, 21600];
-  await deployNewProxy("Ethereum_SpokePool", constructorArgs, initArgs, chainId === "1");
+  const constructorArgs = [L1_ADDRESS_MAP[spokeChainId].weth, 3600, 21600];
+  await deployNewProxy("Ethereum_SpokePool", constructorArgs, initArgs);
 
   // Transfer ownership to hub pool.
 };

--- a/deploy/011_deploy_polygon_spokepool.ts
+++ b/deploy/011_deploy_polygon_spokepool.ts
@@ -32,7 +32,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     L2_ADDRESS_MAP[spokeChainId].l2Usdc,
     L2_ADDRESS_MAP[spokeChainId].cctpTokenMessenger,
   ];
-  await deployNewProxy("Polygon_SpokePool", constructorArgs, initArgs, spokeChainId === 137);
+  await deployNewProxy("Polygon_SpokePool", constructorArgs, initArgs);
 };
 
 module.exports = func;

--- a/deploy/016_deploy_zksync_spokepool.ts
+++ b/deploy/016_deploy_zksync_spokepool.ts
@@ -1,9 +1,10 @@
 import * as zk from "zksync-web3";
 import { Deployer as zkDeployer } from "@matterlabs/hardhat-zksync-deploy";
 import { DeployFunction, DeploymentSubmission } from "hardhat-deploy/types";
-import { L2_ADDRESS_MAP } from "./consts";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { getDeployedAddress } from "../src/DeploymentUtils";
 import { getSpokePoolDeploymentInfo } from "../utils/utils.hre";
+import { L2_ADDRESS_MAP } from "./consts";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const contractName = "ZkSync_SpokePool";
@@ -33,8 +34,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // On production, we'll rarely want to deploy a new proxy contract so we'll default to deploying a new implementation
   // contract.
   // If SKIP_PROXY is defined, only deploy an implementation contract.
-  const implementationOnly = process.env.SKIP_PROXY !== undefined;
+  const proxy = getDeployedAddress("SpokePool", spokeChainId, false);
+  const implementationOnly = proxy !== undefined;
   if (implementationOnly) {
+    console.log(`${name} deployment already detected @ ${proxy}, deploying new implementation.`);
     const _deployment = await deployer.deploy(artifact, constructorArgs);
     newAddress = _deployment.address;
     console.log(`New ${contractName} implementation deployed @ ${newAddress}`);

--- a/deploy/016_deploy_zksync_spokepool.ts
+++ b/deploy/016_deploy_zksync_spokepool.ts
@@ -33,7 +33,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   let newAddress: string;
   // On production, we'll rarely want to deploy a new proxy contract so we'll default to deploying a new implementation
   // contract.
-// If a SpokePool can be found in deployments/deployments.json, then only deploy an implementation contract.
+  // If a SpokePool can be found in deployments/deployments.json, then only deploy an implementation contract.
   const proxy = getDeployedAddress("SpokePool", spokeChainId, false);
   const implementationOnly = proxy !== undefined;
   if (implementationOnly) {

--- a/deploy/016_deploy_zksync_spokepool.ts
+++ b/deploy/016_deploy_zksync_spokepool.ts
@@ -29,10 +29,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   //    * A fillDeadlineBuffer of 6 hours
   const constructorArgs = [L2_ADDRESS_MAP[spokeChainId].l2Weth, 3600, 21600];
 
-  let newAddress;
+  let newAddress: string;
   // On production, we'll rarely want to deploy a new proxy contract so we'll default to deploying a new implementation
   // contract.
-  if (spokeChainId === 324) {
+  // If SKIP_PROXY is defined, only deploy an implementation contract.
+  const implementationOnly = process.env.SKIP_PROXY !== undefined;
+  if (implementationOnly) {
     const _deployment = await deployer.deploy(artifact, constructorArgs);
     newAddress = _deployment.address;
     console.log(`New ${contractName} implementation deployed @ ${newAddress}`);

--- a/deploy/016_deploy_zksync_spokepool.ts
+++ b/deploy/016_deploy_zksync_spokepool.ts
@@ -33,7 +33,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   let newAddress: string;
   // On production, we'll rarely want to deploy a new proxy contract so we'll default to deploying a new implementation
   // contract.
-  // If SKIP_PROXY is defined, only deploy an implementation contract.
+// If a SpokePool can be found in deployments/deployments.json, then only deploy an implementation contract.
   const proxy = getDeployedAddress("SpokePool", spokeChainId, false);
   const implementationOnly = proxy !== undefined;
   if (implementationOnly) {

--- a/deploy/025_deploy_base_spokepool.ts
+++ b/deploy/025_deploy_base_spokepool.ts
@@ -27,7 +27,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     L2_ADDRESS_MAP[spokeChainId].l2Usdc,
     L2_ADDRESS_MAP[spokeChainId].cctpTokenMessenger,
   ];
-  await deployNewProxy("Base_SpokePool", constructorArgs, initArgs, spokeChainId === 8453);
+  await deployNewProxy("Base_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
 func.tags = ["BaseSpokePool", "base"];

--- a/deploy/029_deploy_linea_spokepool.ts
+++ b/deploy/029_deploy_linea_spokepool.ts
@@ -21,7 +21,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   ];
   const constructorArgs = [L2_ADDRESS_MAP[chainId].l2Weth, 3600, 21600];
 
-  await deployNewProxy("Linea_SpokePool", constructorArgs, initArgs, chainId === 59144);
+  await deployNewProxy("Linea_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
 func.tags = ["LineaSpokePool", "linea"];

--- a/deploy/036_deploy_blast_spokepool.ts
+++ b/deploy/036_deploy_blast_spokepool.ts
@@ -35,7 +35,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     "0x8bA929bE3462a809AFB3Bf9e100Ee110D2CFE531",
     L1_ADDRESS_MAP[hubChainId].blastDaiRetriever, // Address of mainnet retriever contract to facilitate USDB finalizations.
   ];
-  await deployNewProxy("Blast_SpokePool", constructorArgs, initArgs, spokeChainId === 81457);
+  await deployNewProxy("Blast_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
 func.tags = ["BlastSpokePool", "blast"];

--- a/deploy/039_deploy_mode_spokepool.ts
+++ b/deploy/039_deploy_mode_spokepool.ts
@@ -1,11 +1,10 @@
 import { deployNewProxy, getSpokePoolDeploymentInfo } from "../utils/utils.hre";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { L2_ADDRESS_MAP } from "./consts";
 import { ZERO_ADDRESS } from "@uma/common";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { hubPool, spokeChainId } = await getSpokePoolDeploymentInfo(hre);
+  const { hubPool } = await getSpokePoolDeploymentInfo(hre);
 
   const initArgs = [
     1,
@@ -29,7 +28,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // the cctpTokenMessenger to the zero address.
     ZERO_ADDRESS,
   ];
-  await deployNewProxy("Mode_SpokePool", constructorArgs, initArgs, spokeChainId === 34443);
+  await deployNewProxy("Mode_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
 func.tags = ["ModeSpokePool", "mode"];

--- a/deploy/043_deploy_lisk_spokepool.ts
+++ b/deploy/043_deploy_lisk_spokepool.ts
@@ -4,7 +4,7 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { ZERO_ADDRESS } from "@uma/common";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { hubPool, spokeChainId } = await getSpokePoolDeploymentInfo(hre);
+  const { hubPool } = await getSpokePoolDeploymentInfo(hre);
 
   const initArgs = [
     1,
@@ -28,7 +28,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // the cctpTokenMessenger to the zero address.
     ZERO_ADDRESS,
   ];
-  await deployNewProxy("Lisk_SpokePool", constructorArgs, initArgs, spokeChainId === 1135);
+  await deployNewProxy("Lisk_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
 func.tags = ["LiskSpokePool", "lisk"];

--- a/deploy/047_deploy_redstone_spokepool.ts
+++ b/deploy/047_deploy_redstone_spokepool.ts
@@ -2,10 +2,7 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { ZERO_ADDRESS } from "@uma/common";
 import { deployNewProxy, getSpokePoolDeploymentInfo } from "../utils/utils.hre";
-import { CHAIN_IDs } from "../utils";
 import { WETH } from "./consts";
-
-const { REDSTONE } = CHAIN_IDs;
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { hubPool, spokeChainId } = await getSpokePoolDeploymentInfo(hre);
@@ -32,7 +29,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // the cctpTokenMessenger to the zero address.
     ZERO_ADDRESS,
   ];
-  await deployNewProxy("Redstone_SpokePool", constructorArgs, initArgs, spokeChainId === REDSTONE);
+  await deployNewProxy("Redstone_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
-func.tags = ["spokepool", "redstone"];
+func.tags = ["RedstoneSpokePool", "redstone"];

--- a/deploy/049_deploy_zora_spokepool.ts
+++ b/deploy/049_deploy_zora_spokepool.ts
@@ -2,10 +2,7 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { ZERO_ADDRESS } from "@uma/common";
 import { deployNewProxy, getSpokePoolDeploymentInfo } from "../utils/utils.hre";
-import { CHAIN_IDs } from "../utils";
 import { WETH } from "./consts";
-
-const { ZORA } = CHAIN_IDs;
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { hubPool, spokeChainId } = await getSpokePoolDeploymentInfo(hre);
@@ -32,7 +29,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // the cctpTokenMessenger to the zero address.
     ZERO_ADDRESS,
   ];
-  await deployNewProxy("Zora_SpokePool", constructorArgs, initArgs, spokeChainId === ZORA);
+  await deployNewProxy("Zora_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
-func.tags = ["spokepool", "zora"];
+func.tags = ["ZoraSpokePool", "zora"];

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -175,7 +175,6 @@
     "MulticallHandler": { "address": "0x924a9f036260DdD5808007E1AA95f08eD08aA569", "blockNumber": 7489978 }
   },
   "7777777": {
-    "SpokePool": { "address": "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64", "blockNumber": 18119425 },
     "SpokePoolVerifier": { "address": "0xB4A8d45647445EA9FC3E1058096142390683dBC2", "blockNumber": 18120222 },
     "MulticallHandler": { "address": "0x924a9f036260DdD5808007E1AA95f08eD08aA569", "blockNumber": 18119854 }
   },

--- a/src/DeploymentUtils.ts
+++ b/src/DeploymentUtils.ts
@@ -1,16 +1,18 @@
 import * as deployments_ from "../deployments/deployments.json";
+
 interface DeploymentExport {
   [chainId: string]: { [contractName: string]: { address: string; blockNumber: number } };
 }
 const deployments: DeploymentExport = deployments_ as any;
 
 // Returns the deployed address of any contract on any network.
-export function getDeployedAddress(contractName: string, networkId: number): string {
-  try {
-    return deployments[networkId.toString()][contractName].address;
-  } catch (_) {
+export function getDeployedAddress(contractName: string, networkId: number, throwOnError = true): string | undefined {
+  const address = deployments[networkId.toString()]?.[contractName]?.address;
+  if (!address && throwOnError) {
     throw new Error(`Contract ${contractName} not found on ${networkId} in deployments.json`);
   }
+
+  return address;
 }
 
 // Returns the deployment block number of any contract on any network.


### PR DESCRIPTION
The majority of SpokePool deployment scripts have been updated to support deploying only implementation contracts. This is done with the knowledge that there are already pre-existing deployments on these chains, but it introduces a risk that using one of these scripts as the template for a new chain will inadvertently result in skipping deployment of the proxy contact. Instead, whether to deploy a new proxy or not can be inferred by whether the contract exists in deployments.json.