### PR TITLE
feat(SpokePool): Specify exclusivityDeadlineOffset by default

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -831,9 +831,9 @@ abstract contract SpokePool is
         // Exclusivity deadline is inclusive and is the latest timestamp that the exclusive relayer has sole right
         // to fill the relay.
         if (
-            relayData.exclusiveRelayer != address(0) &&
+            relayData.exclusiveRelayer != msg.sender &&
             relayData.exclusivityDeadline >= getCurrentTime() &&
-            relayData.exclusiveRelayer != msg.sender
+            relayData.exclusiveRelayer != address(0)
         ) {
             revert NotExclusiveRelayer();
         }

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -773,7 +773,11 @@ abstract contract SpokePool is
     {
         // Exclusivity deadline is inclusive and is the latest timestamp that the exclusive relayer has sole right
         // to fill the relay.
-        if (relayData.exclusivityDeadline >= getCurrentTime() && relayData.exclusiveRelayer != msg.sender) {
+        if (
+            relayData.exclusiveRelayer != address(0) &&
+            relayData.exclusivityDeadline >= getCurrentTime() &&
+            relayData.exclusiveRelayer != msg.sender
+        ) {
             revert NotExclusiveRelayer();
         }
 

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -667,7 +667,7 @@ abstract contract SpokePool is
             exclusiveRelayer,
             uint32(getCurrentTime()),
             uint32(getCurrentTime()) + fillDeadlineOffset,
-            uint32(getCurrentTime()) + exclusivityPeriod,
+            exclusivityPeriod,
             message
         );
     }
@@ -735,7 +735,7 @@ abstract contract SpokePool is
             exclusiveRelayer,
             quoteTimestamp,
             fillDeadline,
-            uint32(getCurrentTime()) + exclusivityPeriod,
+            exclusivityPeriod,
             message
         );
     }

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -525,8 +525,7 @@ abstract contract SpokePool is
      * where currentTime is block.timestamp on this chain or this transaction will revert.
      * @param exclusivityPeriod Added to the current time to set the exclusive reayer deadline,
      * which is the deadline for the exclusiveRelayer to fill the deposit. After this destination chain timestamp,
-     * anyone can fill the deposit. If exclusiveRelayer is set to address(0), then this also must be set to 0,
-     * (and vice versa), otherwise this must be set > 0.
+     * anyone can fill the deposit.
      * @param message The message to send to the recipient on the destination chain if the recipient is a contract.
      * If the message is not empty, the recipient contract must implement handleV3AcrossMessage() or the fill will revert.
      */
@@ -567,16 +566,6 @@ abstract contract SpokePool is
         // unless they are significantly out of sync or the depositor is setting very short fill deadlines. This latter
         // situation won't be a problem for honest users.
         if (fillDeadline < currentTime || fillDeadline > currentTime + fillDeadlineBuffer) revert InvalidFillDeadline();
-
-        // As a safety measure, prevent caller from inadvertently locking funds during exclusivity period
-        //  by forcing them to specify an exclusive relayer if the exclusivity deadline timestamp
-        // is in the future.
-        if (exclusivityPeriod != 0 && exclusiveRelayer == address(0)) {
-            revert InvalidExclusiveRelayer();
-        }
-
-        // No need to sanity check exclusivityDeadline because if its bigger than fillDeadline, then
-        // there the full deadline is exclusive, and if its too small, then there is no exclusivity period.
 
         // If the address of the origin token is a wrappedNativeToken contract and there is a msg.value with the
         // transaction then the user is sending the native token. In this case, the native token should be

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -673,6 +673,73 @@ abstract contract SpokePool is
     }
 
     /**
+     * @notice Submits deposit and sets exclusivityDeadline to current time plus some offset. This function is
+     * designed to be called by users who want to set an exclusive relayer for some amount of time after their deposit
+     * transaction is mined.
+     * @notice If exclusivtyDeadlineOffset > 0, then exclusiveRelayer must be set to a valid address, which is a
+     * requirement imposed by depositV3().
+     * @param depositor The account credited with the deposit who can request to "speed up" this deposit by modifying
+     * the output amount, recipient, and message.
+     * @param recipient The account receiving funds on the destination chain. Can be an EOA or a contract. If
+     * the output token is the wrapped native token for the chain, then the recipient will receive native token if
+     * an EOA or wrapped native token if a contract.
+     * @param inputToken The token pulled from the caller's account and locked into this contract to
+     * initiate the deposit. The equivalent of this token on the relayer's repayment chain of choice will be sent
+     * as a refund. If this is equal to the wrapped native token then the caller can optionally pass in native token as
+     * msg.value, as long as msg.value = inputTokenAmount.
+     * @param outputToken The token that the relayer will send to the recipient on the destination chain. Must be an
+     * ERC20.
+     * @param inputAmount The amount of input tokens to pull from the caller's account and lock into this contract.
+     * This amount will be sent to the relayer on their repayment chain of choice as a refund following an optimistic
+     * challenge window in the HubPool, plus a system fee.
+     * @param outputAmount The amount of output tokens that the relayer will send to the recipient on the destination.
+     * @param destinationChainId The destination chain identifier. Must be enabled along with the input token
+     * as a valid deposit route from this spoke pool or this transaction will revert.
+     * @param exclusiveRelayer The relayer that will be exclusively allowed to fill this deposit before the
+     * exclusivity deadline timestamp.
+     * @param quoteTimestamp The HubPool timestamp that is used to determine the system fee paid by the depositor.
+     *  This must be set to some time between [currentTime - depositQuoteTimeBuffer, currentTime]
+     * where currentTime is block.timestamp on this chain or this transaction will revert.
+     * @param fillDeadline The deadline for the relayer to fill the deposit. After this destination chain timestamp,
+     * the fill will revert on the destination chain. Must be set between [currentTime, currentTime + fillDeadlineBuffer]
+     * where currentTime is block.timestamp on this chain or this transaction will revert.
+     * @param exclusivityDeadlineOffset Added to the current time to set the exclusive reayer deadline,
+     * which is the deadline for the exclusiveRelayer to fill the deposit. After this destination chain timestamp,
+     * anyone can fill the deposit.
+     * @param message The message to send to the recipient on the destination chain if the recipient is a contract.
+     * If the message is not empty, the recipient contract must implement handleV3AcrossMessage() or the fill will revert.
+     */
+    function depositExclusive(
+        address depositor,
+        address recipient,
+        address inputToken,
+        address outputToken,
+        uint256 inputAmount,
+        uint256 outputAmount,
+        uint256 destinationChainId,
+        address exclusiveRelayer,
+        uint32 quoteTimestamp,
+        uint32 fillDeadline,
+        uint32 exclusivityDeadlineOffset,
+        bytes calldata message
+    ) public payable {
+        depositV3(
+            depositor,
+            recipient,
+            inputToken,
+            outputToken,
+            inputAmount,
+            outputAmount,
+            destinationChainId,
+            exclusiveRelayer,
+            quoteTimestamp,
+            fillDeadline,
+            uint32(getCurrentTime()) + exclusivityDeadlineOffset,
+            message
+        );
+    }
+
+    /**
      * @notice Depositor can use this function to signal to relayer to use updated output amount, recipient,
      * and/or message.
      * @dev the depositor and depositId must match the params in a V3FundsDeposited event that the depositor

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -523,7 +523,7 @@ abstract contract SpokePool is
      * @param fillDeadline The deadline for the relayer to fill the deposit. After this destination chain timestamp,
      * the fill will revert on the destination chain. Must be set between [currentTime, currentTime + fillDeadlineBuffer]
      * where currentTime is block.timestamp on this chain or this transaction will revert.
-     * @param exclusivityDeadlineOffset Added to the current time to set the exclusive reayer deadline,
+     * @param exclusivityPeriod Added to the current time to set the exclusive reayer deadline,
      * which is the deadline for the exclusiveRelayer to fill the deposit. After this destination chain timestamp,
      * anyone can fill the deposit. If exclusiveRelayer is set to address(0), then this also must be set to 0,
      * (and vice versa), otherwise this must be set > 0.
@@ -541,7 +541,7 @@ abstract contract SpokePool is
         address exclusiveRelayer,
         uint32 quoteTimestamp,
         uint32 fillDeadline,
-        uint32 exclusivityDeadlineOffset,
+        uint32 exclusivityPeriod,
         bytes calldata message
     ) public payable override nonReentrant unpausedDeposits {
         // Check that deposit route is enabled for the input token. There are no checks required for the output token
@@ -571,7 +571,7 @@ abstract contract SpokePool is
         // As a safety measure, prevent caller from inadvertently locking funds during exclusivity period
         //  by forcing them to specify an exclusive relayer if the exclusivity deadline timestamp
         // is in the future.
-        if (exclusivityDeadlineOffset != 0 && exclusiveRelayer == address(0)) {
+        if (exclusivityPeriod != 0 && exclusiveRelayer == address(0)) {
             revert InvalidExclusiveRelayer();
         }
 
@@ -603,7 +603,7 @@ abstract contract SpokePool is
             numberOfDeposits++,
             quoteTimestamp,
             fillDeadline,
-            uint32(getCurrentTime()) + exclusivityDeadlineOffset,
+            uint32(getCurrentTime()) + exclusivityPeriod,
             depositor,
             recipient,
             exclusiveRelayer,
@@ -637,7 +637,7 @@ abstract contract SpokePool is
      * @param fillDeadlineOffset Added to the current time to set the fill deadline, which is the deadline for the
      * relayer to fill the deposit. After this destination chain timestamp, the fill will revert on the
      * destination chain.
-     * @param exclusivityDeadlineOffset Added to the current time to set the exclusive relayer deadline,
+     * @param exclusivityPeriod Added to the current time to set the exclusive relayer deadline,
      * which is the deadline for the exclusiveRelayer to fill the deposit. After this destination chain timestamp,
      * anyone can fill the deposit.
      * @param message The message to send to the recipient on the destination chain if the recipient is a contract.
@@ -653,7 +653,7 @@ abstract contract SpokePool is
         uint256 destinationChainId,
         address exclusiveRelayer,
         uint32 fillDeadlineOffset,
-        uint32 exclusivityDeadlineOffset,
+        uint32 exclusivityPeriod,
         bytes calldata message
     ) external payable {
         depositV3(
@@ -667,7 +667,7 @@ abstract contract SpokePool is
             exclusiveRelayer,
             uint32(getCurrentTime()),
             uint32(getCurrentTime()) + fillDeadlineOffset,
-            uint32(getCurrentTime()) + exclusivityDeadlineOffset,
+            uint32(getCurrentTime()) + exclusivityPeriod,
             message
         );
     }
@@ -703,7 +703,7 @@ abstract contract SpokePool is
      * @param fillDeadline The deadline for the relayer to fill the deposit. After this destination chain timestamp,
      * the fill will revert on the destination chain. Must be set between [currentTime, currentTime + fillDeadlineBuffer]
      * where currentTime is block.timestamp on this chain or this transaction will revert.
-     * @param exclusivityDeadlineOffset Added to the current time to set the exclusive reayer deadline,
+     * @param exclusivityPeriod Added to the current time to set the exclusive reayer deadline,
      * which is the deadline for the exclusiveRelayer to fill the deposit. After this destination chain timestamp,
      * anyone can fill the deposit.
      * @param message The message to send to the recipient on the destination chain if the recipient is a contract.
@@ -720,7 +720,7 @@ abstract contract SpokePool is
         address exclusiveRelayer,
         uint32 quoteTimestamp,
         uint32 fillDeadline,
-        uint32 exclusivityDeadlineOffset,
+        uint32 exclusivityPeriod,
         bytes calldata message
     ) public payable {
         depositV3(
@@ -734,7 +734,7 @@ abstract contract SpokePool is
             exclusiveRelayer,
             quoteTimestamp,
             fillDeadline,
-            uint32(getCurrentTime()) + exclusivityDeadlineOffset,
+            uint32(getCurrentTime()) + exclusivityPeriod,
             message
         );
     }

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -673,6 +673,7 @@ abstract contract SpokePool is
     }
 
     /**
+     * @notice DEPRECATED. Use depositV3() instead.
      * @notice Submits deposit and sets exclusivityDeadline to current time plus some offset. This function is
      * designed to be called by users who want to set an exclusive relayer for some amount of time after their deposit
      * transaction is mined.

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -569,16 +569,10 @@ abstract contract SpokePool is
         if (fillDeadline < currentTime || fillDeadline > currentTime + fillDeadlineBuffer) revert InvalidFillDeadline();
 
         // As a safety measure, prevent caller from inadvertently locking funds during exclusivity period
-        //  by forcing them to specify an exclusive relayer if the exclusivity period
-        // is in the future. If this offset is 0, then the exclusive relayer must also be address(0).
-        // @dev Checks if either are > 0 by bitwise or-ing.
-        if (uint256(uint160(exclusiveRelayer)) | exclusivityDeadlineOffset != 0) {
-            // Now that we know one is nonzero, we need to perform checks on each.
-            // Check that exclusive relayer is nonzero.
-            if (exclusiveRelayer == address(0)) revert InvalidExclusiveRelayer();
-
-            // Check that deadline is in the future.
-            if (exclusivityDeadlineOffset == 0) revert InvalidExclusivityDeadline();
+        //  by forcing them to specify an exclusive relayer if the exclusivity deadline timestamp
+        // is in the future.
+        if (exclusivityDeadlineOffset != 0 && exclusiveRelayer == address(0)) {
+            revert InvalidExclusiveRelayer();
         }
 
         // No need to sanity check exclusivityDeadline because if its bigger than fillDeadline, then

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -434,36 +434,6 @@ describe("SpokePool Depositor Logic", async function () {
         )
       ).to.not.be.reverted;
     });
-    it("invalid exclusivity params", async function () {
-      // If exclusivity period is > 0, then exclusive relayer must be non-0.
-      await expect(
-        spokePool.connect(depositor).depositV3(
-          ...getDepositArgsFromRelayData({
-            ...relayData,
-            exclusiveRelayer: zeroAddress,
-            exclusivityDeadline: 1,
-          })
-        )
-      ).to.be.revertedWith("InvalidExclusiveRelayer");
-      await expect(
-        spokePool.connect(depositor).depositV3(
-          ...getDepositArgsFromRelayData({
-            ...relayData,
-            exclusiveRelayer: depositor.address,
-            exclusivityDeadline: 1,
-          })
-        )
-      ).to.not.be.reverted;
-    });
-    it("exclusive deadline and relayer can both be 0", async function () {
-      await expect(
-        spokePool
-          .connect(depositor)
-          .depositV3(
-            ...getDepositArgsFromRelayData({ ...relayData, exclusiveRelayer: zeroAddress, exclusivityDeadline: 0 })
-          )
-      ).to.not.be.reverted;
-    });
     it("if input token is WETH and msg.value > 0, msg.value must match inputAmount", async function () {
       await expect(
         spokePool

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -505,8 +505,7 @@ describe("SpokePool Depositor Logic", async function () {
     it("depositV3Now uses current time as quote time", async function () {
       const currentTime = (await spokePool.getCurrentTime()).toNumber();
       const fillDeadlineOffset = 1000;
-      const exclusivityDeadline = 0; // Should be zero since
-      // exclusive relayer is zero address
+      const exclusivityDeadline = 0;
       await expect(
         spokePool
           .connect(depositor)
@@ -535,7 +534,7 @@ describe("SpokePool Depositor Logic", async function () {
           0,
           currentTime, // quoteTimestamp should be current time
           currentTime + fillDeadlineOffset, // fillDeadline should be current time + offset
-          exclusivityDeadline,
+          currentTime,
           relayData.depositor,
           relayData.recipient,
           relayData.exclusiveRelayer,
@@ -543,6 +542,7 @@ describe("SpokePool Depositor Logic", async function () {
         );
     });
     it("emits V3FundsDeposited event with correct deposit ID", async function () {
+      const currentTime = (await spokePool.getCurrentTime()).toNumber();
       await expect(spokePool.connect(depositor).depositV3(...depositArgs))
         .to.emit(spokePool, "V3FundsDeposited")
         .withArgs(
@@ -555,7 +555,7 @@ describe("SpokePool Depositor Logic", async function () {
           0,
           quoteTimestamp,
           relayData.fillDeadline,
-          relayData.exclusivityDeadline,
+          currentTime,
           relayData.depositor,
           relayData.recipient,
           relayData.exclusiveRelayer,
@@ -567,6 +567,7 @@ describe("SpokePool Depositor Logic", async function () {
       expect(await spokePool.numberOfDeposits()).to.equal(1);
     });
     it("tokens are always pulled from caller, even if different from specified depositor", async function () {
+      const currentTime = (await spokePool.getCurrentTime()).toNumber();
       const balanceBefore = await erc20.balanceOf(depositor.address);
       const newDepositor = randomAddress();
       await expect(
@@ -584,7 +585,7 @@ describe("SpokePool Depositor Logic", async function () {
           0,
           quoteTimestamp,
           relayData.fillDeadline,
-          relayData.exclusivityDeadline,
+          currentTime,
           // New depositor
           newDepositor,
           relayData.recipient,

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -434,7 +434,7 @@ describe("SpokePool Depositor Logic", async function () {
         )
       ).to.not.be.reverted;
     });
-    it.only("invalid exclusivity params", async function () {
+    it("invalid exclusivity params", async function () {
       // If exclusivity period is > 0, then exclusive relayer must be non-0.
       await expect(
         spokePool.connect(depositor).depositV3(
@@ -451,16 +451,6 @@ describe("SpokePool Depositor Logic", async function () {
             ...relayData,
             exclusiveRelayer: depositor.address,
             exclusivityDeadline: 1,
-          })
-        )
-      ).to.not.be.reverted;
-      // If exclusivity deadline is 0, then exclusive relayer can be 0.
-      await expect(
-        spokePool.connect(depositor).depositV3(
-          ...getDepositArgsFromRelayData({
-            ...relayData,
-            exclusiveRelayer: zeroAddress,
-            exclusivityDeadline: 0,
           })
         )
       ).to.not.be.reverted;

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -434,7 +434,7 @@ describe("SpokePool Depositor Logic", async function () {
         )
       ).to.not.be.reverted;
     });
-    it("invalid exclusivity params", async function () {
+    it.only("invalid exclusivity params", async function () {
       // If exclusivity period is > 0, then exclusive relayer must be non-0.
       await expect(
         spokePool.connect(depositor).depositV3(
@@ -460,15 +460,6 @@ describe("SpokePool Depositor Logic", async function () {
           ...getDepositArgsFromRelayData({
             ...relayData,
             exclusiveRelayer: zeroAddress,
-            exclusivityDeadline: 0,
-          })
-        )
-      ).to.not.be.reverted;
-      await expect(
-        spokePool.connect(depositor).depositV3(
-          ...getDepositArgsFromRelayData({
-            ...relayData,
-            exclusiveRelayer: depositor.address,
             exclusivityDeadline: 0,
           })
         )

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -349,6 +349,16 @@ describe("SpokePool Relayer Logic", async function () {
           )
         ).to.not.be.reverted;
       });
+      it("can have empty exclusive relayer before exclusivity deadline", async function () {
+        const _relayData = {
+          ...relayData,
+          // Overwrite exclusivity deadline
+          exclusivityDeadline: relayData.fillDeadline,
+        };
+
+        // Can send it before exclusivity deadline if exclusive relayer is empty
+        await expect(spokePool.connect(relayer).fillV3Relay(_relayData, consts.repaymentChainId)).to.not.be.reverted;
+      });
       it("calls _fillRelayV3 with  expected params", async function () {
         await expect(spokePool.connect(relayer).fillV3Relay(relayData, consts.repaymentChainId))
           .to.emit(spokePool, "FilledV3Relay")

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -349,6 +349,16 @@ describe("SpokePool Relayer Logic", async function () {
           )
         ).to.not.be.reverted;
       });
+      it("if no exclusive relayer is set, exclusivity deadline can be in future", async function () {
+        const _relayData = {
+          ...relayData,
+          // Overwrite exclusivity deadline
+          exclusivityDeadline: relayData.fillDeadline,
+        };
+
+        // Can send it after exclusivity deadline
+        await expect(spokePool.connect(relayer).fillV3Relay(_relayData, consts.repaymentChainId)).to.not.be.reverted;
+      });
       it("can have empty exclusive relayer before exclusivity deadline", async function () {
         const _relayData = {
           ...relayData,


### PR DESCRIPTION
Better depositor UX if they can specify an offset that is relative to the time that their deposit mines, so they do not have to account for any off-chain latency
