### PR TITLE
[WIP] - feat: add Intermediate_Token retriever contract for L3-L1 withdrawals

### DIFF
--- a/contracts/Intermediate_TokenRetriever.sol
+++ b/contracts/Intermediate_TokenRetriever.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.19;
+
+import "./Lockable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "@uma/core/contracts/common/implementation/MultiCaller.sol";
+
+interface IBridgeAdapter {
+    function withdrawToken(uint256 amountToReturn, address l2Token) external;
+}
+
+/**
+ * @notice Contract deployed on an arbitrary L2 to act as an intermediate contract for withdrawals from L3 to L1.
+ * @dev Since each network has its own bridging requirements, this contract delegates that logic to a bridge adapter contract
+ * which performs the necessary withdraw action.
+ */
+contract Intermediate_TokenRetriever is Lockable, MultiCaller {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    // Should be set to the bridge adapter which contains the proper logic to withdraw tokens on
+    // the deployed L2
+    address public immutable bridgeAdapter;
+
+    error WithdrawalFailed(address l2Token);
+
+    /**
+     * @notice Constructs the Intermediate_TokenRetriever
+     * @param _bridgeAdapter contract which contains network's bridging logic.
+     */
+    constructor(address _bridgeAdapter) {
+        //slither-disable-next-line missing-zero-check
+        bridgeAdapter = _bridgeAdapter;
+    }
+
+    /**
+     * @notice delegatecalls the contract's stored bridge adapter to bridge tokens back to the defined token retriever
+     * @notice This follows the bridging logic of the corresponding bridge adapter.
+     * @param l2Token (current network's) contract address of the token to be withdrawn.
+     */
+    function retrieve(address l2Token) public nonReentrant {
+        (bool success, ) = bridgeAdapter.delegatecall(
+            abi.encodeCall(IBridgeAdapter.withdrawToken, (IERC20Upgradeable(l2Token).balanceOf(address(this)), l2Token))
+        );
+        if (!success) revert WithdrawalFailed(l2Token);
+    }
+}


### PR DESCRIPTION
This contract should be able to be deployed on any L2 network. It should receive tokens from L3 and call the bridge adapter contract to send tokens back to L1. It is still TBD which variables should be stored in which contracts. The name is also TBD.