### PR TITLE
feat(Arbitrum_Adapter): Support custom gas token

### DIFF
--- a/contracts/chain-adapters/Arbitrum_CustomGasToken_Adapter.sol
+++ b/contracts/chain-adapters/Arbitrum_CustomGasToken_Adapter.sol
@@ -9,23 +9,52 @@ import "../external/interfaces/CCTPInterfaces.sol";
 import "../libraries/CircleCCTPAdapter.sol";
 
 /**
- * @notice Interface for Arbitrum's L1 Inbox contract used to send messages to Arbitrum.
- * @custom:security-contact bugs@across.to
+ * @title Staging ground for incoming and outgoing messages
+ * @notice Unlike the standard Eth bridge, native token bridge escrows the custom ERC20 token which is
+ * used as native currency on L2.
+ * @dev Fees are paid in this token. There are certain restrictions on the native token:
+ *       - The token can't be rebasing or have a transfer fee
+ *       - The token must only be transferrable via a call to the token address itself
+ *       - The token must only be able to set allowance via a call to the token address itself
+ *       - The token must not have a callback on transfer, and more generally a user must not be able to make a transfer to themselves revert
+ *       - The token must have a max of 2^256 - 1 wei total supply unscaled
+ *       - The token must have a max of 2^256 - 1 wei total supply when scaled to 18 decimals
+ */
+interface ArbitrumL1ERC20Bridge {
+    /**
+     * @notice Returns token that is escrowed in bridge on L1 side and minted on L2 as native currency.
+     * @dev This function doesn't exist on the generic Bridge interface.
+     */
+    function nativeToken() external view returns (address);
+}
+
+/**
+ * @title Inbox for user and contract originated messages
+ * @notice Messages created via this inbox are enqueued in the delayed accumulator
+ * to await inclusion in the SequencerInbox
  */
 interface ArbitrumL1InboxLike {
     /**
+     * @dev we only use this function to check the native token used by the bridge, so we hardcode the interface
+     * to return an ArbitrumL1ERC20Bridge instead of a more generic Bridge interface.
+     */
+    function bridge() external view returns (ArbitrumL1ERC20Bridge);
+
+    /**
      * @notice Put a message in the L2 inbox that can be reexecuted for some fixed amount of time if it reverts
+     * @notice Overloads the `createRetryableTicket` function but is not payable, and should only be called when paying
+     * for L1 to L2 message using a custom gas token.
+     * @dev all tokenTotalFeeAmount will be deposited to callValueRefundAddress on L2
      * @dev Gas limit and maxFeePerGas should not be set to 1 as that is used to trigger the RetryableData error
-     * @dev Caller must set msg.value equal to at least `maxSubmissionCost + maxGas * gasPriceBid`.
-     *      all msg.value will deposited to callValueRefundAddress on L2
-     * @dev More details can be found here: https://developer.arbitrum.io/arbos/l1-to-l2-messaging
+     * @dev In case of native token having non-18 decimals: tokenTotalFeeAmount is denominated in native token's decimals. All other value params - l2CallValue, maxSubmissionCost and maxFeePerGas are denominated in child chain's native 18 decimals.
      * @param to destination L2 contract address
      * @param l2CallValue call value for retryable L2 message
      * @param maxSubmissionCost Max gas deducted from user's L2 balance to cover base submission fee
-     * @param excessFeeRefundAddress gasLimit x maxFeePerGas - execution cost gets credited here on L2 balance
-     * @param callValueRefundAddress l2Callvalue gets credited here on L2 if retryable txn times out or gets cancelled
+     * @param excessFeeRefundAddress the address which receives the difference between execution fee paid and the actual execution cost. In case this address is a contract, funds will be received in its alias on L2.
+     * @param callValueRefundAddress l2Callvalue gets credited here on L2 if retryable txn times out or gets cancelled. In case this address is a contract, funds will be received in its alias on L2.
      * @param gasLimit Max gas deducted from user's L2 balance to cover L2 execution. Should not be set to 1 (magic value used to trigger the RetryableData error)
      * @param maxFeePerGas price bid for L2 execution. Should not be set to 1 (magic value used to trigger the RetryableData error)
+     * @param tokenTotalFeeAmount amount of fees to be deposited in native token to cover for retryable ticket cost
      * @param data ABI encoded data of L2 message
      * @return unique message number of the retryable transaction
      */
@@ -37,65 +66,15 @@ interface ArbitrumL1InboxLike {
         address callValueRefundAddress,
         uint256 gasLimit,
         uint256 maxFeePerGas,
+        uint256 tokenTotalFeeAmount,
         bytes calldata data
-    ) external payable returns (uint256);
-
-    /**
-     * @notice Put a message in the L2 inbox that can be reexecuted for some fixed amount of time if it reverts
-     * @dev Same as createRetryableTicket, but does not guarantee that submission will succeed by requiring the needed
-     * funds come from the deposit alone, rather than falling back on the user's L2 balance
-     * @dev Advanced usage only (does not rewrite aliases for excessFeeRefundAddress and callValueRefundAddress).
-     * createRetryableTicket method is the recommended standard.
-     * @dev Gas limit and maxFeePerGas should not be set to 1 as that is used to trigger the RetryableData error
-     * @param to destination L2 contract address
-     * @param l2CallValue call value for retryable L2 message
-     * @param maxSubmissionCost Max gas deducted from user's L2 balance to cover base submission fee
-     * @param excessFeeRefundAddress gasLimit x maxFeePerGas - execution cost gets credited here on L2 balance
-     * @param callValueRefundAddress l2Callvalue gets credited here on L2 if retryable txn times out or gets cancelled
-     * @param gasLimit Max gas deducted from user's L2 balance to cover L2 execution. Should not be set to 1 (magic value used to trigger the RetryableData error)
-     * @param maxFeePerGas price bid for L2 execution. Should not be set to 1 (magic value used to trigger the RetryableData error)
-     * @param data ABI encoded data of L2 message
-     * @return unique message number of the retryable transaction
-     */
-    function unsafeCreateRetryableTicket(
-        address to,
-        uint256 l2CallValue,
-        uint256 maxSubmissionCost,
-        address excessFeeRefundAddress,
-        address callValueRefundAddress,
-        uint256 gasLimit,
-        uint256 maxFeePerGas,
-        bytes calldata data
-    ) external payable returns (uint256);
+    ) external returns (uint256);
 }
 
 /**
  * @notice Layer 1 Gateway contract for bridging standard ERC20s to Arbitrum.
  */
 interface ArbitrumL1ERC20GatewayLike {
-    /**
-     * @notice Deprecated in favor of outboundTransferCustomRefund but still used in custom bridges
-     * like the DAI bridge.
-     * @dev Refunded to aliased L2 address of sender if sender has code on L1, otherwise to to sender's EOA on L2.
-     * @param _l1Token L1 address of ERC20
-     * @param _to Account to be credited with the tokens in the L2 (can be the user's L2 account or a contract),
-     * not subject to L2 aliasing. This account, or its L2 alias if it have code in L1, will also be able to
-     * cancel the retryable ticket and receive callvalue refund
-     * @param _amount Token Amount
-     * @param _maxGas Max gas deducted from user's L2 balance to cover L2 execution
-     * @param _gasPriceBid Gas price for L2 execution
-     * @param _data encoded data from router and user
-     * @return res abi encoded inbox sequence number
-     */
-    function outboundTransfer(
-        address _l1Token,
-        address _to,
-        uint256 _amount,
-        uint256 _maxGas,
-        uint256 _gasPriceBid,
-        bytes calldata _data
-    ) external payable returns (bytes memory);
-
     /**
      * @notice Deposit ERC20 token from Ethereum into Arbitrum.
      * @dev L2 address alias will not be applied to the following types of addresses on L1:
@@ -138,18 +117,22 @@ interface ArbitrumL1ERC20GatewayLike {
  * called via delegatecall, which will execute this contract's logic within the context of the originating contract.
  * For example, the HubPool will delegatecall these functions, therefore its only necessary that the HubPool's methods
  * that call this contract's logic guard against reentrancy.
+ * @dev This contract is very similar to Arbitrum_Adapter but it allows the caller to pay for submission
+ * fees using a custom gas token. This is required to support certain Arbitrum orbit L2s and L3s.
+ * @dev This contract
  */
 
 // solhint-disable-next-line contract-name-camelcase
-contract Arbitrum_Adapter is AdapterInterface, CircleCCTPAdapter {
+contract Arbitrum_CustomGasToken_Adapter is AdapterInterface, CircleCCTPAdapter {
     using SafeERC20 for IERC20;
 
-    // Amount of ETH allocated to pay for the base submission fee. The base submission fee is a parameter unique to
+    // Amount of gas token allocated to pay for the base submission fee. The base submission fee is a parameter unique to
     // retryable transactions; the user is charged the base submission fee to cover the storage costs of keeping their
     // ticket’s calldata in the retry buffer. (current base submission fee is queryable via
     // ArbRetryableTx.getSubmissionPrice). ArbRetryableTicket precompile interface exists at L2 address
     // 0x000000000000000000000000000000000000006E.
-    uint256 public constant L2_MAX_SUBMISSION_COST = 0.01e18;
+    // @dev Unlike in Arbitrum_Adapter, this is immutable because we don't know what precision the custom gas token has.
+    uint256 public immutable L2_MAX_SUBMISSION_COST;
 
     // L2 Gas price bid for immediate L2 execution attempt (queryable via standard eth*gasPrice RPC)
     uint256 public constant L2_GAS_PRICE = 5e9; // 5 gWei
@@ -159,14 +142,17 @@ contract Arbitrum_Adapter is AdapterInterface, CircleCCTPAdapter {
     uint32 public constant RELAY_TOKENS_L2_GAS_LIMIT = 300_000;
     uint32 public constant RELAY_MESSAGE_L2_GAS_LIMIT = 2_000_000;
 
-    address public constant L1_DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
-
-    // This address on L2 receives extra ETH that is left over after relaying a message via the inbox.
+    // This address on L2 receives extra gas token that is left over after relaying a message via the inbox.
     address public immutable L2_REFUND_L2_ADDRESS;
 
     ArbitrumL1InboxLike public immutable L1_INBOX;
 
     ArbitrumL1ERC20GatewayLike public immutable L1_ERC20_GATEWAY_ROUTER;
+
+    // This token is used to pay for l1 to l2 messages if its configured by an Arbitrum orbit chain.
+    IERC20 public immutable CUSTOM_GAS_TOKEN;
+
+    address public immutable CUSTOM_GAS_TOKEN_FUNDER;
 
     /**
      * @notice Constructs new Adapter.
@@ -175,30 +161,41 @@ contract Arbitrum_Adapter is AdapterInterface, CircleCCTPAdapter {
      * @param _l2RefundL2Address L2 address to receive gas refunds on after a message is relayed.
      * @param _l1Usdc USDC address on L1.
      * @param _cctpTokenMessenger TokenMessenger contract to bridge via CCTP.
+     * @param _customGasToken Custom gas token to pay for L1 to L2 messages.
+     * @param _customGasTokenFunder Address that funds the custom gas token.
      */
     constructor(
         ArbitrumL1InboxLike _l1ArbitrumInbox,
         ArbitrumL1ERC20GatewayLike _l1ERC20GatewayRouter,
         address _l2RefundL2Address,
         IERC20 _l1Usdc,
-        ITokenMessenger _cctpTokenMessenger
+        ITokenMessenger _cctpTokenMessenger,
+        IERC20 _customGasToken,
+        address _customGasTokenFunder,
+        uint256 _l2MaxSubmissionCost
     ) CircleCCTPAdapter(_l1Usdc, _cctpTokenMessenger, CircleDomainIds.Arbitrum) {
         L1_INBOX = _l1ArbitrumInbox;
         L1_ERC20_GATEWAY_ROUTER = _l1ERC20GatewayRouter;
         L2_REFUND_L2_ADDRESS = _l2RefundL2Address;
+        CUSTOM_GAS_TOKEN = _customGasToken;
+        L2_MAX_SUBMISSION_COST = _l2MaxSubmissionCost;
+        CUSTOM_GAS_TOKEN_FUNDER = _customGasTokenFunder;
+        require(address(_customGasToken) != address(0), "Custom gas token cannot be 0");
+        require(L1_INBOX.bridge().nativeToken() == address(_customGasToken), "Incorrect custom gas token");
+        require(CUSTOM_GAS_TOKEN_FUNDER != address(0), "token funder address cannot be 0");
     }
 
     /**
      * @notice Send cross-chain message to target on Arbitrum.
-     * @notice This contract must hold at least getL1CallValue() amount of ETH to send a message via the Inbox
-     * successfully, or the message will get stuck.
+     * @notice This contract must hold at least getL1CallValue() amount of the custom gas token
+     * to send a message via the Inbox successfully, or the message will get stuck.
      * @param target Contract on Arbitrum that will receive message.
      * @param message Data to send to target.
      */
     function relayMessage(address target, bytes memory message) external payable override {
-        uint256 requiredL1CallValue = _contractHasSufficientEthBalance(RELAY_MESSAGE_L2_GAS_LIMIT);
-
-        L1_INBOX.createRetryableTicket{ value: requiredL1CallValue }(
+        uint256 requiredL1TokenTotalFeeAmount = _pullCustomGas(RELAY_MESSAGE_L2_GAS_LIMIT);
+        CUSTOM_GAS_TOKEN.safeIncreaseAllowance(address(L1_INBOX), requiredL1TokenTotalFeeAmount);
+        L1_INBOX.createRetryableTicket(
             target, // destAddr destination L2 contract address
             L2_CALL_VALUE, // l2CallValue call value for retryable L2 message
             L2_MAX_SUBMISSION_COST, // maxSubmissionCost Max gas deducted from user's L2 balance to cover base fee
@@ -206,16 +203,16 @@ contract Arbitrum_Adapter is AdapterInterface, CircleCCTPAdapter {
             L2_REFUND_L2_ADDRESS, // callValueRefundAddress l2Callvalue gets credited here on L2 if retryable txn times out or gets cancelled
             RELAY_MESSAGE_L2_GAS_LIMIT, // maxGas Max gas deducted from user's L2 balance to cover L2 execution
             L2_GAS_PRICE, // gasPriceBid price bid for L2 execution
+            requiredL1TokenTotalFeeAmount, // tokenTotalFeeAmount amount of fees to be deposited in native token.
             message // data ABI encoded data of L2 message
         );
-
         emit MessageRelayed(target, message);
     }
 
     /**
      * @notice Bridge tokens to Arbitrum.
-     * @notice This contract must hold at least getL1CallValue() amount of ETH to send a message via the Inbox
-     * successfully, or the message will get stuck.
+     * @notice This contract must hold at least getL1CallValue() amount of ETH or custom gas token
+     * to send a message via the Inbox successfully, or the message will get stuck.
      * @param l1Token L1 token to deposit.
      * @param l2Token L2 token to receive.
      * @param amount Amount of L1 tokens to deposit and L2 tokens to receive.
@@ -233,38 +230,35 @@ contract Arbitrum_Adapter is AdapterInterface, CircleCCTPAdapter {
         }
         // If not, we can use the Arbitrum gateway
         else {
-            uint256 requiredL1CallValue = _contractHasSufficientEthBalance(RELAY_TOKENS_L2_GAS_LIMIT);
-
-            // Approve the gateway, not the router, to spend the hub pool's balance. The gateway, which is different
-            // per L1 token, will temporarily escrow the tokens to be bridged and pull them from this contract.
             address erc20Gateway = L1_ERC20_GATEWAY_ROUTER.getGateway(l1Token);
-            IERC20(l1Token).safeIncreaseAllowance(erc20Gateway, amount);
 
-            // `outboundTransfer` expects that the caller includes a bytes message as the last param that includes the
-            // maxSubmissionCost to use when creating an L2 retryable ticket: https://github.com/OffchainLabs/arbitrum/blob/e98d14873dd77513b569771f47b5e05b72402c5e/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol#L232
-            bytes memory data = abi.encode(L2_MAX_SUBMISSION_COST, "");
+            // If custom gas token, call special functions that handle paying with custom gas tokens.
+            uint256 requiredL1TokenTotalFeeAmount = _pullCustomGas(RELAY_MESSAGE_L2_GAS_LIMIT);
 
-            // Note: Legacy routers don't have the outboundTransferCustomRefund method, so default to using
-            // outboundTransfer(). Legacy routers are used for the following tokens that are currently enabled:
-            // - DAI: the implementation of `outboundTransfer` at the current DAI custom gateway
-            //        (https://etherscan.io/address/0xD3B5b60020504bc3489D6949d545893982BA3011#writeContract) sets the
-            //        sender as the refund address so the aliased HubPool should receive excess funds. Implementation here:
-            //        https://github.com/makerdao/arbitrum-dai-bridge/blob/11a80385e2622968069c34d401b3d54a59060e87/contracts/l1/L1DaiGateway.sol#L109
-            if (l1Token == L1_DAI) {
-                // This means that the excess ETH to pay for the L2 transaction will be sent to the aliased
-                // contract address on L2, which we'd have to retrieve via a custom adapter, the Arbitrum_RescueAdapter.
-                // To do so, in a single transaction: 1) setCrossChainContracts to Arbitrum_RescueAdapter, 2) relayMessage
-                // with function data = abi.encode(amountToRescue), 3) setCrossChainContracts back to this adapter.
-                L1_ERC20_GATEWAY_ROUTER.outboundTransfer{ value: requiredL1CallValue }(
-                    l1Token,
-                    to,
-                    amount,
-                    RELAY_TOKENS_L2_GAS_LIMIT,
-                    L2_GAS_PRICE,
-                    data
+            // Must use Inbox to bridge custom gas token.
+            // Source: https://github.com/OffchainLabs/token-bridge-contracts/blob/5bdf33259d2d9ae52ddc69bc5a9cbc558c4c40c7/contracts/tokenbridge/ethereum/gateway/L1OrbitERC20Gateway.sol#L33
+            if (l1Token == address(CUSTOM_GAS_TOKEN)) {
+                uint256 amountToBridge = amount + requiredL1TokenTotalFeeAmount;
+                CUSTOM_GAS_TOKEN.safeIncreaseAllowance(address(L1_INBOX), amountToBridge);
+                L1_INBOX.createRetryableTicket(
+                    to, // destAddr destination L2 contract address
+                    L2_CALL_VALUE, // l2CallValue call value for retryable L2 message
+                    L2_MAX_SUBMISSION_COST, // maxSubmissionCost Max gas deducted from user's L2 balance to cover base fee
+                    L2_REFUND_L2_ADDRESS, // excessFeeRefundAddress maxgas * gasprice - execution cost gets credited here on L2
+                    L2_REFUND_L2_ADDRESS, // callValueRefundAddress l2Callvalue gets credited here on L2 if retryable txn times out or gets cancelled
+                    RELAY_MESSAGE_L2_GAS_LIMIT, // maxGas Max gas deducted from user's L2 balance to cover L2 execution
+                    L2_GAS_PRICE, // gasPriceBid price bid for L2 execution
+                    amountToBridge, // tokenTotalFeeAmount amount of fees to be deposited in native token.
+                    "0x" // data ABI encoded data of L2 message
                 );
             } else {
-                L1_ERC20_GATEWAY_ROUTER.outboundTransferCustomRefund{ value: requiredL1CallValue }(
+                CUSTOM_GAS_TOKEN.safeIncreaseAllowance(erc20Gateway, amount);
+
+                // To pay for gateway outbound transfer with custom gas token, encode the tokenTotalFeeAmount in the data field:
+                // The data format should be (uint256 maxSubmissionCost, bytes extraData, uint256 tokenTotalFeeAmount).
+                // Source: https://github.com/OffchainLabs/token-bridge-contracts/blob/5bdf33259d2d9ae52ddc69bc5a9cbc558c4c40c7/contracts/tokenbridge/ethereum/gateway/L1OrbitERC20Gateway.sol#L57
+                bytes memory data = abi.encode(L2_MAX_SUBMISSION_COST, "", requiredL1TokenTotalFeeAmount);
+                L1_ERC20_GATEWAY_ROUTER.outboundTransferCustomRefund(
                     l1Token,
                     L2_REFUND_L2_ADDRESS,
                     to,
@@ -279,16 +273,17 @@ contract Arbitrum_Adapter is AdapterInterface, CircleCCTPAdapter {
     }
 
     /**
-     * @notice Returns required amount of ETH to send a message via the Inbox.
-     * @return amount of ETH that this contract needs to hold in order for relayMessage to succeed.
+     * @notice Returns required amount of gas token to send a message via the Inbox.
+     * @return amount of gas token that this contract needs to hold in order for relayMessage to succeed.
      */
-    function getL1CallValue(uint32 l2GasLimit) public pure returns (uint256) {
+    function getL1CallValue(uint32 l2GasLimit) public view returns (uint256) {
         return L2_MAX_SUBMISSION_COST + L2_GAS_PRICE * l2GasLimit;
     }
 
-    function _contractHasSufficientEthBalance(uint32 l2GasLimit) internal view returns (uint256) {
+    function _pullCustomGas(uint32 l2GasLimit) internal returns (uint256) {
         uint256 requiredL1CallValue = getL1CallValue(l2GasLimit);
-        require(address(this).balance >= requiredL1CallValue, "Insufficient ETH balance");
+        CUSTOM_GAS_TOKEN.transferFrom(CUSTOM_GAS_TOKEN_FUNDER, address(this), requiredL1CallValue);
+        require(CUSTOM_GAS_TOKEN.balanceOf(address(this)) >= requiredL1CallValue, "Insufficient gas balance");
         return requiredL1CallValue;
     }
 }

--- a/contracts/chain-adapters/Arbitrum_CustomGasToken_Funder.sol
+++ b/contracts/chain-adapters/Arbitrum_CustomGasToken_Funder.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract Arbitrum_CustomGasToken_Funder is Ownable {
+    using SafeERC20 for IERC20;
+
+    /**
+     * @notice Deposit tokens into the contract.
+     * @param token Token to deposit.
+     * @param amount Amount of tokens to deposit.
+     */
+    function deposit(IERC20 token, uint256 amount) external {
+        token.safeTransferFrom(msg.sender, address(this), amount);
+    }
+
+    /**
+     * @notice Withdraw tokens from the contract.
+     * @param token Token to withdraw.
+     * @param amount Amount of tokens to withdraw.
+     */
+    function withdraw(IERC20 token, uint256 amount) external onlyOwner {
+        token.safeTransfer(msg.sender, amount);
+    }
+}

--- a/contracts/chain-adapters/Arbitrum_CustomGasToken_Funder.sol
+++ b/contracts/chain-adapters/Arbitrum_CustomGasToken_Funder.sol
@@ -9,15 +9,6 @@ contract Arbitrum_CustomGasToken_Funder is Ownable {
     using SafeERC20 for IERC20;
 
     /**
-     * @notice Deposit tokens into the contract.
-     * @param token Token to deposit.
-     * @param amount Amount of tokens to deposit.
-     */
-    function deposit(IERC20 token, uint256 amount) external {
-        token.safeTransferFrom(msg.sender, address(this), amount);
-    }
-
-    /**
      * @notice Withdraw tokens from the contract.
      * @param token Token to withdraw.
      * @param amount Amount of tokens to withdraw.


### PR DESCRIPTION
- Example `createRetryableTicket` paying for submission with custom gas token and also sending custom gas token to L2: https://etherscan.io/tx/0xfbcd1f29a0db9971c885815e74499f3a545e7c0ee0a2d06ee4a94dc08c03f4e0

- Example `outboundTransfer` paying with custom gas token and sending a different ERC20 to L2: https://etherscan.io/tx/0x7f65fff856520cc419c3a9f43a61f3427ad495ddf5dc81276c2767ac74242e39
