### PR TITLE
fix(svm): override chain id in executing slow fill

### DIFF
--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -188,10 +188,16 @@ pub fn execute_v3_slow_relay_leaf(
     root_bundle_id: u32,
     proof: Vec<[u8; 32]>,
 ) -> Result<()> {
-    let relay_data = slow_fill_leaf.relay_data.clone(); // Clone relay_data to avoid move
+    let relay_data = slow_fill_leaf.relay_data;
+
+    let slow_fill = V3SlowFill {
+        relay_data: relay_data.clone(), // Clone relay_data to avoid move
+        chain_id: ctx.accounts.state.chain_id, // This overrides caller provided chain_id, same as in EVM SpokePool.
+        updated_output_amount: slow_fill_leaf.updated_output_amount,
+    };
 
     let root = ctx.accounts.root_bundle.slow_relay_root;
-    let leaf = slow_fill_leaf.to_keccak_hash();
+    let leaf = slow_fill.to_keccak_hash();
     verify_merkle_proof(root, leaf, proof)?;
 
     // Check if the fill status is unfilled


### PR DESCRIPTION
Adds overriding to local `chain_id` in `execute_v3_slow_relay_leaf`. This makes SVM behavior consistent with EVM SpokePool: if someone was trying to replay slow fill targeted at another chain, this should fail the proof verification due to mismatched chain id.