### PR TITLE
improve: rename Spoke Pool's hubPool variable to withdrawalRecipient

### DIFF
--- a/contracts/Base_SpokePool.sol
+++ b/contracts/Base_SpokePool.sol
@@ -32,13 +32,14 @@ contract Base_SpokePool is Ovm_SpokePool {
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, Lib_PredeployAddresses.OVM_ETH);
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient, Lib_PredeployAddresses.OVM_ETH);
     }
 }

--- a/contracts/Blast_SpokePool.sol
+++ b/contracts/Blast_SpokePool.sol
@@ -96,15 +96,16 @@ contract Blast_SpokePool is Ovm_SpokePool {
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      * @dev this method also sets yield settings for the Blast SpokePool.
      */
     function initialize(
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, Lib_PredeployAddresses.OVM_ETH);
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient, Lib_PredeployAddresses.OVM_ETH);
 
         // Sets native yield to be claimable manually.
         BLAST_YIELD_CONTRACT.configureClaimableYield();

--- a/contracts/Boba_SpokePool.sol
+++ b/contracts/Boba_SpokePool.sol
@@ -27,13 +27,19 @@ contract Boba_SpokePool is Ovm_SpokePool {
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, 0x4200000000000000000000000000000000000006);
+        __OvmSpokePool_init(
+            _initialDepositId,
+            _crossDomainAdmin,
+            _withdrawalRecipient,
+            0x4200000000000000000000000000000000000006
+        );
     }
 }

--- a/contracts/Ethereum_SpokePool.sol
+++ b/contracts/Ethereum_SpokePool.sol
@@ -23,11 +23,12 @@ contract Ethereum_SpokePool is SpokePool, OwnableUpgradeable {
      * @dev crossDomainAdmin is unused on this contract.
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
-    function initialize(uint32 _initialDepositId, address _hubPool) public initializer {
+    function initialize(uint32 _initialDepositId, address _withdrawalRecipient) public initializer {
         __Ownable_init();
-        __SpokePool_init(_initialDepositId, _hubPool, _hubPool);
+        __SpokePool_init(_initialDepositId, _withdrawalRecipient, _withdrawalRecipient);
     }
 
     /**************************************
@@ -35,7 +36,7 @@ contract Ethereum_SpokePool is SpokePool, OwnableUpgradeable {
      **************************************/
 
     function _bridgeTokensToHubPool(uint256 amountToReturn, address l2TokenAddress) internal override {
-        IERC20Upgradeable(l2TokenAddress).safeTransfer(hubPool, amountToReturn);
+        IERC20Upgradeable(l2TokenAddress).safeTransfer(withdrawalRecipient, amountToReturn);
     }
 
     // The SpokePool deployed to the same network as the HubPool must be owned by the HubPool.

--- a/contracts/Linea_SpokePool.sol
+++ b/contracts/Linea_SpokePool.sol
@@ -61,7 +61,8 @@ contract Linea_SpokePool is SpokePool {
      * @param _l2TokenBridge Address of Canonical Token Bridge. Can be reset by admin.
      * @param _l2UsdcBridge Address of USDC Bridge. Can be reset by admin.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         uint32 _initialDepositId,
@@ -69,9 +70,9 @@ contract Linea_SpokePool is SpokePool {
         ITokenBridge _l2TokenBridge,
         IUSDCBridge _l2UsdcBridge,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool);
+        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient);
         _setL2TokenBridge(_l2TokenBridge);
         _setL2MessageService(_l2MessageService);
         _setL2UsdcBridge(_l2UsdcBridge);
@@ -150,17 +151,17 @@ contract Linea_SpokePool is SpokePool {
             // before the execution of any wrapped token refund leaf. So it must be unwrapped before being sent as a
             // fee to the l2MessageService.
             WETH9Interface(l2TokenAddress).withdraw(amountToReturn + msg.value); // Unwrap into ETH.
-            l2MessageService.sendMessage{ value: amountToReturn + msg.value }(hubPool, msg.value, "");
+            l2MessageService.sendMessage{ value: amountToReturn + msg.value }(withdrawalRecipient, msg.value, "");
         }
         // If the l1Token is USDC, then we need sent it via the USDC Bridge.
         else if (l2TokenAddress == l2UsdcBridge.usdc()) {
             IERC20(l2TokenAddress).safeIncreaseAllowance(address(l2UsdcBridge), amountToReturn);
-            l2UsdcBridge.depositTo{ value: msg.value }(amountToReturn, hubPool);
+            l2UsdcBridge.depositTo{ value: msg.value }(amountToReturn, withdrawalRecipient);
         }
         // For other tokens, we can use the Canonical Token Bridge.
         else {
             IERC20(l2TokenAddress).safeIncreaseAllowance(address(l2TokenBridge), amountToReturn);
-            l2TokenBridge.bridgeToken{ value: msg.value }(l2TokenAddress, amountToReturn, hubPool);
+            l2TokenBridge.bridgeToken{ value: msg.value }(l2TokenAddress, amountToReturn, withdrawalRecipient);
         }
     }
 

--- a/contracts/Lisk_SpokePool.sol
+++ b/contracts/Lisk_SpokePool.sol
@@ -32,13 +32,14 @@ contract Lisk_SpokePool is Ovm_SpokePool {
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, Lib_PredeployAddresses.OVM_ETH);
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient, Lib_PredeployAddresses.OVM_ETH);
     }
 }

--- a/contracts/Mode_SpokePool.sol
+++ b/contracts/Mode_SpokePool.sol
@@ -32,13 +32,14 @@ contract Mode_SpokePool is Ovm_SpokePool {
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, Lib_PredeployAddresses.OVM_ETH);
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient, Lib_PredeployAddresses.OVM_ETH);
     }
 }

--- a/contracts/Optimism_SpokePool.sol
+++ b/contracts/Optimism_SpokePool.sol
@@ -43,21 +43,22 @@ contract Optimism_SpokePool is Ovm_SpokePool {
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, Lib_PredeployAddresses.OVM_ETH);
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient, Lib_PredeployAddresses.OVM_ETH);
     }
 
     function _bridgeTokensToHubPool(uint256 amountToReturn, address l2TokenAddress) internal virtual override {
         // Handle custom SNX bridge which doesn't conform to the standard bridge interface.
         if (l2TokenAddress == SNX)
             SynthetixBridgeToBase(SYNTHETIX_BRIDGE).withdrawTo(
-                hubPool, // _to. Withdraw, over the bridge, to the l1 pool contract.
+                withdrawalRecipient, // _to. Withdraw, over the bridge, to the l1 pool contract.
                 amountToReturn // _amount.
             );
         else super._bridgeTokensToHubPool(amountToReturn, l2TokenAddress);

--- a/contracts/Ovm_SpokePool.sol
+++ b/contracts/Ovm_SpokePool.sol
@@ -80,18 +80,19 @@ contract Ovm_SpokePool is SpokePool, CircleCCTPAdapter {
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      * @param _l2Eth Address of L2 ETH token. Usually should be Lib_PreeployAddresses.OVM_ETH but sometimes this can
      * be different, like with Boba which flips the WETH and OVM_ETH addresses.
      */
     function __OvmSpokePool_init(
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool,
+        address _withdrawalRecipient,
         address _l2Eth
     ) public onlyInitializing {
         l1Gas = 5_000_000;
-        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool);
+        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient);
         //slither-disable-next-line missing-zero-check
         l2Eth = _l2Eth;
     }
@@ -153,7 +154,7 @@ contract Ovm_SpokePool is SpokePool, CircleCCTPAdapter {
             l2TokenAddress = l2Eth; // Set the l2TokenAddress to ETH.
             IL2ERC20Bridge(Lib_PredeployAddresses.L2_STANDARD_BRIDGE).withdrawTo{ value: amountToReturn }(
                 l2TokenAddress, // _l2Token. Address of the L2 token to bridge over.
-                hubPool, // _to. Withdraw, over the bridge, to the l1 pool contract.
+                withdrawalRecipient, // _to. Withdraw, over the bridge, to the l1 pool contract.
                 amountToReturn, // _amount.
                 l1Gas, // _l1Gas. Unused, but included for potential forward compatibility considerations
                 "" // _data. We don't need to send any data for the bridging action.
@@ -161,7 +162,7 @@ contract Ovm_SpokePool is SpokePool, CircleCCTPAdapter {
         }
         // If the token is USDC && CCTP bridge is enabled, then bridge USDC via CCTP.
         else if (_isCCTPEnabled() && l2TokenAddress == address(usdcToken)) {
-            _transferUsdc(hubPool, amountToReturn);
+            _transferUsdc(withdrawalRecipient, amountToReturn);
         }
         // Note we'll default to withdrawTo instead of bridgeERC20To unless the remoteL1Tokens mapping is set for
         // the l2TokenAddress. withdrawTo should be used to bridge back non-native L2 tokens
@@ -185,7 +186,7 @@ contract Ovm_SpokePool is SpokePool, CircleCCTPAdapter {
                     // remoteL1Token on the other chain does not recognize the local token as the correct
                     // pair token, the ERC20 bridge will fail and the tokens will be returned to sender on
                     // this chain.
-                    hubPool, // _to
+                    withdrawalRecipient, // _to
                     amountToReturn, // _amount
                     l1Gas, // _l1Gas
                     "" // _data
@@ -193,7 +194,7 @@ contract Ovm_SpokePool is SpokePool, CircleCCTPAdapter {
             } else {
                 tokenBridge.withdrawTo(
                     l2TokenAddress, // _l2Token. Address of the L2 token to bridge over.
-                    hubPool, // _to. Withdraw, over the bridge, to the l1 pool contract.
+                    withdrawalRecipient, // _to. Withdraw, over the bridge, to the l1 pool contract.
                     amountToReturn, // _amount.
                     l1Gas, // _l1Gas. Unused, but included for potential forward compatibility considerations
                     "" // _data. We don't need to send any data for the bridging action.

--- a/contracts/PolygonZkEVM_SpokePool.sol
+++ b/contracts/PolygonZkEVM_SpokePool.sol
@@ -100,15 +100,16 @@ contract PolygonZkEVM_SpokePool is SpokePool, IBridgeMessageReceiver {
      * @param _l2PolygonZkEVMBridge Address of Polygon zkEVM's canonical bridge contract on L2.
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         IPolygonZkEVMBridge _l2PolygonZkEVMBridge,
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool);
+        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient);
         _setL2PolygonZkEVMBridge(_l2PolygonZkEVMBridge);
     }
 
@@ -177,7 +178,7 @@ contract PolygonZkEVM_SpokePool is SpokePool, IBridgeMessageReceiver {
             WETH9Interface(l2TokenAddress).withdraw(amountToReturn); // Unwrap into ETH.
             l2PolygonZkEVMBridge.bridgeAsset{ value: amountToReturn }(
                 POLYGON_ZKEVM_L1_NETWORK_ID,
-                hubPool,
+                withdrawalRecipient,
                 amountToReturn,
                 address(0),
                 true, // Indicates if the new global exit root is updated or not, which is true for asset bridges
@@ -187,7 +188,7 @@ contract PolygonZkEVM_SpokePool is SpokePool, IBridgeMessageReceiver {
             IERC20(l2TokenAddress).safeIncreaseAllowance(address(l2PolygonZkEVMBridge), amountToReturn);
             l2PolygonZkEVMBridge.bridgeAsset(
                 POLYGON_ZKEVM_L1_NETWORK_ID,
-                hubPool,
+                withdrawalRecipient,
                 amountToReturn,
                 l2TokenAddress,
                 true, // Indicates if the new global exit root is updated or not, which is true for asset bridges

--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -97,18 +97,19 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool, CircleCCTPAdapter 
      * relay hash collisions.
      * @param _polygonTokenBridger Token routing contract that sends tokens from here to HubPool. Changeable by Admin.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      * @param _fxChild FxChild contract, changeable by Admin.
      */
     function initialize(
         uint32 _initialDepositId,
         PolygonTokenBridger _polygonTokenBridger,
         address _crossDomainAdmin,
-        address _hubPool,
+        address _withdrawalRecipient,
         address _fxChild
     ) public initializer {
         callValidated = false;
-        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool);
+        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient);
         _setPolygonTokenBridger(payable(_polygonTokenBridger));
         //slither-disable-next-line missing-zero-check
         _setFxChild(_fxChild);
@@ -239,7 +240,7 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool, CircleCCTPAdapter 
     function _bridgeTokensToHubPool(uint256 amountToReturn, address l2TokenAddress) internal override {
         // If the token is USDC, we need to use the CCTP bridge to transfer it to the hub pool.
         if (_isCCTPEnabled() && l2TokenAddress == address(usdcToken)) {
-            _transferUsdc(hubPool, amountToReturn);
+            _transferUsdc(withdrawalRecipient, amountToReturn);
         } else {
             PolygonIERC20Upgradeable(l2TokenAddress).safeIncreaseAllowance(
                 address(polygonTokenBridger),

--- a/contracts/Redstone_SpokePool.sol
+++ b/contracts/Redstone_SpokePool.sol
@@ -32,13 +32,14 @@ contract Redstone_SpokePool is Ovm_SpokePool {
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, Lib_PredeployAddresses.OVM_ETH);
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient, Lib_PredeployAddresses.OVM_ETH);
     }
 }

--- a/contracts/Scroll_SpokePool.sol
+++ b/contracts/Scroll_SpokePool.sol
@@ -56,16 +56,17 @@ contract Scroll_SpokePool is SpokePool {
      * @param _l2ScrollMessenger Scroll Messenger contract on L2.
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         IL2GatewayRouterExtended _l2GatewayRouter,
         IScrollMessenger _l2ScrollMessenger,
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool);
+        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient);
         _setL2GatewayRouter(_l2GatewayRouter);
         _setL2MessageService(_l2ScrollMessenger);
     }
@@ -107,7 +108,7 @@ contract Scroll_SpokePool is SpokePool {
         // Note: This happens due to the L2GatewayRouter.getERC20Gateway() call
         l2GatewayRouter.withdrawERC20(
             l2TokenAddress,
-            hubPool,
+            withdrawalRecipient,
             amountToReturn,
             // This is the gasLimit for the L2 -> L1 transaction. We don't need to set it.
             // Scroll official docs say it's for compatibility reasons.

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -44,7 +44,7 @@ abstract contract SpokePool is
 
     // Address of the L1 contract that will send tokens to and receive tokens from this contract to fund relayer
     // refunds and slow relays.
-    address public hubPool;
+    address public withdrawalRecipient;
 
     // Note: The following two storage variables prefixed with DEPRECATED used to be variables that could be set by
     // the cross-domain admin. Admins ended up not changing these in production, so to reduce
@@ -145,7 +145,7 @@ abstract contract SpokePool is
      *                EVENTS                *
      ****************************************/
     event SetXDomainAdmin(address indexed newAdmin);
-    event SetHubPool(address indexed newHubPool);
+    event SetWithdrawalRecipient(address indexed newWithdrawalRecipient);
     event EnabledDepositRoute(address indexed originToken, uint256 indexed destinationChainId, bool enabled);
     event RelayedRootBundle(
         uint32 indexed rootBundleId,
@@ -267,19 +267,20 @@ abstract contract SpokePool is
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function __SpokePool_init(
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public onlyInitializing {
         numberOfDeposits = _initialDepositId;
         __EIP712_init("ACROSS-V2", "1.0.0");
         __UUPSUpgradeable_init();
         __ReentrancyGuard_init();
         _setCrossDomainAdmin(_crossDomainAdmin);
-        _setHubPool(_hubPool);
+        _setWithdrawalRecipient(_withdrawalRecipient);
     }
 
     /****************************************
@@ -345,11 +346,11 @@ abstract contract SpokePool is
     }
 
     /**
-     * @notice Change L1 hub pool address. Callable by admin only.
-     * @param newHubPool New hub pool.
+     * @notice Change L1 withdrawal recipient address. Callable by admin only.
+     * @param newWithdrawalRecipient New withdrawal recipient address.
      */
-    function setHubPool(address newHubPool) public override onlyAdmin nonReentrant {
-        _setHubPool(newHubPool);
+    function setWithdrawalRecipient(address newWithdrawalRecipient) public override onlyAdmin nonReentrant {
+        _setWithdrawalRecipient(newWithdrawalRecipient);
     }
 
     /**
@@ -1168,10 +1169,10 @@ abstract contract SpokePool is
         emit SetXDomainAdmin(newCrossDomainAdmin);
     }
 
-    function _setHubPool(address newHubPool) internal {
-        if (newHubPool == address(0)) revert InvalidHubPool();
-        hubPool = newHubPool;
-        emit SetHubPool(newHubPool);
+    function _setWithdrawalRecipient(address newWithdrawalRecipient) internal {
+        if (newWithdrawalRecipient == address(0)) revert InvalidWithdrawalRecipient();
+        withdrawalRecipient = newWithdrawalRecipient;
+        emit SetWithdrawalRecipient(newWithdrawalRecipient);
     }
 
     function _preExecuteLeafHook(address) internal virtual {

--- a/contracts/Succinct_SpokePool.sol
+++ b/contracts/Succinct_SpokePool.sol
@@ -55,16 +55,17 @@ contract Succinct_SpokePool is SpokePool, ITelepathyHandler {
      * @param _succinctTargetAmb Address of the succinct AMB contract.
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         uint16 _hubChainId,
         address _succinctTargetAmb,
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool);
+        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient);
         succinctTargetAmb = _succinctTargetAmb;
         hubChainId = _hubChainId;
     }
@@ -92,7 +93,7 @@ contract Succinct_SpokePool is SpokePool, ITelepathyHandler {
         // Validate msg.sender as succinct, the x-chain sender as being the hubPool (the admin) and the source chain as
         // 1 (mainnet).
         require(msg.sender == succinctTargetAmb, "caller not succinct AMB");
-        require(_senderAddress == hubPool, "sender not hubPool");
+        require(_senderAddress == crossDomainAdmin, "sender not hubPool");
         require(_sourceChainId == hubChainId, "source chain not hub chain");
 
         /// @custom:oz-upgrades-unsafe-allow delegatecall

--- a/contracts/ZkSync_SpokePool.sol
+++ b/contracts/ZkSync_SpokePool.sol
@@ -49,16 +49,17 @@ contract ZkSync_SpokePool is SpokePool {
      * relay hash collisions.
      * @param _zkErc20Bridge Address of L2 ERC20 gateway. Can be reset by admin.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         uint32 _initialDepositId,
         ZkBridgeLike _zkErc20Bridge,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
         l2Eth = 0x000000000000000000000000000000000000800A;
-        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool);
+        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient);
         _setZkBridge(_zkErc20Bridge);
     }
 
@@ -107,9 +108,9 @@ contract ZkSync_SpokePool is SpokePool {
         if (l2TokenAddress == address(wrappedNativeToken)) {
             WETH9Interface(l2TokenAddress).withdraw(amountToReturn); // Unwrap into ETH.
             // To withdraw tokens, we actually call 'withdraw' on the L2 eth token itself.
-            IL2ETH(l2Eth).withdraw{ value: amountToReturn }(hubPool);
+            IL2ETH(l2Eth).withdraw{ value: amountToReturn }(withdrawalRecipient);
         } else {
-            zkErc20Bridge.withdraw(hubPool, l2TokenAddress, amountToReturn);
+            zkErc20Bridge.withdraw(withdrawalRecipient, l2TokenAddress, amountToReturn);
         }
     }
 

--- a/contracts/Zora_SpokePool.sol
+++ b/contracts/Zora_SpokePool.sol
@@ -32,13 +32,14 @@ contract Zora_SpokePool is Ovm_SpokePool {
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, Lib_PredeployAddresses.OVM_ETH);
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient, Lib_PredeployAddresses.OVM_ETH);
     }
 }

--- a/contracts/interfaces/SpokePoolInterface.sol
+++ b/contracts/interfaces/SpokePoolInterface.sol
@@ -36,7 +36,7 @@ interface SpokePoolInterface {
 
     function setCrossDomainAdmin(address newCrossDomainAdmin) external;
 
-    function setHubPool(address newHubPool) external;
+    function setWithdrawalRecipient(address newWithdrawalRecipient) external;
 
     function setEnableRoute(
         address originToken,
@@ -88,7 +88,7 @@ interface SpokePoolInterface {
     error InvalidRelayerFeePct();
     error MaxTransferSizeExceeded();
     error InvalidCrossDomainAdmin();
-    error InvalidHubPool();
+    error InvalidWithdrawalRecipient();
     error DepositsArePaused();
     error FillsArePaused();
 }

--- a/contracts/test/MockSpokePoolV2.sol
+++ b/contracts/test/MockSpokePoolV2.sol
@@ -17,7 +17,7 @@ contract MockSpokePoolV2 is MockSpokePool {
     // Demonstrative of how we could reset state variables in a V2 contract conveniently while initializing new
     // modules. The `reinitializer` modifier is required to create new Initializable contracts.
     function reinitialize(address _hubPool) public reinitializer(2) {
-        _setHubPool(_hubPool);
+        _setWithdrawalRecipient(_hubPool);
     }
 
     // Demonstrative new function we could add in a V2 contract.

--- a/storage-layouts/Arbitrum_SpokePool.json
+++ b/storage-layouts/Arbitrum_SpokePool.json
@@ -68,7 +68,7 @@
     },
     {
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
-      "label": "hubPool",
+      "label": "withdrawalRecipient",
       "offset": 0,
       "slot": "2154"
     },

--- a/storage-layouts/Base_SpokePool.json
+++ b/storage-layouts/Base_SpokePool.json
@@ -68,7 +68,7 @@
     },
     {
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
-      "label": "hubPool",
+      "label": "withdrawalRecipient",
       "offset": 0,
       "slot": "2154"
     },

--- a/storage-layouts/Blast_SpokePool.json
+++ b/storage-layouts/Blast_SpokePool.json
@@ -68,7 +68,7 @@
     },
     {
       "contract": "contracts/Blast_SpokePool.sol:Blast_SpokePool",
-      "label": "hubPool",
+      "label": "withdrawalRecipient",
       "offset": 0,
       "slot": "2154"
     },

--- a/storage-layouts/Ethereum_SpokePool.json
+++ b/storage-layouts/Ethereum_SpokePool.json
@@ -68,7 +68,7 @@
     },
     {
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
-      "label": "hubPool",
+      "label": "withdrawalRecipient",
       "offset": 0,
       "slot": "2154"
     },

--- a/storage-layouts/Linea_SpokePool.json
+++ b/storage-layouts/Linea_SpokePool.json
@@ -68,7 +68,7 @@
     },
     {
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
-      "label": "hubPool",
+      "label": "withdrawalRecipient",
       "offset": 0,
       "slot": "2154"
     },

--- a/storage-layouts/Mode_SpokePool.json
+++ b/storage-layouts/Mode_SpokePool.json
@@ -68,7 +68,7 @@
     },
     {
       "contract": "contracts/Mode_SpokePool.sol:Mode_SpokePool",
-      "label": "hubPool",
+      "label": "withdrawalRecipient",
       "offset": 0,
       "slot": "2154"
     },

--- a/storage-layouts/Optimism_SpokePool.json
+++ b/storage-layouts/Optimism_SpokePool.json
@@ -68,7 +68,7 @@
     },
     {
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
-      "label": "hubPool",
+      "label": "withdrawalRecipient",
       "offset": 0,
       "slot": "2154"
     },

--- a/storage-layouts/Polygon_SpokePool.json
+++ b/storage-layouts/Polygon_SpokePool.json
@@ -68,7 +68,7 @@
     },
     {
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
-      "label": "hubPool",
+      "label": "withdrawalRecipient",
       "offset": 0,
       "slot": "2154"
     },

--- a/storage-layouts/ZkSync_SpokePool.json
+++ b/storage-layouts/ZkSync_SpokePool.json
@@ -68,7 +68,7 @@
     },
     {
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
-      "label": "hubPool",
+      "label": "withdrawalRecipient",
       "offset": 0,
       "slot": "2154"
     },

--- a/test/evm/hardhat/SpokePool.Upgrades.ts
+++ b/test/evm/hardhat/SpokePool.Upgrades.ts
@@ -29,7 +29,7 @@ describe("SpokePool Upgrade Functions", async function () {
 
     // Hub pool should be changed.
     const spokePoolContract = (await ethers.getContractFactory("MockSpokePoolV2")).attach(spokePool.address);
-    expect(await spokePoolContract.hubPool()).to.equal(newHubPool);
+    expect(await spokePoolContract.withdrawalRecipient()).to.equal(newHubPool);
 
     // Can't reinitialize again.
     expect(spokePoolContract.reinitialize(newHubPool)).to.be.revertedWith(

--- a/test/evm/hardhat/chain-specific-spokepools/Arbitrum_SpokePool.ts
+++ b/test/evm/hardhat/chain-specific-spokepools/Arbitrum_SpokePool.ts
@@ -95,9 +95,9 @@ describe("Arbitrum Spoke Pool", function () {
   });
 
   it("Only cross domain owner can set the hub pool address", async function () {
-    await expect(arbitrumSpokePool.setHubPool(rando.address)).to.be.reverted;
-    await arbitrumSpokePool.connect(crossDomainAlias).setHubPool(rando.address);
-    expect(await arbitrumSpokePool.hubPool()).to.equal(rando.address);
+    await expect(arbitrumSpokePool.setWithdrawalRecipient(rando.address)).to.be.reverted;
+    await arbitrumSpokePool.connect(crossDomainAlias).setWithdrawalRecipient(rando.address);
+    expect(await arbitrumSpokePool.withdrawalRecipient()).to.equal(rando.address);
   });
 
   it("Only cross domain owner can initialize a relayer refund", async function () {

--- a/test/evm/hardhat/chain-specific-spokepools/Ethereum_SpokePool.ts
+++ b/test/evm/hardhat/chain-specific-spokepools/Ethereum_SpokePool.ts
@@ -51,9 +51,9 @@ describe("Ethereum Spoke Pool", function () {
   });
 
   it("Only owner can set the hub pool address", async function () {
-    await expect(spokePool.connect(rando).setHubPool(rando.address)).to.be.reverted;
-    await spokePool.connect(owner).setHubPool(rando.address);
-    expect(await spokePool.hubPool()).to.equal(rando.address);
+    await expect(spokePool.connect(rando).setWithdrawalRecipient(rando.address)).to.be.reverted;
+    await spokePool.connect(owner).setWithdrawalRecipient(rando.address);
+    expect(await spokePool.withdrawalRecipient()).to.equal(rando.address);
   });
 
   it("Only owner can initialize a relayer refund", async function () {

--- a/test/evm/hardhat/chain-specific-spokepools/Optimism_SpokePool.ts
+++ b/test/evm/hardhat/chain-specific-spokepools/Optimism_SpokePool.ts
@@ -104,10 +104,10 @@ describe("Optimism Spoke Pool", function () {
   });
 
   it("Only cross domain owner can set the hub pool address", async function () {
-    await expect(optimismSpokePool.setHubPool(rando.address)).to.be.reverted;
+    await expect(optimismSpokePool.setWithdrawalRecipient(rando.address)).to.be.reverted;
     crossDomainMessenger.xDomainMessageSender.returns(owner.address);
-    await optimismSpokePool.connect(crossDomainMessenger.wallet).setHubPool(rando.address);
-    expect(await optimismSpokePool.hubPool()).to.equal(rando.address);
+    await optimismSpokePool.connect(crossDomainMessenger.wallet).setWithdrawalRecipient(rando.address);
+    expect(await optimismSpokePool.withdrawalRecipient()).to.equal(rando.address);
   });
 
   it("Only cross domain owner can initialize a relayer refund", async function () {

--- a/test/evm/hardhat/chain-specific-spokepools/Polygon_SpokePool.ts
+++ b/test/evm/hardhat/chain-specific-spokepools/Polygon_SpokePool.ts
@@ -124,9 +124,9 @@ describe("Polygon Spoke Pool", function () {
 
   it("Only correct caller can set the hub pool address", async function () {
     // Cannot call directly
-    await expect(polygonSpokePool.setHubPool(rando.address)).to.be.reverted;
+    await expect(polygonSpokePool.setWithdrawalRecipient(rando.address)).to.be.reverted;
 
-    const setHubPoolData = polygonSpokePool.interface.encodeFunctionData("setHubPool", [rando.address]);
+    const setHubPoolData = polygonSpokePool.interface.encodeFunctionData("setWithdrawalRecipient", [rando.address]);
 
     // Wrong rootMessageSender address.
     await expect(polygonSpokePool.connect(fxChild).processMessageFromRoot(0, rando.address, setHubPoolData)).to.be
@@ -137,7 +137,7 @@ describe("Polygon Spoke Pool", function () {
       .reverted;
 
     await polygonSpokePool.connect(fxChild).processMessageFromRoot(0, owner.address, setHubPoolData);
-    expect(await polygonSpokePool.hubPool()).to.equal(rando.address);
+    expect(await polygonSpokePool.withdrawalRecipient()).to.equal(rando.address);
   });
 
   it("Only correct caller can enable a route", async function () {


### PR DESCRIPTION
This is meant to generalize the `hubPool` variable in all spoke pools. The `hubPool` variable is only used in `_bridgeTokensToHubPool`, where it is set as the recipient. For spoke pools deployed on L3s, or for spoke pools which may not want to withdraw token to the hub pool (e.g. the `Blast_SpokePool`), the `hubPool` variable is either a misnomer or unused. This changes the variable to be called `withdrawalRecipient` to better reflect the purpose of the `hubPool` variable.