### PR TITLE
[WIP] refactor: export bridging logic to l2 adapter contracts

### DIFF
--- a/contracts/chain-adapters/l2/Arbitrum_WithdrawalAdapter.sol
+++ b/contracts/chain-adapters/l2/Arbitrum_WithdrawalAdapter.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// Arbitrum only supports v0.8.19
+// See https://docs.arbitrum.io/for-devs/concepts/differences-between-arbitrum-ethereum/solidity-support#differences-from-solidity-on-ethereum
+pragma solidity ^0.8.19;
+
+import "../../libraries/CircleCCTPAdapter.sol";
+import { StandardBridgeLike } from "../../Arbitrum_SpokePool.sol";
+
+/**
+ * @notice AVM specific bridge adapter. Implements logic to bridge tokens back to mainnet.
+ * @custom:security-contact bugs@across.to
+ */
+
+/*
+ * @notice Interface for the Across Arbitrum_SpokePool contract. Used to access state which
+ * can only be modified by admin functions.
+ */
+interface IArbitrum_SpokePool {
+    function whitelistedTokens(address) external view returns (address);
+}
+
+/**
+ * @title Adapter for interacting with bridges from the Arbitrum One L2 to Ethereum mainnet.
+ * @notice This contract is used to share L2-L1 bridging logic with other L2 Across contracts.
+ */
+contract Arbitrum_WithdrawalAdapter is CircleCCTPAdapter {
+    IArbitrum_SpokePool public immutable spokePool;
+    address public immutable tokenRetriever;
+    address public immutable l2GatewayRouter;
+
+    /*
+     * @notice constructs the withdrawal adapter.
+     * @param _l2Usdc address of native USDC on the L2.
+     * @param _cctpTokenMessenger address of the CCTP token messenger contract on L2.
+     * @param _spokePool address of the spoke pool on L2.
+     * @param _tokenRetriever L1 address of the recipient of withdrawals.
+     * @param _l2GatewayRouter address of the Arbitrum l2 gateway router contract.
+     */
+    constructor(
+        IERC20 _l2Usdc,
+        ITokenMessenger _cctpTokenMessenger,
+        IArbitrum_SpokePool _spokePool,
+        address _tokenRetriever,
+        address _l2GatewayRouter
+    ) CircleCCTPAdapter(_l2Usdc, _cctpTokenMessenger, CircleDomainIds.Ethereum) {
+        spokePool = _spokePool;
+        tokenRetriever = _tokenRetriever;
+        l2GatewayRouter = _l2GatewayRouter;
+    }
+
+    /*
+     * @notice Calls CCTP or the Arbitrum gateway router to withdraw tokens back to the `tokenRetriever`. The
+     * bridge will not be called if the token is not in the Arbitrum_SpokePool's `whitelistedTokens` mapping.
+     * @param amountToReturn amount of l2Token to send back to the token retriever.
+     * @param l2TokenAddress address of the l2Token to send back to the token retriever.
+     */
+    function withdrawToken(uint256 amountToReturn, address l2TokenAddress) external {
+        // If the l2TokenAddress is UDSC, we need to use the CCTP bridge.
+        if (_isCCTPEnabled() && l2TokenAddress == address(usdcToken)) {
+            _transferUsdc(tokenRetriever, amountToReturn);
+        } else {
+            // Check that the Ethereum counterpart of the L2 token is stored on this contract.
+            // Tokens will only be bridged if they are whitelisted by the spoke pool.
+            address ethereumTokenToBridge = spokePool.whitelistedTokens(l2TokenAddress);
+            require(ethereumTokenToBridge != address(0), "Uninitialized mainnet token");
+            //slither-disable-next-line unused-return
+            StandardBridgeLike(l2GatewayRouter).outboundTransfer(
+                ethereumTokenToBridge, // _l1Token. Address of the L1 token to bridge over.
+                tokenRetriever, // _to. Withdraw, over the bridge, to the l1 hub pool contract.
+                amountToReturn, // _amount.
+                "" // _data. We don't need to send any data for the bridging action.
+            );
+        }
+    }
+}

--- a/test/foundry/local/Arbitrum_WithdrawalAdapter.t.sol
+++ b/test/foundry/local/Arbitrum_WithdrawalAdapter.t.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+import { MockERC20 } from "forge-std/mocks/MockERC20.sol";
+import { ERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { Arbitrum_SpokePool, ITokenMessenger } from "../../../contracts/Arbitrum_SpokePool.sol";
+import { Arbitrum_WithdrawalAdapter, IArbitrum_SpokePool } from "../../../contracts/chain-adapters/l2/Arbitrum_WithdrawalAdapter.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+
+import "forge-std/console.sol";
+
+contract Token_ERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 value) public virtual {
+        _mint(to, value);
+    }
+
+    function burn(address from, uint256 value) public virtual {
+        _burn(from, value);
+    }
+}
+
+contract ArbitrumGatewayRouter {
+    function outboundTransfer(
+        address tokenToBridge,
+        address recipient,
+        uint256 amountToReturn,
+        bytes memory
+    ) external returns (bytes memory) {
+        Token_ERC20(tokenToBridge).burn(msg.sender, amountToReturn);
+        Token_ERC20(tokenToBridge).mint(recipient, amountToReturn);
+        return "";
+    }
+}
+
+contract Arbitrum_WithdrawalAdapterTest is Test {
+    Arbitrum_WithdrawalAdapter arbitrumWithdrawalAdapter;
+    Arbitrum_SpokePool arbitrumSpokePool;
+    Token_ERC20 whitelistedToken;
+    Token_ERC20 usdc;
+    ArbitrumGatewayRouter gatewayRouter;
+
+    // HubPool should receive funds.
+    address hubPool;
+
+    address owner;
+    address aliasedOwner;
+    address wrappedNativeToken;
+
+    // Token messenger is set so CCTP is activated.
+    ITokenMessenger tokenMessenger;
+
+    function setUp() public {
+        whitelistedToken = new Token_ERC20("DAI", "DAI");
+        usdc = new Token_ERC20("USDC", "USDC");
+        gatewayRouter = new ArbitrumGatewayRouter();
+
+        tokenMessenger = ITokenMessenger(vm.addr(1));
+        owner = vm.addr(2);
+        wrappedNativeToken = vm.addr(3);
+        hubPool = vm.addr(4);
+        aliasedOwner = _applyL1ToL2Alias(owner);
+
+        vm.startPrank(owner);
+        Arbitrum_SpokePool implementation = new Arbitrum_SpokePool(wrappedNativeToken, 0, 0, usdc, tokenMessenger);
+        address proxy = address(
+            new ERC1967Proxy(
+                address(implementation),
+                abi.encodeCall(Arbitrum_SpokePool.initialize, (0, address(gatewayRouter), owner, owner))
+            )
+        );
+        vm.stopPrank();
+
+        arbitrumSpokePool = Arbitrum_SpokePool(payable(proxy));
+        arbitrumWithdrawalAdapter = new Arbitrum_WithdrawalAdapter(
+            usdc,
+            tokenMessenger,
+            IArbitrum_SpokePool(proxy),
+            hubPool,
+            address(gatewayRouter)
+        );
+    }
+
+    function testWithdrawWhitelistedTokenNonCCTP() public {
+        assertEq(whitelistedToken.balanceOf(hubPool), 0);
+        assertEq(whitelistedToken.balanceOf(owner), 0);
+        assertEq(whitelistedToken.balanceOf(address(arbitrumWithdrawalAdapter)), 0);
+        uint256 amountToBridge = uint256(block.timestamp + 100);
+
+        // Whitelist tokens in the spoke pool and mint tokens to the withdrawal adapter.
+        vm.startPrank(aliasedOwner);
+        arbitrumSpokePool.whitelistToken(address(whitelistedToken), address(whitelistedToken));
+        whitelistedToken.mint(address(arbitrumWithdrawalAdapter), amountToBridge);
+        vm.stopPrank();
+
+        // Attempt to withdraw token.
+        arbitrumWithdrawalAdapter.withdrawToken(amountToBridge, address(whitelistedToken));
+        assertEq(whitelistedToken.balanceOf(hubPool), amountToBridge);
+        assertEq(whitelistedToken.balanceOf(owner), 0);
+        assertEq(whitelistedToken.balanceOf(address(arbitrumWithdrawalAdapter)), 0);
+    }
+
+    function testWithdrawOtherTokenNonCCTP() public {
+        assertEq(whitelistedToken.balanceOf(hubPool), 0);
+        assertEq(whitelistedToken.balanceOf(owner), 0);
+        assertEq(whitelistedToken.balanceOf(address(arbitrumWithdrawalAdapter)), 0);
+        uint256 amountToBridge = uint256(block.timestamp + 100);
+
+        // Mint tokens to the withdrawal adapter but do not whitelist it in the spoke pool.
+        whitelistedToken.mint(address(arbitrumWithdrawalAdapter), amountToBridge);
+
+        // Attempt to withdraw token.
+        vm.expectRevert();
+        arbitrumWithdrawalAdapter.withdrawToken(amountToBridge, address(whitelistedToken));
+        assertEq(whitelistedToken.balanceOf(hubPool), 0);
+        assertEq(whitelistedToken.balanceOf(owner), 0);
+        assertEq(whitelistedToken.balanceOf(address(arbitrumWithdrawalAdapter)), amountToBridge);
+    }
+
+    function _applyL1ToL2Alias(address l1Address) internal pure returns (address l2Address) {
+        // Allows overflows as explained above.
+        unchecked {
+            l2Address = address(uint160(l1Address) + uint160(0x1111000000000000000000000000000000001111));
+        }
+    }
+}


### PR DESCRIPTION
There will be shared logic between L2 token retrievers which need to bridge funds from L3 back to L1 and L2 spoke pool logic. We may be able to factor this out for each chain and create another adapter-like contract which can be `delegatecall`-ed by both L2 token retriever and spoke pool contracts.