### PR TITLE
fix: do not shrink root bundle account

### DIFF
--- a/programs/svm-spoke/src/instructions/bundle.rs
+++ b/programs/svm-spoke/src/instructions/bundle.rs
@@ -23,7 +23,10 @@ pub struct ExecuteRelayerRefundLeaf<'info> {
     #[account(
         mut,
         seeds =[b"root_bundle", state.key().as_ref(), root_bundle_id.to_le_bytes().as_ref()], bump,
-        realloc = DISCRIMINATOR_SIZE + RootBundle::INIT_SPACE + relayer_refund_leaf.leaf_id as usize / 8,
+        realloc = std::cmp::max(
+            DISCRIMINATOR_SIZE + RootBundle::INIT_SPACE + relayer_refund_leaf.leaf_id as usize / 8,
+            root_bundle.to_account_info().data_len()
+        ),
         realloc::payer = signer,
         realloc::zero = false
     )]


### PR DESCRIPTION
Anchor would shrink root_bundle account when executing leaves in reverse order. This fixes the issue by adding current account size as minimum condition in realloc constraint.