### PR TITLE
improve(SpokePool): Remove redundant getCurrentTime() call

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -592,7 +592,7 @@ abstract contract SpokePool is
             numberOfDeposits++,
             quoteTimestamp,
             fillDeadline,
-            uint32(getCurrentTime()) + exclusivityPeriod,
+            uint32(currentTime) + exclusivityPeriod,
             depositor,
             recipient,
             exclusiveRelayer,


### PR DESCRIPTION
This call is already loaded into memory above within the same function
