### PR TITLE
feat: add updated implementation of ERC-7683

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -951,6 +951,24 @@ abstract contract SpokePool is
         );
     }
 
+    function fill(
+        bytes32 orderId,
+        bytes calldata originData,
+        bytes calldata fillerData
+    ) external {
+        if (keccak256(originData) != orderId) {
+            revert WrongERC7683OrderId();
+        }
+
+        // Must do a delegatecall because the function requires the inputs to be calldata.
+        (bool success, bytes memory data) = address(this).delegatecall(
+            abi.encodeWithSelector(this.fillV3Relay.selector, abi.encodePacked(originData, fillerData))
+        );
+        if (!success) {
+            revert LowLevelCallFailed(data);
+        }
+    }
+
     /**************************************
      *         DATA WORKER FUNCTIONS      *
      **************************************/

--- a/contracts/erc7683/ERC7683.sol
+++ b/contracts/erc7683/ERC7683.sol
@@ -1,44 +1,38 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-/// @notice Tokens sent by the swapper as inputs to the order
-struct Input {
-    /// @dev The address of the ERC20 token on the origin chain
-    address token;
-    /// @dev The amount of the token to be sent
-    uint256 amount;
-}
-
-/// @notice Tokens that must be received for a valid order fulfillment
-struct Output {
-    /// @dev The address of the ERC20 token on the destination chain
-    /// @dev address(0) used as a sentinel for the native token
-    address token;
-    /// @dev The amount of the token to be sent
-    uint256 amount;
-    /// @dev The address to receive the output tokens
-    address recipient;
-    /// @dev The destination chain for this output
-    uint32 chainId;
-}
-
-/// @title CrossChainOrder type
-/// @notice Standard order struct to be signed by swappers, disseminated to fillers, and submitted to settlement contracts
-struct CrossChainOrder {
+/// @title GaslessCrossChainOrder CrossChainOrder type
+/// @notice Standard order struct to be signed by users, disseminated to fillers, and submitted to origin settler contracts
+struct GaslessCrossChainOrder {
     /// @dev The contract address that the order is meant to be settled by.
     /// Fillers send this order to this contract address on the origin chain
-    address settlementContract;
+    address originSettler;
     /// @dev The address of the user who is initiating the swap,
     /// whose input tokens will be taken and escrowed
-    address swapper;
+    address user;
     /// @dev Nonce to be used as replay protection for the order
     uint256 nonce;
     /// @dev The chainId of the origin chain
-    uint32 originChainId;
-    /// @dev The timestamp by which the order must be initiated
-    uint32 initiateDeadline;
+    uint64 originChainId;
+    /// @dev The timestamp by which the order must be opened
+    uint32 openDeadline;
     /// @dev The timestamp by which the order must be filled on the destination chain
     uint32 fillDeadline;
+    /// @dev Type identifier for the order data. This is an EIP-712 typehash.
+    bytes32 orderDataType;
+    /// @dev Arbitrary implementation-specific data
+    /// Can be used to define tokens, amounts, destination chains, fees, settlement parameters,
+    /// or any other order-type specific information
+    bytes orderData;
+}
+
+/// @title OnchainCrossChainOrder CrossChainOrder type
+/// @notice Standard order struct for user-opened orders, where the user is the msg.sender.
+struct OnchainCrossChainOrder {
+    /// @dev The timestamp by which the order must be filled on the destination chain
+    uint32 fillDeadline;
+    /// @dev Type identifier for the order data. This is an EIP-712 typehash.
+    bytes32 orderDataType;
     /// @dev Arbitrary implementation-specific data
     /// Can be used to define tokens, amounts, destination chains, fees, settlement parameters,
     /// or any other order-type specific information
@@ -46,51 +40,108 @@ struct CrossChainOrder {
 }
 
 /// @title ResolvedCrossChainOrder type
-/// @notice An implementation-generic representation of an order
+/// @notice An implementation-generic representation of an order intended for filler consumption
 /// @dev Defines all requirements for filling an order by unbundling the implementation-specific orderData.
 /// @dev Intended to improve integration generalization by allowing fillers to compute the exact input and output information of any order
 struct ResolvedCrossChainOrder {
-    /// @dev The contract address that the order is meant to be settled by.
-    address settlementContract;
-    /// @dev The address of the user who is initiating the swap
-    address swapper;
-    /// @dev Nonce to be used as replay protection for the order
-    uint256 nonce;
+    /// @dev The address of the user who is initiating the transfer
+    address user;
     /// @dev The chainId of the origin chain
-    uint32 originChainId;
-    /// @dev The timestamp by which the order must be initiated
-    uint32 initiateDeadline;
+    uint64 originChainId;
+    /// @dev The timestamp by which the order must be opened
+    uint32 openDeadline;
     /// @dev The timestamp by which the order must be filled on the destination chain(s)
     uint32 fillDeadline;
-    /// @dev The inputs to be taken from the swapper as part of order initiation
-    Input[] swapperInputs;
-    /// @dev The outputs to be given to the swapper as part of order fulfillment
-    Output[] swapperOutputs;
-    /// @dev The outputs to be given to the filler as part of order settlement
-    Output[] fillerOutputs;
+    /// @dev The max outputs that the filler will send. It's possible the actual amount depends on the state of the destination
+    ///      chain (destination dutch auction, for instance), so these outputs should be considered a cap on filler liabilities.
+    Output[] maxSpent;
+    /// @dev The minimum outputs that must to be given to the filler as part of order settlement. Similar to maxSpent, it's possible
+    ///      that special order types may not be able to guarantee the exact amount at open time, so this should be considered
+    ///      a floor on filler receipts.
+    Output[] minReceived;
+    /// @dev Each instruction in this array is parameterizes a single leg of the fill. This provides the filler with the information
+    ///      necessary to perform the fill on the destination(s).
+    FillInstruction[] fillInstructions;
 }
 
-/// @title ISettlementContract
-/// @notice Standard interface for settlement contracts
-interface ISettlementContract {
-    /// @notice Initiates the settlement of a cross-chain order
-    /// @dev To be called by the filler
-    /// @param order The CrossChainOrder definition
-    /// @param signature The swapper's signature over the order
-    /// @param fillerData Any filler-defined data required by the settler
-    function initiate(
-        CrossChainOrder memory order,
-        bytes memory signature,
-        bytes memory fillerData
+/// @notice Tokens that must be receive for a valid order fulfillment
+struct Output {
+    /// @dev The address of the ERC20 token on the destination chain
+    /// @dev address(0) used as a sentinel for the native token
+    bytes32 token;
+    /// @dev The amount of the token to be sent
+    uint256 amount;
+    /// @dev The address to receive the output tokens
+    bytes32 recipient;
+    /// @dev The destination chain for this output
+    uint64 chainId;
+}
+
+/// @title FillInstruction type
+/// @notice Instructions to parameterize each leg of the fill
+/// @dev Provides all the origin-generated information required to produce a valid fill leg
+struct FillInstruction {
+    /// @dev The contract address that the order is meant to be settled by
+    uint64 destinationChainId;
+    /// @dev The contract address that the order is meant to be filled on
+    bytes32 destinationSettler;
+    /// @dev The data generated on the origin chain needed by the destinationSettler to process the fill
+    bytes originData;
+}
+
+/// @title IOriginSettler
+/// @notice Standard interface for settlement contracts on the origin chain
+interface IOriginSettler {
+    /// @notice Signals that an order has been opened
+    /// @param orderId a unique order identifier within this settlement system
+    /// @param resolvedOrder resolved order that would be returned by resolve if called instead of Open
+    event Open(bytes32 indexed orderId, ResolvedCrossChainOrder resolvedOrder);
+
+    /// @notice Opens a gasless cross-chain order on behalf of a user.
+    /// @dev To be called by the filler.
+    /// @dev This method must emit the Open event
+    /// @param order The GaslessCrossChainOrder definition
+    /// @param signature The user's signature over the order
+    /// @param originFillerData Any filler-defined data required by the settler
+    function openFor(
+        GaslessCrossChainOrder calldata order,
+        bytes calldata signature,
+        bytes calldata originFillerData
     ) external;
 
-    /// @notice Resolves a specific CrossChainOrder into a generic ResolvedCrossChainOrder
+    /// @notice Opens a cross-chain order
+    /// @dev To be called by the user
+    /// @dev This method must emit the Open event
+    /// @param order The OnchainCrossChainOrder definition
+    function open(OnchainCrossChainOrder calldata order) external;
+
+    /// @notice Resolves a specific GaslessCrossChainOrder into a generic ResolvedCrossChainOrder
     /// @dev Intended to improve standardized integration of various order types and settlement contracts
-    /// @param order The CrossChainOrder definition
-    /// @param fillerData Any filler-defined data required by the settler
+    /// @param order The GaslessCrossChainOrder definition
+    /// @param originFillerData Any filler-defined data required by the settler
     /// @return ResolvedCrossChainOrder hydrated order data including the inputs and outputs of the order
-    function resolve(CrossChainOrder memory order, bytes memory fillerData)
+    function resolveFor(GaslessCrossChainOrder calldata order, bytes calldata originFillerData)
         external
         view
         returns (ResolvedCrossChainOrder memory);
+
+    /// @notice Resolves a specific OnchainCrossChainOrder into a generic ResolvedCrossChainOrder
+    /// @dev Intended to improve standardized integration of various order types and settlement contracts
+    /// @param order The OnchainCrossChainOrder definition
+    /// @return ResolvedCrossChainOrder hydrated order data including the inputs and outputs of the order
+    function resolve(OnchainCrossChainOrder calldata order) external view returns (ResolvedCrossChainOrder memory);
+}
+
+/// @title IDestinationSettler
+/// @notice Standard interface for settlement contracts on the destination chain
+interface IDestinationSettler {
+    /// @notice Fills a single leg of a particular order on the destination chain
+    /// @param orderId Unique order identifier for this order
+    /// @param originData Data emitted on the origin to parameterize the fill
+    /// @param fillerData Data provided by the filler to inform the fill or express their preferences
+    function fill(
+        bytes32 orderId,
+        bytes calldata originData,
+        bytes calldata fillerData
+    ) external;
 }

--- a/contracts/erc7683/ERC7683Across.sol
+++ b/contracts/erc7683/ERC7683Across.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "../external/interfaces/IPermit2.sol";
-import { CrossChainOrder } from "./ERC7683.sol";
+import { GaslessCrossChainOrder } from "./ERC7683.sol";
 
 // Data unique to every CrossChainOrder settled on Across
 struct AcrossOrderData {
@@ -12,13 +12,33 @@ struct AcrossOrderData {
     uint256 outputAmount;
     uint32 destinationChainId;
     address recipient;
-    uint32 exclusivityDeadlineOffset;
+    address exclusiveRelayer;
+    uint32 exclusivityPeriod;
     bytes message;
 }
 
-struct AcrossFillerData {
+struct AcrossOriginFillerData {
     address exclusiveRelayer;
 }
+
+struct AcrossDestinationFillerData {
+    uint256 repaymentChainId;
+}
+
+bytes constant ACROSS_ORDER_DATA_TYPE = abi.encodePacked(
+    "AcrossOrderData(",
+    "address inputToken,",
+    "uint256 inputAmount,",
+    "address outputToken,",
+    "uint256 outputAmount,",
+    "uint32 destinationChainId,",
+    "address recipient,",
+    "address exclusiveRelayer,"
+    "uint32 exclusivityPeriod,",
+    "bytes message)"
+);
+
+bytes32 constant ACROSS_ORDER_DATA_TYPE_HASH = keccak256(ACROSS_ORDER_DATA_TYPE);
 
 /**
  * @notice ERC7683Permit2Lib knows how to process a particular type of external Permit2Order so that it can be used in Across.
@@ -26,30 +46,16 @@ struct AcrossFillerData {
  * @custom:security-contact bugs@across.to
  */
 library ERC7683Permit2Lib {
-    bytes private constant ACROSS_ORDER_DATA_TYPE =
-        abi.encodePacked(
-            "AcrossOrderData(",
-            "address inputToken,",
-            "uint256 inputAmount,",
-            "address outputToken,",
-            "uint256 outputAmount,",
-            "uint32 destinationChainId,",
-            "address recipient,",
-            "uint32 exclusivityDeadlineOffset,",
-            "bytes message)"
-        );
-
-    bytes32 private constant ACROSS_ORDER_DATA_TYPE_HASH = keccak256(ACROSS_ORDER_DATA_TYPE);
-
     bytes internal constant CROSS_CHAIN_ORDER_TYPE =
         abi.encodePacked(
-            "CrossChainOrder(",
-            "address settlementContract,",
-            "address swapper,",
+            "GaslessCrossChainOrder(",
+            "address originSettler,",
+            "address user,",
             "uint256 nonce,",
             "uint32 originChainId,",
-            "uint32 initiateDeadline,",
+            "uint32 openDeadline,",
             "uint32 fillDeadline,",
+            "bytes32 orderDataType,",
             "AcrossOrderData orderData)"
         );
 
@@ -69,16 +75,16 @@ library ERC7683Permit2Lib {
         );
 
     // Hashes an order to get an order hash. Needed for permit2.
-    function hashOrder(CrossChainOrder memory order, bytes32 orderDataHash) internal pure returns (bytes32) {
+    function hashOrder(GaslessCrossChainOrder memory order, bytes32 orderDataHash) internal pure returns (bytes32) {
         return
             keccak256(
                 abi.encode(
                     CROSS_CHAIN_ORDER_TYPE_HASH,
-                    order.settlementContract,
-                    order.swapper,
+                    order.originSettler,
+                    order.user,
                     order.nonce,
                     order.originChainId,
-                    order.initiateDeadline,
+                    order.openDeadline,
                     order.fillDeadline,
                     orderDataHash
                 )
@@ -96,7 +102,7 @@ library ERC7683Permit2Lib {
                     orderData.outputAmount,
                     orderData.destinationChainId,
                     orderData.recipient,
-                    orderData.exclusivityDeadlineOffset,
+                    orderData.exclusivityPeriod,
                     keccak256(orderData.message)
                 )
             );

--- a/contracts/erc7683/ERC7683OrderDepositor.sol
+++ b/contracts/erc7683/ERC7683OrderDepositor.sol
@@ -4,9 +4,10 @@ pragma solidity ^0.8.0;
 import "../external/interfaces/IPermit2.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import { Input, Output, CrossChainOrder, ResolvedCrossChainOrder, ISettlementContract } from "./ERC7683.sol";
-import { AcrossOrderData, AcrossFillerData, ERC7683Permit2Lib } from "./ERC7683Across.sol";
+import { Output, GaslessCrossChainOrder, OnchainCrossChainOrder, ResolvedCrossChainOrder, IOriginSettler, FillInstruction } from "./ERC7683.sol";
+import { AcrossOrderData, AcrossOriginFillerData, ERC7683Permit2Lib, ACROSS_ORDER_DATA_TYPE_HASH } from "./ERC7683Across.sol";
 
 /**
  * @notice ERC7683OrderDepositor processes an external order type and translates it into an AcrossV3 deposit.
@@ -14,9 +15,13 @@ import { AcrossOrderData, AcrossFillerData, ERC7683Permit2Lib } from "./ERC7683A
  * as well as one that sends the deposit to another contract.
  * @custom:security-contact bugs@across.to
  */
-abstract contract ERC7683OrderDepositor is ISettlementContract {
+abstract contract ERC7683OrderDepositor is IOriginSettler {
+    using SafeERC20 for IERC20;
+
     error WrongSettlementContract();
     error WrongChainId();
+    error WrongOrderDataType();
+    error WrongExclusiveRelayer();
 
     // Permit2 contract for this network.
     IPermit2 public immutable PERMIT2;
@@ -36,107 +41,98 @@ abstract contract ERC7683OrderDepositor is ISettlementContract {
     }
 
     /**
-     * @notice Initiate the order.
+     * @notice Open the order on behalf of the user.
      * @dev This will pull in the user's funds and make the order available to be filled.
      * @param order the ERC7683 compliant order.
      * @param signature signature for the EIP-712 compliant order type.
      * @param fillerData Across-specific fillerData.
      */
-    function initiate(
-        CrossChainOrder memory order,
-        bytes memory signature,
-        bytes memory fillerData
+    function openFor(
+        GaslessCrossChainOrder calldata order,
+        bytes calldata signature,
+        bytes calldata fillerData
     ) external {
-        // Ensure that order was intended to be settled by Across.
-        if (order.settlementContract != address(this)) {
-            revert WrongSettlementContract();
-        }
-
-        if (order.originChainId != block.chainid) {
-            revert WrongChainId();
-        }
-
-        // Extract Across-specific params.
-        (AcrossOrderData memory acrossOrderData, AcrossFillerData memory acrossFillerData) = decode(
-            order.orderData,
-            fillerData
-        );
+        (
+            ResolvedCrossChainOrder memory resolvedOrder,
+            AcrossOrderData memory acrossOrderData,
+            AcrossOriginFillerData memory acrossOriginFillerData
+        ) = _resolveFor(order, fillerData);
 
         // Verify Permit2 signature and pull user funds into this contract
         _processPermit2Order(order, acrossOrderData, signature);
 
         _callDeposit(
-            order.swapper,
+            order.user,
             acrossOrderData.recipient,
             acrossOrderData.inputToken,
             acrossOrderData.outputToken,
             acrossOrderData.inputAmount,
             acrossOrderData.outputAmount,
             acrossOrderData.destinationChainId,
-            acrossFillerData.exclusiveRelayer,
+            acrossOriginFillerData.exclusiveRelayer,
             // Note: simplifying assumption to avoid quote timestamps that cause orders to expire before the deadline.
-            SafeCast.toUint32(order.initiateDeadline - QUOTE_BEFORE_DEADLINE),
+            SafeCast.toUint32(order.openDeadline - QUOTE_BEFORE_DEADLINE),
             order.fillDeadline,
-            getCurrentTime() + acrossOrderData.exclusivityDeadlineOffset,
+            acrossOrderData.exclusivityPeriod,
             acrossOrderData.message
         );
+
+        emit Open(keccak256(resolvedOrder.fillInstructions[0].originData), resolvedOrder);
     }
 
     /**
-     * @notice Constructs a ResolvedOrder from a CrossChainOrder and fillerData.
+     * @notice Opens the order.
+     * @dev Unlike openFor, this method is callable by the user.
+     * @dev This will pull in the user's funds and make the order available to be filled.
      * @param order the ERC7683 compliant order.
-     * @param fillerData Across-specific fillerData.
      */
-    function resolve(CrossChainOrder memory order, bytes memory fillerData)
-        external
+    function open(OnchainCrossChainOrder calldata order) external {
+        (ResolvedCrossChainOrder memory resolvedOrder, AcrossOrderData memory acrossOrderData) = _resolve(order);
+
+        IERC20(acrossOrderData.inputToken).safeTransferFrom(msg.sender, address(this), acrossOrderData.inputAmount);
+
+        _callDeposit(
+            msg.sender,
+            acrossOrderData.recipient,
+            acrossOrderData.inputToken,
+            acrossOrderData.outputToken,
+            acrossOrderData.inputAmount,
+            acrossOrderData.outputAmount,
+            acrossOrderData.destinationChainId,
+            acrossOrderData.exclusiveRelayer,
+            // Note: simplifying assumption to avoid the order type having to bake in the quote timestamp.
+            SafeCast.toUint32(block.timestamp),
+            order.fillDeadline,
+            acrossOrderData.exclusivityPeriod,
+            acrossOrderData.message
+        );
+
+        emit Open(keccak256(resolvedOrder.fillInstructions[0].originData), resolvedOrder);
+    }
+
+    /**
+     * @notice Constructs a ResolvedOrder from a GaslessCrossChainOrder and originFillerData.
+     * @param order the ERC-7683 compliant order.
+     * @param originFillerData Across-specific fillerData.
+     */
+    function resolveFor(GaslessCrossChainOrder calldata order, bytes calldata originFillerData)
+        public
         view
         returns (ResolvedCrossChainOrder memory resolvedOrder)
     {
-        if (order.settlementContract != address(this)) {
-            revert WrongSettlementContract();
-        }
+        (resolvedOrder, , ) = _resolveFor(order, originFillerData);
+    }
 
-        if (order.originChainId != block.chainid) {
-            revert WrongChainId();
-        }
-
-        (AcrossOrderData memory acrossOrderData, AcrossFillerData memory acrossFillerData) = decode(
-            order.orderData,
-            fillerData
-        );
-        Input[] memory inputs = new Input[](1);
-        inputs[0] = Input({ token: acrossOrderData.inputToken, amount: acrossOrderData.inputAmount });
-        Output[] memory outputs = new Output[](1);
-        outputs[0] = Output({
-            token: acrossOrderData.outputToken,
-            amount: acrossOrderData.outputAmount,
-            recipient: acrossOrderData.recipient,
-            chainId: acrossOrderData.destinationChainId
-        });
-
-        // We assume that filler takes repayment on the origin chain in which case the filler output
-        // will always be equal to the input amount. If the filler requests repayment somewhere else then
-        // the filler output will be equal to the input amount less a fee based on the chain they request
-        // repayment on.
-        Output[] memory fillerOutputs = new Output[](1);
-        fillerOutputs[0] = Output({
-            token: acrossOrderData.inputToken,
-            amount: acrossOrderData.inputAmount,
-            recipient: acrossFillerData.exclusiveRelayer,
-            chainId: SafeCast.toUint32(block.chainid)
-        });
-
-        resolvedOrder = ResolvedCrossChainOrder({
-            settlementContract: address(this),
-            swapper: order.swapper,
-            nonce: order.nonce,
-            originChainId: order.originChainId,
-            initiateDeadline: order.initiateDeadline,
-            fillDeadline: order.fillDeadline,
-            swapperInputs: inputs,
-            swapperOutputs: outputs,
-            fillerOutputs: fillerOutputs
-        });
+    /**
+     * @notice Constructs a ResolvedOrder from a CrossChainOrder.
+     * @param order the ERC7683 compliant order.
+     */
+    function resolve(OnchainCrossChainOrder calldata order)
+        public
+        view
+        returns (ResolvedCrossChainOrder memory resolvedOrder)
+    {
+        (resolvedOrder, ) = _resolve(order);
     }
 
     /**
@@ -144,14 +140,14 @@ abstract contract ERC7683OrderDepositor is ISettlementContract {
      * @param orderData the orderData field of the ERC7683 compliant order.
      * @param fillerData Across-specific fillerData.
      * @return acrossOrderData decoded AcrossOrderData.
-     * @return acrossFillerData decoded AcrossFillerData.
+     * @return acrossOriginFillerData decoded AcrossOriginFillerData.
      */
     function decode(bytes memory orderData, bytes memory fillerData)
         public
         pure
-        returns (AcrossOrderData memory, AcrossFillerData memory)
+        returns (AcrossOrderData memory, AcrossOriginFillerData memory)
     {
-        return (abi.decode(orderData, (AcrossOrderData)), abi.decode(fillerData, (AcrossFillerData)));
+        return (abi.decode(orderData, (AcrossOrderData)), abi.decode(fillerData, (AcrossOriginFillerData)));
     }
 
     /**
@@ -162,8 +158,154 @@ abstract contract ERC7683OrderDepositor is ISettlementContract {
         return SafeCast.toUint32(block.timestamp); // solhint-disable-line not-rely-on-time
     }
 
+    function _resolveFor(GaslessCrossChainOrder calldata order, bytes calldata fillerData)
+        internal
+        view
+        returns (
+            ResolvedCrossChainOrder memory resolvedOrder,
+            AcrossOrderData memory acrossOrderData,
+            AcrossOriginFillerData memory acrossOriginFillerData
+        )
+    {
+        // Ensure that order was intended to be settled by Across.
+        if (order.originSettler != address(this)) {
+            revert WrongSettlementContract();
+        }
+
+        if (order.originChainId != block.chainid) {
+            revert WrongChainId();
+        }
+
+        if (order.orderDataType != ACROSS_ORDER_DATA_TYPE_HASH) {
+            revert WrongOrderDataType();
+        }
+
+        // Extract Across-specific params.
+        (acrossOrderData, acrossOriginFillerData) = decode(order.orderData, fillerData);
+
+        if (
+            acrossOrderData.exclusiveRelayer != address(0) &&
+            acrossOrderData.exclusiveRelayer != acrossOriginFillerData.exclusiveRelayer
+        ) {
+            revert WrongExclusiveRelayer();
+        }
+
+        Output[] memory maxSpent = new Output[](1);
+        maxSpent[0] = Output({
+            token: _toBytes32(acrossOrderData.outputToken),
+            amount: acrossOrderData.outputAmount,
+            recipient: _toBytes32(acrossOrderData.recipient),
+            chainId: acrossOrderData.destinationChainId
+        });
+
+        // We assume that filler takes repayment on the origin chain in which case the filler output
+        // will always be equal to the input amount. If the filler requests repayment somewhere else then
+        // the filler output will be equal to the input amount less a fee based on the chain they request
+        // repayment on.
+        Output[] memory minReceived = new Output[](1);
+        minReceived[0] = Output({
+            token: _toBytes32(acrossOrderData.inputToken),
+            amount: acrossOrderData.inputAmount,
+            recipient: _toBytes32(acrossOriginFillerData.exclusiveRelayer),
+            chainId: SafeCast.toUint32(block.chainid)
+        });
+
+        FillInstruction[] memory fillInstructions = new FillInstruction[](1);
+        fillInstructions[0] = FillInstruction({
+            destinationChainId: acrossOrderData.destinationChainId,
+            destinationSettler: _toBytes32(_destinationSettler(acrossOrderData.destinationChainId)),
+            originData: abi.encode(
+                order.user,
+                acrossOrderData.recipient,
+                acrossOriginFillerData.exclusiveRelayer,
+                acrossOrderData.inputToken,
+                acrossOrderData.outputToken,
+                acrossOrderData.inputAmount,
+                acrossOrderData.outputAmount,
+                block.chainid,
+                _currentDepositId(),
+                order.fillDeadline,
+                acrossOrderData.exclusivityPeriod,
+                acrossOrderData.message
+            )
+        });
+
+        resolvedOrder = ResolvedCrossChainOrder({
+            user: order.user,
+            originChainId: order.originChainId,
+            openDeadline: order.openDeadline,
+            fillDeadline: order.fillDeadline,
+            minReceived: minReceived,
+            maxSpent: maxSpent,
+            fillInstructions: fillInstructions
+        });
+    }
+
+    function _resolve(OnchainCrossChainOrder calldata order)
+        internal
+        view
+        returns (ResolvedCrossChainOrder memory resolvedOrder, AcrossOrderData memory acrossOrderData)
+    {
+        if (order.orderDataType != ACROSS_ORDER_DATA_TYPE_HASH) {
+            revert WrongOrderDataType();
+        }
+
+        // Extract Across-specific params.
+        acrossOrderData = abi.decode(order.orderData, (AcrossOrderData));
+
+        Output[] memory maxSpent = new Output[](1);
+        maxSpent[0] = Output({
+            token: _toBytes32(acrossOrderData.outputToken),
+            amount: acrossOrderData.outputAmount,
+            recipient: _toBytes32(acrossOrderData.recipient),
+            chainId: acrossOrderData.destinationChainId
+        });
+
+        // We assume that filler takes repayment on the origin chain in which case the filler output
+        // will always be equal to the input amount. If the filler requests repayment somewhere else then
+        // the filler output will be equal to the input amount less a fee based on the chain they request
+        // repayment on.
+        Output[] memory minReceived = new Output[](1);
+        minReceived[0] = Output({
+            token: _toBytes32(acrossOrderData.inputToken),
+            amount: acrossOrderData.inputAmount,
+            recipient: _toBytes32(acrossOrderData.exclusiveRelayer),
+            chainId: SafeCast.toUint32(block.chainid)
+        });
+
+        FillInstruction[] memory fillInstructions = new FillInstruction[](1);
+        fillInstructions[0] = FillInstruction({
+            destinationChainId: acrossOrderData.destinationChainId,
+            destinationSettler: _toBytes32(_destinationSettler(acrossOrderData.destinationChainId)),
+            originData: abi.encode(
+                msg.sender,
+                acrossOrderData.recipient,
+                acrossOrderData.exclusiveRelayer,
+                acrossOrderData.inputToken,
+                acrossOrderData.outputToken,
+                acrossOrderData.inputAmount,
+                acrossOrderData.outputAmount,
+                block.chainid,
+                _currentDepositId(),
+                order.fillDeadline,
+                acrossOrderData.exclusivityPeriod,
+                acrossOrderData.message
+            )
+        });
+
+        resolvedOrder = ResolvedCrossChainOrder({
+            user: msg.sender,
+            originChainId: SafeCast.toUint64(block.chainid),
+            openDeadline: type(uint32).max, // no deadline since the user is sending it
+            fillDeadline: order.fillDeadline,
+            minReceived: minReceived,
+            maxSpent: maxSpent,
+            fillInstructions: fillInstructions
+        });
+    }
+
     function _processPermit2Order(
-        CrossChainOrder memory order,
+        GaslessCrossChainOrder memory order,
         AcrossOrderData memory acrossOrderData,
         bytes memory signature
     ) internal {
@@ -173,7 +315,7 @@ abstract contract ERC7683OrderDepositor is ISettlementContract {
                 amount: acrossOrderData.inputAmount
             }),
             nonce: order.nonce,
-            deadline: order.initiateDeadline
+            deadline: order.openDeadline
         });
 
         IPermit2.SignatureTransferDetails memory signatureTransferDetails = IPermit2.SignatureTransferDetails({
@@ -185,11 +327,15 @@ abstract contract ERC7683OrderDepositor is ISettlementContract {
         PERMIT2.permitWitnessTransferFrom(
             permit,
             signatureTransferDetails,
-            order.swapper,
+            order.user,
             ERC7683Permit2Lib.hashOrder(order, ERC7683Permit2Lib.hashOrderData(acrossOrderData)), // witness data hash
             ERC7683Permit2Lib.PERMIT2_ORDER_TYPE, // witness data type string
             signature
         );
+    }
+
+    function _toBytes32(address input) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(input)));
     }
 
     function _callDeposit(
@@ -206,4 +352,8 @@ abstract contract ERC7683OrderDepositor is ISettlementContract {
         uint32 exclusivityDeadline,
         bytes memory message
     ) internal virtual;
+
+    function _currentDepositId() internal view virtual returns (uint32);
+
+    function _destinationSettler(uint256 chainId) internal view virtual returns (address);
 }

--- a/contracts/interfaces/V3SpokePoolInterface.sol
+++ b/contracts/interfaces/V3SpokePoolInterface.sol
@@ -235,4 +235,6 @@ interface V3SpokePoolInterface {
     error InvalidMerkleLeaf();
     error ClaimedMerkleLeaf();
     error InvalidPayoutAdjustmentPct();
+    error WrongERC7683OrderId();
+    error LowLevelCallFailed(bytes data);
 }


### PR DESCRIPTION
This PR implements the updated version of ERC-7683 as described [here](https://github.com/across-protocol/ERCs/pull/1). This change ended up being more involved than expected.

There are only a few open questions remaining:
1. Should this handle pre-fills? Right now, it assumes the incrementing deposit id. Would require #583 to be merged first to support them.
2. Quote timestamp is assumed to be the deposit timestamp for Onchain deposits. I think this is probably a reasonable initial assumption to keep the AcrossOrderData struct consistent between the onchain and gasless versions, but we could add a param for it if necessary.
3. The external depositor contract (which we rely on since we don't have room to merge the bulk of this into the spoke) now needs a lookup table of destination settler contracts (spoke pools until we allow relayer refunds to be redirected). I designated this as a simple ownable contract to avoid having to bake in chain-specific authentication logic, but I don't think we will have a good way to administer this (since we don't want to use chain-specific multisigs). This is becoming a common issue -- I wonder if it would make sense to have a lib deployed to every chain or a per-chain admin passthrough contract to help manage all the downstream contracts on that chain. Simplest solution I could think of for now to avoid a lot of code bloat was to just make it ownable (meaning we could configure at construction and discard ownership or administer with a chain-specific multisig).