### PR TITLE
fix(svm): add missing constraints in svm spoke pool

### DIFF
--- a/programs/svm-spoke/src/instructions/admin.rs
+++ b/programs/svm-spoke/src/instructions/admin.rs
@@ -176,7 +176,11 @@ pub struct SetEnableRoute<'info> {
     )]
     pub vault: InterfaceAccount<'info, TokenAccount>,
 
-    #[account(mint::token_program = token_program)]
+    #[account(
+        mint::token_program = token_program,
+        // IDL build fails when requiring `address = input_token` for mint, thus using a custom constraint.
+        constraint = origin_token_mint.key() == origin_token.into() @ CustomError::InvalidMint
+    )]
     pub origin_token_mint: InterfaceAccount<'info, Mint>,
 
     pub token_program: Interface<'info, TokenInterface>,

--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -40,10 +40,20 @@ pub struct DepositV3<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        token::mint = mint,
+        token::authority = signer,
+        token::token_program = token_program
+    )]
     pub user_token_account: InterfaceAccount<'info, TokenAccount>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        associated_token::mint = mint,
+        associated_token::authority = state,
+        associated_token::token_program = token_program
+    )]
     pub vault: InterfaceAccount<'info, TokenAccount>,
 
     #[account(

--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -49,7 +49,7 @@ pub struct DepositV3<'info> {
     #[account(
         mut,
         mint::token_program = token_program,
-        // IDL build fails when requiring `mint address = input_token`, thus using a custom constraint.
+        // IDL build fails when requiring `address = input_token` for mint, thus using a custom constraint.
         constraint = mint.key() == input_token @ CustomError::InvalidMint
     )]
     pub mint: InterfaceAccount<'info, Mint>,

--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -46,7 +46,12 @@ pub struct DepositV3<'info> {
     #[account(mut)]
     pub vault: InterfaceAccount<'info, TokenAccount>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        mint::token_program = token_program,
+        // IDL build fails when requiring `mint address = input_token`, thus using a custom constraint.
+        constraint = mint.key() == input_token @ CustomError::InvalidMint
+    )]
     pub mint: InterfaceAccount<'info, Mint>,
 
     pub token_program: Interface<'info, TokenInterface>,

--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -38,6 +38,7 @@ pub struct FillV3Relay<'info> {
 
     #[account(
         mut,
+        token::token_program = token_program,
         address = relay_data.output_token @ CustomError::InvalidMint
     )]
     pub mint_account: InterfaceAccount<'info, Mint>,

--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -40,6 +40,7 @@ pub struct FillV3Relay<'info> {
         mut,
         associated_token::mint = mint_account,
         associated_token::authority = relayer,
+        associated_token::token_program = token_program
     )]
     pub relayer_token_account: InterfaceAccount<'info, TokenAccount>,
 
@@ -47,6 +48,7 @@ pub struct FillV3Relay<'info> {
         mut,
         associated_token::mint = mint_account,
         associated_token::authority = recipient,
+        associated_token::token_program = token_program
     )]
     pub recipient_token_account: InterfaceAccount<'info, TokenAccount>,
 

--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -36,7 +36,10 @@ pub struct FillV3Relay<'info> {
     )]
     pub recipient: SystemAccount<'info>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        address = relay_data.output_token @ CustomError::InvalidMint
+    )]
     pub mint_account: InterfaceAccount<'info, Mint>,
 
     #[account(

--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -30,7 +30,10 @@ pub struct FillV3Relay<'info> {
     #[account(mut)]
     pub relayer: SystemAccount<'info>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        address = relay_data.recipient @ CustomError::InvalidFillRecipient
+    )]
     pub recipient: SystemAccount<'info>,
 
     #[account(mut)]

--- a/programs/svm-spoke/src/instructions/handle_receive_message.rs
+++ b/programs/svm-spoke/src/instructions/handle_receive_message.rs
@@ -24,6 +24,8 @@ pub struct HandleReceiveMessage<'info> {
     )]
     pub authority_pda: Signer<'info>,
     #[account(
+        seeds = [b"state", state.seed.to_le_bytes().as_ref()],
+        bump,
         constraint = params.remote_domain == state.remote_domain @ CustomError::InvalidRemoteDomain,
         constraint = params.sender == state.cross_domain_admin @ CustomError::InvalidRemoteSender,
     )]

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -163,7 +163,10 @@ pub struct ExecuteV3SlowRelayLeaf<'info> {
     )]
     pub recipient: SystemAccount<'info>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        address = slow_fill_leaf.relay_data.output_token @ CustomError::InvalidMint
+    )]
     pub mint: InterfaceAccount<'info, Mint>,
 
     #[account(

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -151,7 +151,10 @@ pub struct ExecuteV3SlowRelayLeaf<'info> {
     #[account(
         mut,
         seeds = [b"fills", relay_hash.as_ref()],
-        bump)]
+        bump,
+        // Make sure caller provided relay_hash used in PDA seeds is valid.
+        constraint = is_relay_hash_valid(&relay_hash, &slow_fill_leaf.relay_data, &state) @ CustomError::InvalidRelayHash
+    )]
     pub fill_status: Account<'info, FillStatusAccount>,
 
     #[account(

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -170,6 +170,7 @@ pub struct ExecuteV3SlowRelayLeaf<'info> {
         mut,
         associated_token::mint = mint,
         associated_token::authority = recipient,
+        associated_token::token_program = token_program
     )]
     pub recipient_token_account: InterfaceAccount<'info, TokenAccount>,
 
@@ -177,6 +178,7 @@ pub struct ExecuteV3SlowRelayLeaf<'info> {
         mut,
         associated_token::mint = mint,
         associated_token::authority = state,
+        associated_token::token_program = token_program
     )]
     pub vault: InterfaceAccount<'info, TokenAccount>,
 

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -165,6 +165,7 @@ pub struct ExecuteV3SlowRelayLeaf<'info> {
 
     #[account(
         mut,
+        token::token_program = token_program,
         address = slow_fill_leaf.relay_data.output_token @ CustomError::InvalidMint
     )]
     pub mint: InterfaceAccount<'info, Mint>,

--- a/test/svm/SvmSpoke.Deposit.ts
+++ b/test/svm/SvmSpoke.Deposit.ts
@@ -23,16 +23,14 @@ describe("svm_spoke.deposit", () => {
   let depositAccounts: any; // Re-used between tests to simplify props.
   let setEnableRouteAccounts: any; // Common variable for setEnableRoute accounts
 
-  before("Creates token mint and associated token accounts", async () => {
+  const setupInputToken = async () => {
     inputToken = await createMint(connection, payer, owner, owner, 6);
 
     depositorTA = (await getOrCreateAssociatedTokenAccount(connection, payer, inputToken, depositor.publicKey)).address;
     await mintTo(connection, payer, inputToken, depositorTA, owner, seedBalance);
-  });
+  };
 
-  beforeEach(async () => {
-    state = await initializeState();
-
+  const enableRoute = async () => {
     const routeChainId = new BN(1);
     const route = createRoutePda(inputToken, routeChainId);
     vault = getVaultAta(inputToken, state);
@@ -67,6 +65,16 @@ describe("svm_spoke.deposit", () => {
       mint: inputToken,
       tokenProgram: TOKEN_PROGRAM_ID,
     };
+  };
+
+  before("Creates token mint and associated token accounts", async () => {
+    await setupInputToken();
+  });
+
+  beforeEach(async () => {
+    state = await initializeState();
+
+    await enableRoute();
   });
 
   it("Deposits tokens via deposit_v3 function and checks balances", async () => {
@@ -210,6 +218,32 @@ describe("svm_spoke.deposit", () => {
     } catch (err) {
       assert.instanceOf(err, anchor.AnchorError);
       assert.strictEqual(err.error.errorCode.code, "DepositsArePaused", "Expected error code DepositsArePaused");
+    }
+  });
+
+  it("Fails to process deposit for mint inconsistent input_token", async () => {
+    // Save the correct data and accounts from global scope before changing it when creating a new input token.
+    const firstInputToken = inputToken;
+    const firstDepositAccounts = depositAccounts;
+
+    // Create a new input token and enable the route (this updates global scope variables).
+    await setupInputToken();
+    await enableRoute();
+
+    // Try to execute the deposit_v3 call with malformed inputs where the first input token and its derived route is
+    // passed combined with mint, vault and user token account from the second input token.
+    const malformedDepositData = { ...depositData, inputToken: firstInputToken };
+    const malformedDepositAccounts = { ...depositAccounts, route: firstDepositAccounts.route };
+    try {
+      await program.methods
+        .depositV3(...Object.values(malformedDepositData))
+        .accounts(malformedDepositAccounts)
+        .signers([depositor])
+        .rpc();
+      assert.fail("Should not be able to process deposit for inconsistent mint");
+    } catch (err) {
+      assert.instanceOf(err, anchor.AnchorError);
+      assert.strictEqual(err.error.errorCode.code, "InvalidMint", "Expected error code InvalidMint");
     }
   });
 });

--- a/test/svm/SvmSpoke.Fill.ts
+++ b/test/svm/SvmSpoke.Fill.ts
@@ -294,4 +294,32 @@ describe("svm_spoke.fill", () => {
       assert.strictEqual(err.error.errorCode.code, "InvalidFillRecipient", "Expected error code InvalidFillRecipient");
     }
   });
+
+  it("Fails to fill a relay for mint inconsistent output_token", async () => {
+    const relayHash = calculateRelayHashUint8Array(relayData, chainId);
+
+    // Create and fund new accounts as derived from wrong mint account.
+    const wrongMint = await createMint(connection, payer, owner, owner, 6);
+    const wrongRecipientTA = (await getOrCreateAssociatedTokenAccount(connection, payer, wrongMint, recipient)).address;
+    const wrongRelayerTA = (await getOrCreateAssociatedTokenAccount(connection, payer, wrongMint, relayer.publicKey))
+      .address;
+    await mintTo(connection, payer, wrongMint, wrongRelayerTA, owner, seedBalance);
+
+    try {
+      await program.methods
+        .fillV3Relay(relayHash, relayData, new BN(1))
+        .accounts({
+          ...accounts,
+          mintAccount: wrongMint,
+          relayerTokenAccount: wrongRelayerTA,
+          recipientTokenAccount: wrongRecipientTA,
+        })
+        .signers([relayer])
+        .rpc();
+      assert.fail("Should not be able to process fill for inconsistent mint");
+    } catch (err) {
+      assert.instanceOf(err, anchor.AnchorError);
+      assert.strictEqual(err.error.errorCode.code, "InvalidMint", "Expected error code InvalidMint");
+    }
+  });
 });

--- a/test/svm/SvmSpoke.HandleReceiveMessage.ts
+++ b/test/svm/SvmSpoke.HandleReceiveMessage.ts
@@ -310,7 +310,7 @@ describe("svm_spoke.handle_receive_message", () => {
 
   it("Enables and disables route remotely", async () => {
     // Enable the route.
-    const originToken = Keypair.generate().publicKey;
+    const originToken = await createMint(provider.connection, provider.wallet.payer, owner, owner, 6);
     const routeChainId = 1;
     let calldata = ethereumIface.encodeFunctionData("setEnableRoute", [originToken.toBuffer(), routeChainId, true]);
     let messageBody = Buffer.from(calldata.slice(2), "hex");
@@ -327,8 +327,7 @@ describe("svm_spoke.handle_receive_message", () => {
 
     // Remaining accounts specific to SetEnableRoute.
     const routePda = createRoutePda(originToken, new anchor.BN(routeChainId));
-    const tokenMint = await createMint(provider.connection, provider.wallet.payer, owner, owner, 6);
-    const vault = getVaultAta(tokenMint, state);
+    const vault = getVaultAta(originToken, state);
     // Same 3 remaining accounts passed for HandleReceiveMessage context.
     const enableRouteRemainingAccounts = remainingAccounts.slice(0, 3);
     // payer in self-invoked SetEnableRoute.
@@ -359,7 +358,7 @@ describe("svm_spoke.handle_receive_message", () => {
     enableRouteRemainingAccounts.push({
       isSigner: false,
       isWritable: false,
-      pubkey: tokenMint,
+      pubkey: originToken,
     });
     // token_program in self-invoked SetEnableRoute.
     enableRouteRemainingAccounts.push({

--- a/test/svm/SvmSpoke.Routes.ts
+++ b/test/svm/SvmSpoke.Routes.ts
@@ -16,8 +16,6 @@ describe("svm_spoke.routes", () => {
   let routeChainId: BN;
   let setEnableRouteAccounts: any;
 
-  before("Creates token mint and associated token accounts", async () => {});
-
   beforeEach(async () => {
     state = await initializeState();
     tokenMint = await createMint(provider.connection, provider.wallet.payer, owner, owner, 6);

--- a/test/svm/SvmSpoke.Routes.ts
+++ b/test/svm/SvmSpoke.Routes.ts
@@ -12,28 +12,25 @@ describe("svm_spoke.routes", () => {
   anchor.setProvider(provider);
 
   const nonOwner = Keypair.generate();
-  let state: PublicKey, tokenMint: PublicKey;
+  let state: PublicKey, tokenMint: PublicKey, routePda: PublicKey, vault: PublicKey;
+  let routeChainId: BN;
+  let setEnableRouteAccounts: any;
 
-  before("Creates token mint and associated token accounts", async () => {
-    tokenMint = await createMint(provider.connection, provider.wallet.payer, owner, owner, 6);
-  });
+  before("Creates token mint and associated token accounts", async () => {});
 
   beforeEach(async () => {
     state = await initializeState();
-  });
-
-  it("Sets, retrieves, and controls access to route enablement", async () => {
-    const originToken = Keypair.generate().publicKey;
-    const routeChainId = new BN(1);
+    tokenMint = await createMint(provider.connection, provider.wallet.payer, owner, owner, 6);
 
     // Create a PDA for the route
-    const routePda = createRoutePda(originToken, routeChainId);
+    routeChainId = new BN(1);
+    routePda = createRoutePda(tokenMint, routeChainId);
 
     // Create ATA for the origin token to be stored by state (vault).
-    const vault = getVaultAta(tokenMint, state);
+    vault = getVaultAta(tokenMint, state);
 
     // Common accounts object
-    const accounts = {
+    setEnableRouteAccounts = {
       signer: owner,
       payer: owner,
       state,
@@ -44,9 +41,14 @@ describe("svm_spoke.routes", () => {
       associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
       systemProgram: anchor.web3.SystemProgram.programId,
     };
+  });
 
+  it("Sets, retrieves, and controls access to route enablement", async () => {
     // Enable the route as owner
-    await program.methods.setEnableRoute(originToken.toBytes(), routeChainId, true).accounts(accounts).rpc();
+    await program.methods
+      .setEnableRoute(tokenMint.toBytes(), routeChainId, true)
+      .accounts(setEnableRouteAccounts)
+      .rpc();
     await new Promise((resolve) => setTimeout(resolve, 500));
 
     // Retrieve and verify the route is enabled
@@ -58,12 +60,15 @@ describe("svm_spoke.routes", () => {
       (event) => event.name === "enabledDepositRoute"
     );
     let event = events[0].data;
-    assert.strictEqual(event.originToken.toString(), originToken.toString(), "originToken event match");
+    assert.strictEqual(event.originToken.toString(), tokenMint.toString(), "originToken event match");
     assert.strictEqual(event.destinationChainId.toString(), routeChainId.toString(), "destinationChainId should match");
     assert.isTrue(event.enabled, "enabledDepositRoute enabled");
 
     // Disable the route as owner
-    await program.methods.setEnableRoute(originToken.toBytes(), routeChainId, false).accounts(accounts).rpc();
+    await program.methods
+      .setEnableRoute(tokenMint.toBytes(), routeChainId, false)
+      .accounts(setEnableRouteAccounts)
+      .rpc();
     await new Promise((resolve) => setTimeout(resolve, 500));
 
     // Retrieve and verify the route is disabled
@@ -75,15 +80,15 @@ describe("svm_spoke.routes", () => {
       (event) => event.name === "enabledDepositRoute"
     );
     event = events[0].data; // take most recent event, index 0.
-    assert.strictEqual(event.originToken.toString(), originToken.toString(), "originToken event match");
+    assert.strictEqual(event.originToken.toString(), tokenMint.toString(), "originToken event match");
     assert.strictEqual(event.destinationChainId.toString(), routeChainId.toString(), "destinationChainId should match");
     assert.isFalse(event.enabled, "enabledDepositRoute disabled");
 
     // Try to enable the route as non-owner
     try {
       await program.methods
-        .setEnableRoute(originToken.toBytes(), routeChainId, true)
-        .accounts({ ...accounts, signer: nonOwner.publicKey })
+        .setEnableRoute(tokenMint.toBytes(), routeChainId, true)
+        .accounts({ ...setEnableRouteAccounts, signer: nonOwner.publicKey })
         .signers([nonOwner])
         .rpc();
       assert.fail("Non-owner should not be able to set route enablement");
@@ -102,5 +107,21 @@ describe("svm_spoke.routes", () => {
     // Verify the owner of the state is the expected owner
     const stateAccount = await program.account.state.fetch(state);
     assert.strictEqual(stateAccount.owner.toBase58(), owner.toBase58(), "State owner should be the expected owner");
+  });
+
+  it("Cannot misconfigure route with wrong origin token", async () => {
+    const wrongOriginToken = Keypair.generate().publicKey;
+    const wrongRoutePda = createRoutePda(wrongOriginToken, routeChainId);
+
+    try {
+      await program.methods
+        .setEnableRoute(wrongOriginToken.toBytes(), routeChainId, true)
+        .accounts({ ...setEnableRouteAccounts, route: wrongRoutePda })
+        .rpc();
+      assert.fail("Setting route with wrong origin token should fail");
+    } catch (err) {
+      assert.instanceOf(err, anchor.AnchorError);
+      assert.strictEqual(err.error.errorCode.code, "InvalidMint", "Expected error code InvalidMint");
+    }
   });
 });

--- a/test/svm/SvmSpoke.SlowFill.ts
+++ b/test/svm/SvmSpoke.SlowFill.ts
@@ -51,7 +51,7 @@ describe("svm_spoke.slow_fill", () => {
     requestAccounts = {
       state,
       signer: relayer.publicKey,
-      recipient: relayData.recipient, // This could be different from default recipient.
+      recipient: relayData.recipient, // This could be different from global recipient.
       fillStatus,
       systemProgram: anchor.web3.SystemProgram.programId,
     };
@@ -59,7 +59,7 @@ describe("svm_spoke.slow_fill", () => {
       state,
       signer: relayer.publicKey,
       relayer: relayer.publicKey,
-      recipient: relayData.recipient, // This could be different from default recipient.
+      recipient: relayData.recipient, // This could be different from global recipient.
       mintAccount: mint,
       relayerTA: relayerTA,
       recipientTA: recipientTA,

--- a/test/svm/SvmSpoke.SlowFill.ts
+++ b/test/svm/SvmSpoke.SlowFill.ts
@@ -28,54 +28,55 @@ describe("svm_spoke.slow_fill", () => {
     relayerTA: PublicKey,
     recipientTA: PublicKey,
     otherRelayerTA: PublicKey,
-    vault: PublicKey;
+    vault: PublicKey,
+    fillStatus: PublicKey;
 
   const relayAmount = 500_000;
-  let relayData: any; // reused relay data for all tests.
+  let relayData: SlowFillLeaf["relayData"]; // reused relay data for all tests.
   let requestAccounts: any; // Store accounts to simplify program interactions.
   let fillAccounts: any;
 
   const initialMintAmount = 10_000_000_000;
 
-  function updateRelayData(newRelayData: any) {
+  async function updateRelayData(newRelayData: SlowFillLeaf["relayData"]) {
     relayData = newRelayData;
     const relayHashUint8Array = calculateRelayHashUint8Array(relayData, chainId);
-    const [fillStatusPDA] = PublicKey.findProgramAddressSync(
-      [Buffer.from("fills"), relayHashUint8Array],
-      program.programId
-    );
+    [fillStatus] = PublicKey.findProgramAddressSync([Buffer.from("fills"), relayHashUint8Array], program.programId);
+
+    // recipientTA could be different for each relayData if custom recipient was passed.
+    recipientTA = (await getOrCreateAssociatedTokenAccount(connection, payer, mint, relayData.recipient)).address;
 
     // Accounts for requestingSlowFill.
     requestAccounts = {
       state,
       signer: relayer.publicKey,
-      recipient: recipient,
-      fillStatus: fillStatusPDA,
+      recipient: relayData.recipient, // This could be different from default recipient.
+      fillStatus,
       systemProgram: anchor.web3.SystemProgram.programId,
     };
     fillAccounts = {
       state,
       signer: relayer.publicKey,
       relayer: relayer.publicKey,
-      recipient: recipient,
+      recipient: relayData.recipient, // This could be different from default recipient.
       mintAccount: mint,
       relayerTA: relayerTA,
       recipientTA: recipientTA,
-      fillStatus: fillStatusPDA,
+      fillStatus,
       tokenProgram: TOKEN_PROGRAM_ID,
       associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
       systemProgram: anchor.web3.SystemProgram.programId,
     };
   }
 
-  const relaySlowFillRootBundle = async () => {
+  const relaySlowFillRootBundle = async (slowRelayLeafRecipient = recipient) => {
     //TODO: verify that the leaf structure created here is equivalent to the one created by the EVM logic. I think
     // I've gotten the concatenation, endianness, etc correct but want to be sure.
     const slowRelayLeafs: SlowFillLeaf[] = [];
     const slowRelayLeaf: SlowFillLeaf = {
       relayData: {
-        depositor: recipient,
-        recipient: recipient,
+        depositor: slowRelayLeafRecipient,
+        recipient: slowRelayLeafRecipient,
         exclusiveRelayer: relayer.publicKey,
         inputToken: mint,
         outputToken: mint,
@@ -90,7 +91,7 @@ describe("svm_spoke.slow_fill", () => {
       chainId,
       updatedOutputAmount: new BN(relayAmount),
     };
-    updateRelayData(slowRelayLeaf.relayData);
+    await updateRelayData(slowRelayLeaf.relayData);
 
     slowRelayLeafs.push(slowRelayLeaf);
 
@@ -122,7 +123,6 @@ describe("svm_spoke.slow_fill", () => {
 
   before("Creates token mint and associated token accounts", async () => {
     mint = await createMint(connection, payer, owner, owner, 6);
-    recipientTA = (await getOrCreateAssociatedTokenAccount(connection, payer, mint, recipient)).address;
     relayerTA = (await getOrCreateAssociatedTokenAccount(connection, payer, mint, relayer.publicKey)).address;
     otherRelayerTA = (await getOrCreateAssociatedTokenAccount(connection, payer, mint, otherRelayer.publicKey)).address;
 
@@ -156,13 +156,13 @@ describe("svm_spoke.slow_fill", () => {
       inputAmount: new BN(relayAmount),
       outputAmount: new BN(relayAmount),
       originChainId: new BN(1),
-      depositId: 1,
+      depositId: new BN(1),
       fillDeadline: new BN(Math.floor(Date.now() / 1000) + 60), // 1 minute from now
       exclusivityDeadline: new BN(Math.floor(Date.now() / 1000) + 30), // 30 seconds from now
       message: Buffer.from("Test message"),
     };
 
-    updateRelayData(initialRelayData);
+    await updateRelayData(initialRelayData);
   });
 
   it("Requests a V3 slow fill, verify the event & state change", async () => {
@@ -379,6 +379,87 @@ describe("svm_spoke.slow_fill", () => {
     } catch (err) {
       assert.instanceOf(err, anchor.AnchorError);
       assert.strictEqual(err.error.errorCode.code, "InvalidFillRecipient", "Expected error code InvalidFillRecipient");
+    }
+  });
+
+  it("Cannot replay execute V3 slow relay leaf against wrong fill status account", async () => {
+    // Request V3 slow fill for the first recipient.
+    const firstRecipient = Keypair.generate().publicKey;
+    const {
+      relayHash: firstRelayHash,
+      leaf: firstLeaf,
+      rootBundleId: firstRootBundleId,
+      proofAsNumbers: firstProofAsNumbers,
+      rootBundle: firstRootBundle,
+    } = await relaySlowFillRootBundle(firstRecipient);
+    await program.methods
+      .requestV3SlowFill(firstRelayHash, firstLeaf.relayData)
+      .accounts(requestAccounts)
+      .signers([relayer])
+      .rpc();
+    const firstRecipientTA = recipientTA; // Global recipientTA will get updated when passing the second relayData.
+    const firstFillStatus = fillStatus; // Global fillStatus will get updated when passing the second relayData.
+
+    // Request V3 slow fill for the second recipient.
+    const secondRecipient = Keypair.generate().publicKey;
+    const {
+      relayHash: secondRelayHash,
+      leaf: secondLeaf,
+      rootBundleId: secondRootBundleId,
+      proofAsNumbers: secondProofAsNumbers,
+      rootBundle: secondRootBundle,
+    } = await relaySlowFillRootBundle(secondRecipient);
+    await program.methods
+      .requestV3SlowFill(secondRelayHash, secondLeaf.relayData)
+      .accounts(requestAccounts)
+      .signers([relayer])
+      .rpc();
+    const secondFillStatus = fillStatus; // Global fillStatus got updated with the second relayData.
+
+    const iFirstRecipientBal = (await connection.getTokenAccountBalance(firstRecipientTA)).value.amount;
+    // Execute V3 slow relay leaf for the first recipient.
+    await program.methods
+      .executeV3SlowRelayLeaf(firstRelayHash, firstLeaf, firstRootBundleId, firstProofAsNumbers)
+      .accounts({
+        state,
+        firstRootBundle,
+        signer: owner,
+        fillStatus: firstFillStatus,
+        vault,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        mint,
+        recipient: firstRecipient,
+        recipientTokenAccount: firstRecipientTA,
+      })
+      .rpc();
+    const fFirstRecipientBal = (await connection.getTokenAccountBalance(firstRecipientTA)).value.amount;
+    assert.strictEqual(
+      BigInt(fFirstRecipientBal) - BigInt(iFirstRecipientBal),
+      BigInt(firstLeaf.updatedOutputAmount.toString()),
+      "First recipient balance should be increased by its relay amount"
+    );
+
+    // Try to replay execute V3 slow relay leaf for the first recipient using the fill status account that is derived
+    // from the second relay hash. This should fail due to mismatching relay hash.
+    try {
+      await program.methods
+        .executeV3SlowRelayLeaf(secondRelayHash, firstLeaf, firstRootBundleId, firstProofAsNumbers)
+        .accounts({
+          state,
+          firstRootBundle,
+          signer: owner,
+          fillStatus: secondFillStatus,
+          vault,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          mint,
+          recipient: firstRecipient,
+          recipientTokenAccount: firstRecipientTA,
+        })
+        .rpc();
+      assert.fail("Execution should have failed due to wrong fill status account");
+    } catch (err) {
+      assert.instanceOf(err, anchor.AnchorError);
+      assert.strictEqual(err.error.errorCode.code, "InvalidRelayHash", "Expected error code InvalidRelayHash");
     }
   });
 });


### PR DESCRIPTION
Adds missing account constraints in `svm-spoke` program. This also makes sure all relevant function parameters are validated to be consistent with context accounts.