### PR TITLE
improve(SpokePool): deposit with message gas optimization

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1372,7 +1372,7 @@ abstract contract SpokePool is
         }
 
         bytes memory updatedMessage = relayExecution.updatedMessage;
-        if (recipientToSend.isContract() && updatedMessage.length > 0) {
+        if (updatedMessage.length > 0 && recipientToSend.isContract()) {
             AcrossMessageHandler(recipientToSend).handleV3AcrossMessage(
                 outputToken,
                 amountToSend,


### PR DESCRIPTION
In most cases, we can avoid having to do the `extcodesize` call that’s inside `isContract()`.

This could save [~2600](https://github.com/wolflo/evm-opcodes/blob/main/gas.md#a5-balance-extcodesize-extcodehash) gas per call for non ETH bridges to EOAs
