### PR TITLE
feat(svm-routes): add additional param to block non-enabled routes

### DIFF
--- a/programs/svm-spoke/src/instructions/admin.rs
+++ b/programs/svm-spoke/src/instructions/admin.rs
@@ -162,7 +162,7 @@ pub struct SetEnableRoute<'info> {
         init_if_needed,
         payer = payer,
         space = DISCRIMINATOR_SIZE + Route::INIT_SPACE,
-        seeds = [b"route", origin_token.as_ref(), destination_chain_id.to_le_bytes().as_ref()],
+        seeds = [b"route", origin_token.as_ref(), state.key().as_ref(), destination_chain_id.to_le_bytes().as_ref()],
         bump
     )]
     pub route: Account<'info, Route>,

--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -84,10 +84,6 @@ pub fn deposit_v3(
 ) -> Result<()> {
     let state = &mut ctx.accounts.state;
 
-    // TODO: I'm not totally sure how the check here is sufficient. For example can an account make their own fake
-    // spoke pool, create a route PDA, toggle it to enabled and then call deposit, passing in that PDA and
-    // enable a deposit to occur against a route that was not canonically enabled? write some tests for this and
-    // verify that this check is sufficient or update accordingly.
     require!(ctx.accounts.route.enabled, CustomError::RouteNotEnabled);
 
     let transfer_accounts = TransferChecked {

--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -34,7 +34,7 @@ pub struct DepositV3<'info> {
     )]
     pub state: Account<'info, State>,
 
-    #[account(mut, seeds = [b"route", input_token.as_ref(), destination_chain_id.to_le_bytes().as_ref()], bump)]
+    #[account(mut, seeds = [b"route", input_token.as_ref(), state.key().as_ref(), destination_chain_id.to_le_bytes().as_ref()], bump)]
     pub route: Account<'info, Route>,
 
     #[account(mut)]

--- a/test/svm/SvmSpoke.Deposit.ts
+++ b/test/svm/SvmSpoke.Deposit.ts
@@ -246,4 +246,90 @@ describe("svm_spoke.deposit", () => {
       assert.strictEqual(err.error.errorCode.code, "InvalidMint", "Expected error code InvalidMint");
     }
   });
+
+  it("Tests deposit with a fake route PDA", async () => {
+    // Create a fake spoke pool and route PDA
+    const fakeRouteChainId = new BN(3);
+    const fakeRoutePda = createRoutePda(inputToken, fakeRouteChainId);
+
+    // Create fake program state
+    const fakeState = await initializeState();
+    const fakeVault = getVaultAta(inputToken, fakeState);
+
+    // Attempt to enable the fake route
+    const fakeSetEnableRouteAccounts = {
+      signer: owner,
+      payer: owner,
+      state: fakeState,
+      route: fakeRoutePda,
+      vault: fakeVault,
+      originTokenMint: inputToken,
+      tokenProgram: TOKEN_PROGRAM_ID,
+      associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+      systemProgram: anchor.web3.SystemProgram.programId,
+    };
+
+    await program.methods
+      .setEnableRoute(inputToken.toBytes(), fakeRouteChainId, true)
+      .accounts(fakeSetEnableRouteAccounts)
+      .rpc();
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const fakeDepositAccounts = {
+      state: fakeState,
+      route: fakeRoutePda,
+      signer: depositor.publicKey,
+      userTokenAccount: depositorTA,
+      vault: fakeVault,
+      mint: inputToken,
+      tokenProgram: TOKEN_PROGRAM_ID,
+    };
+
+    // Deposit with the fake state and route PDA should succeed.
+    await program.methods
+      .depositV3(
+        ...Object.values({
+          ...depositData,
+          destinationChainId: fakeRouteChainId,
+        })
+      )
+      .accounts(fakeDepositAccounts)
+      .signers([depositor])
+      .rpc();
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // Fetch and verify the depositEvent
+    let events = await readProgramEvents(connection, program);
+    let event = events.find((event) => event.name === "v3FundsDeposited").data;
+    const expectedValues1 = { ...{ ...depositData, destinationChainId: fakeRouteChainId }, depositId: "1" }; // Verify the event props emitted match the depositData.
+    for (const [key, value] of Object.entries(expectedValues1)) {
+      assertSE(event[key], value, `${key} should match`);
+    }
+
+    // Check fake vault acount balance
+    const fakeVaultAccount = await getAccount(connection, fakeVault);
+    assertSE(
+      fakeVaultAccount.amount,
+      depositData.inputAmount.toNumber(),
+      "Fake vault balance should be increased by the deposited amount"
+    );
+
+    // Deposit with the fake route in the original program state should fail.
+    await program.methods
+      .depositV3(
+        ...Object.values({
+          ...{ ...depositData, destinationChainId: fakeRouteChainId },
+        })
+      )
+      .accounts({ ...depositAccounts, route: fakeRoutePda })
+      .signers([depositor])
+      .rpc();
+
+    const vaultAccount = await getAccount(connection, vault);
+    assertSE(vaultAccount.amount, 0, "Vault balance should not be changed by the fake route deposit");
+
+    assert.fail("Deposit should have failed for a fake route PDA");
+  });
 });

--- a/test/svm/SvmSpoke.HandleReceiveMessage.ts
+++ b/test/svm/SvmSpoke.HandleReceiveMessage.ts
@@ -326,7 +326,7 @@ describe("svm_spoke.handle_receive_message", () => {
     });
 
     // Remaining accounts specific to SetEnableRoute.
-    const routePda = createRoutePda(originToken, new anchor.BN(routeChainId));
+    const routePda = createRoutePda(originToken, state, new anchor.BN(routeChainId));
     const vault = getVaultAta(originToken, state);
     // Same 3 remaining accounts passed for HandleReceiveMessage context.
     const enableRouteRemainingAccounts = remainingAccounts.slice(0, 3);

--- a/test/svm/SvmSpoke.Routes.ts
+++ b/test/svm/SvmSpoke.Routes.ts
@@ -22,7 +22,7 @@ describe("svm_spoke.routes", () => {
 
     // Create a PDA for the route
     routeChainId = new BN(1);
-    routePda = createRoutePda(tokenMint, routeChainId);
+    routePda = createRoutePda(tokenMint, state, routeChainId);
 
     // Create ATA for the origin token to be stored by state (vault).
     vault = getVaultAta(tokenMint, state);
@@ -109,7 +109,7 @@ describe("svm_spoke.routes", () => {
 
   it("Cannot misconfigure route with wrong origin token", async () => {
     const wrongOriginToken = Keypair.generate().publicKey;
-    const wrongRoutePda = createRoutePda(wrongOriginToken, routeChainId);
+    const wrongRoutePda = createRoutePda(wrongOriginToken, state, routeChainId);
 
     try {
       await program.methods

--- a/test/svm/SvmSpoke.common.ts
+++ b/test/svm/SvmSpoke.common.ts
@@ -41,9 +41,9 @@ const initializeState = async (seed?: BN) => {
   return state;
 };
 
-const createRoutePda = (originToken: PublicKey, routeChainId: BN) => {
+const createRoutePda = (originToken: PublicKey, state: PublicKey, routeChainId: BN) => {
   return PublicKey.findProgramAddressSync(
-    [Buffer.from("route"), originToken.toBytes(), routeChainId.toArrayLike(Buffer, "le", 8)],
+    [Buffer.from("route"), originToken.toBytes(), state.toBytes(), routeChainId.toArrayLike(Buffer, "le", 8)],
     program.programId
   )[0];
 };


### PR DESCRIPTION
Changes proposed in this PR:
- Fix routes seed to use state key to prevent passing fake enabled routes