### PR TITLE
improve: Rename Arbitrum_CustomGasToken_Funder to DonationBox

### DIFF
--- a/contracts/chain-adapters/DonationBox.sol
+++ b/contracts/chain-adapters/DonationBox.sol
@@ -5,7 +5,13 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-contract Arbitrum_CustomGasToken_Funder is Ownable {
+/**
+ * @notice Users can donate tokens to this contract that only the owner can withdraw.
+ * @dev This contract is designed to be used as a convience for the owner to store funds to pay for
+ * future transactions, such as donating custom gas tokens to pay for future retryable ticket messages
+ * to be sent via the Arbitrum_Adapter.
+ */
+contract DonationBox is Ownable {
     using SafeERC20 for IERC20;
 
     /**


### PR DESCRIPTION
Makes it more clear that anyone depositing tokens to the box is willingly giving them away to the owner. The contract is mostly designed to be used by the owner to deposit fundsto. be used  for future transactions.