### PR TITLE
test: use address lookup table in max refund test

### DIFF
--- a/programs/svm-spoke/src/instructions/bundle.rs
+++ b/programs/svm-spoke/src/instructions/bundle.rs
@@ -92,7 +92,6 @@ impl RelayerRefundLeaf {
 
     pub fn to_keccak_hash(&self) -> [u8; 32] {
         let input = self.to_bytes();
-        msg!("input: {:?}", input);
         keccak::hash(&input).0
     }
 }

--- a/src/SvmUtils.ts
+++ b/src/SvmUtils.ts
@@ -43,6 +43,10 @@ export async function readEvents(
   }
 
   let events = [];
+
+  // TODO: Add support for version 0 transactions.
+  if (txResult.transaction.message.version !== "legacy") return events;
+
   for (const ixBlock of txResult.meta.innerInstructions) {
     for (const ix of ixBlock.instructions) {
       for (const program of programs) {

--- a/test/svm/SvmSpoke.Bundle.ts
+++ b/test/svm/SvmSpoke.Bundle.ts
@@ -1,7 +1,14 @@
 import * as anchor from "@coral-xyz/anchor";
 import * as crypto from "crypto";
 import { BN } from "@coral-xyz/anchor";
-import { Keypair, PublicKey } from "@solana/web3.js";
+import {
+  AddressLookupTableProgram,
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
 import { assert } from "chai";
 import { common } from "./SvmSpoke.common";
 import { MerkleTree } from "@uma/common/dist/MerkleTree";
@@ -612,7 +619,9 @@ describe("svm_spoke.bundle", () => {
   it("Execute Max Refunds", async () => {
     const relayerRefundLeaves: RelayerRefundLeafType[] = [];
 
-    const numberOfRefunds = 5;
+    // Higher refund count panics out of memory when looping the transfers.
+    // TODO: split out claiming individual refunds to resolve this bottleneck.
+    const numberOfRefunds = 19;
 
     const refundAccounts: anchor.web3.PublicKey[] = [];
     const refundAmounts: BN[] = [];
@@ -655,25 +664,80 @@ describe("svm_spoke.bundle", () => {
       .accounts({ state, rootBundle, signer: owner })
       .rpc();
 
-    const remainingAccounts = refundAccounts.map((account) => ({ pubkey: account, isWritable: true, isSigner: false }));
-
     // Verify valid leaf
     const proofAsNumbers = proof.map((p) => Array.from(p));
 
-    await program.methods
+    // We will be using Address Lookup Table (ALT), so to test maximum refunds we better add, not only refund accounts,
+    // but also all static accounts.
+    const staticAccounts = {
+      state: state,
+      rootBundle: rootBundle,
+      signer: owner,
+      vault: vault,
+      tokenProgram: TOKEN_PROGRAM_ID,
+      mint: mint,
+      transferLiability,
+      systemProgram: anchor.web3.SystemProgram.programId,
+      // Appended by Acnhor `event_cpi` macro:
+      eventAuthority: PublicKey.findProgramAddressSync([Buffer.from("__event_authority")], program.programId)[0],
+      program: program.programId,
+    };
+
+    const remainingAccounts = refundAccounts.map((account) => ({ pubkey: account, isWritable: true, isSigner: false }));
+
+    // Consolidate all accounts (static and remaining) into a single array for the ALT.
+    const allAccounts = [...Object.values(staticAccounts), ...refundAccounts];
+
+    // Create instructions for creating and extending the ALT.
+    const [lookupTableInstruction, lookupTableAddress] = await AddressLookupTableProgram.createLookupTable({
+      authority: payer.publicKey,
+      payer: payer.publicKey,
+      recentSlot: await connection.getSlot(),
+    });
+    const extendInstruction = AddressLookupTableProgram.extendLookupTable({
+      lookupTable: lookupTableAddress,
+      authority: payer.publicKey,
+      payer: payer.publicKey,
+      addresses: allAccounts,
+    });
+
+    // Submit the ALT creation and extend transaction
+    await anchor.web3.sendAndConfirmTransaction(
+      connection,
+      new anchor.web3.Transaction().add(lookupTableInstruction).add(extendInstruction),
+      [payer],
+      {
+        skipPreflight: true, // Avoids recent slot mismatch in simulation.
+        commitment: "finalized", // Avoids invalid ALT index as ALT might not be active yet on the following tx.
+      }
+    );
+
+    // Fetch the AddressLookupTableAccount
+    const lookupTableAccount = (await connection.getAddressLookupTable(lookupTableAddress)).value;
+    assert(lookupTableAccount !== null, "AddressLookupTableAccount not fetched");
+
+    // Build the instruction to execute relayer refund leaf
+    const executeInstruction = await program.methods
       .executeRelayerRefundLeaf(stateAccountData.rootBundleId, leaf, proofAsNumbers)
-      .accounts({
-        state: state,
-        rootBundle: rootBundle,
-        signer: owner,
-        vault: vault,
-        tokenProgram: TOKEN_PROGRAM_ID,
-        mint: mint,
-        transferLiability,
-        systemProgram: anchor.web3.SystemProgram.programId,
-      })
+      .accounts(staticAccounts)
       .remainingAccounts(remainingAccounts)
-      .rpc();
+      .instruction();
+
+    // Build the instruction to increase the CU limit as the default 200k is not sufficient.
+    const computeBudgetInstruction = ComputeBudgetProgram.setComputeUnitLimit({ units: 500_000 });
+
+    // Create the versioned transaction
+    const versionedTx = new VersionedTransaction(
+      new TransactionMessage({
+        payerKey: payer.publicKey,
+        recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+        instructions: [computeBudgetInstruction, executeInstruction],
+      }).compileToV0Message([lookupTableAccount])
+    );
+
+    // Sign and submit the versioned transaction.
+    versionedTx.sign([payer]);
+    await connection.sendTransaction(versionedTx);
   });
 
   it("Increments pending amount to HubPool", async () => {


### PR DESCRIPTION
Increases max refund count by using Address Lookup Table (ALT). This is capped at 19 refunds as higher count causes out of memory panic when looping through refund transfers. To overcome this limit we would need to split individual refund claims in separate transaction. And if we split this, then we don't really need to use ALT.

Edit: limit is now increased to 21 by dropping expensive debug msg of input data. Now the bottleneck is calldata size, but that could be resolved by passing it from a buffer account.