### PR TITLE
fix: Support OP bridged USDC in WorldChain adapter

### DIFF
--- a/contracts/chain-adapters/WorldChain_Adapter.sol
+++ b/contracts/chain-adapters/WorldChain_Adapter.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
-import "./interfaces/AdapterInterface.sol";
-import "../external/interfaces/WETH9Interface.sol";
-
-// @dev Use local modified CrossDomainEnabled contract instead of one exported by eth-optimism because we need
-// this contract's state variables to be `immutable` because of the delegateCall call.
-import "./CrossDomainEnabled.sol";
 import "@eth-optimism/contracts/L1/messaging/IL1StandardBridge.sol";
-
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import "../libraries/CircleCCTPAdapter.sol";
-import "../external/interfaces/CCTPInterfaces.sol";
+import { CircleCCTPAdapter, CircleDomainIds } from "../libraries/CircleCCTPAdapter.sol";
+import { ITokenMessenger } from "../external/interfaces/CCTPInterfaces.sol";
+import { IOpUSDCBridgeAdapter } from "../external/interfaces/IOpUSDCBridgeAdapter.sol";
+import { WETH9Interface } from "../external/interfaces/WETH9Interface.sol";
+import { AdapterInterface } from "./interfaces/AdapterInterface.sol";
+
+// @dev Use local modified CrossDomainEnabled contract instead of one exported by eth-optimism because we need
+// this contract's state variables to be `immutable` because of the delegateCall call.
+import { CrossDomainEnabled } from "./CrossDomainEnabled.sol";
 
 /**
  * @notice Contract containing logic to send messages from L1 to World Chain. This is a clone of the Base/Mode adapter
@@ -32,6 +32,7 @@ contract WorldChain_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPA
     WETH9Interface public immutable L1_WETH;
 
     IL1StandardBridge public immutable L1_STANDARD_BRIDGE;
+    IOpUSDCBridgeAdapter public immutable L1_OP_USDC_BRIDGE;
 
     /**
      * @notice Constructs new Adapter.
@@ -42,9 +43,10 @@ contract WorldChain_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPA
      */
     constructor(
         WETH9Interface _l1Weth,
+        IERC20 _l1Usdc,
         address _crossDomainMessenger,
         IL1StandardBridge _l1StandardBridge,
-        IERC20 _l1Usdc
+        IOpUSDCBridgeAdapter _l1USDCBridge
     )
         CrossDomainEnabled(_crossDomainMessenger)
         CircleCCTPAdapter(
@@ -56,6 +58,7 @@ contract WorldChain_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPA
     {
         L1_WETH = _l1Weth;
         L1_STANDARD_BRIDGE = _l1StandardBridge;
+        L1_OP_USDC_BRIDGE = _l1USDCBridge;
     }
 
     /**
@@ -85,15 +88,17 @@ contract WorldChain_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPA
         if (l1Token == address(L1_WETH)) {
             L1_WETH.withdraw(amount);
             L1_STANDARD_BRIDGE.depositETHTo{ value: amount }(to, L2_GAS_LIMIT, "");
-        }
-        // Check if this token is USDC, which requires a custom bridge via CCTP.
-        else if (_isCCTPEnabled() && l1Token == address(usdcToken)) {
-            _transferUsdc(to, amount);
+        } else if (l1Token == address(usdcToken)) {
+            if (_isCCTPEnabled()) {
+                _transferUsdc(to, amount);
+            } else {
+                // Use Circle's standard bridge for Bridged USDC.
+                IERC20(l1Token).safeIncreaseAllowance(address(L1_OP_USDC_BRIDGE), amount);
+                L1_OP_USDC_BRIDGE.sendMessage(to, amount, L2_GAS_LIMIT);
+            }
         } else {
-            IL1StandardBridge _l1StandardBridge = L1_STANDARD_BRIDGE;
-
-            IERC20(l1Token).safeIncreaseAllowance(address(_l1StandardBridge), amount);
-            _l1StandardBridge.depositERC20To(l1Token, l2Token, to, amount, L2_GAS_LIMIT, "");
+            IERC20(l1Token).safeIncreaseAllowance(address(L1_STANDARD_BRIDGE), amount);
+            L1_STANDARD_BRIDGE.depositERC20To(l1Token, l2Token, to, amount, L2_GAS_LIMIT, "");
         }
         emit TokensRelayed(l1Token, l2Token, amount, to);
     }

--- a/contracts/chain-adapters/WorldChain_Adapter.sol
+++ b/contracts/chain-adapters/WorldChain_Adapter.sol
@@ -92,7 +92,7 @@ contract WorldChain_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPA
             if (_isCCTPEnabled()) {
                 _transferUsdc(to, amount);
             } else {
-                // Use Circle's standard bridge for Bridged USDC.
+                // Use WorldChain's OP USDC bridge for Bridged USDC.
                 IERC20(l1Token).safeIncreaseAllowance(address(L1_OP_USDC_BRIDGE), amount);
                 L1_OP_USDC_BRIDGE.sendMessage(to, amount, L2_GAS_LIMIT);
             }

--- a/contracts/external/interfaces/IOpUSDCBridgeAdapter.sol
+++ b/contracts/external/interfaces/IOpUSDCBridgeAdapter.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * Imported from https://github.com/defi-wonderland/opUSDC
+ * https://github.com/defi-wonderland/opUSDC/blob/ef22e5731f1655bf5249b2160452cce9aa06ff3f/src/interfaces/IOpUSDCBridgeAdapter.sol#L198C1-L204C84
+ */
+interface IOpUSDCBridgeAdapter {
+    /**
+     * @notice Send tokens to another chain through the linked adapter
+     * @param _to The target address on the destination chain
+     * @param _amount The amount of tokens to send
+     * @param _minGasLimit Minimum gas limit that the message can be executed with
+     */
+    function sendMessage(
+        address _to,
+        uint256 _amount,
+        uint32 _minGasLimit
+    ) external;
+}

--- a/deploy/050_deploy_worldchain_adapter.ts
+++ b/deploy/050_deploy_worldchain_adapter.ts
@@ -1,6 +1,6 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
-import { L1_ADDRESS_MAP, WETH, ZERO_ADDRESS } from "./consts";
+import { L1_ADDRESS_MAP, USDC, WETH } from "./consts";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
@@ -12,9 +12,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     skipIfAlreadyDeployed: true,
     args: [
       WETH[chainId],
+      USDC[chainId],
       L1_ADDRESS_MAP[chainId].worldChainCrossDomainMessenger,
       L1_ADDRESS_MAP[chainId].worldChainStandardBridge,
-      ZERO_ADDRESS,
+      L1_ADDRESS_MAP[chainId].worldChainOpUSDCBridge,
     ],
   });
 };

--- a/deploy/consts.ts
+++ b/deploy/consts.ts
@@ -48,6 +48,7 @@ export const L1_ADDRESS_MAP: { [key: number]: { [contractName: string]: string }
     zoraStandardBridge: "0x3e2Ea9B92B7E48A52296fD261dc26fd995284631",
     worldChainCrossDomainMessenger: "0xf931a81D18B1766d15695ffc7c1920a62b7e710a",
     worldChainStandardBridge: "0x470458C91978D2d929704489Ad730DC3E3001113",
+    worldChainOpUSDCBridge: "0x153A69e4bb6fEDBbAaF463CB982416316c84B2dB",
   },
   [CHAIN_IDs.SEPOLIA]: {
     optimismCrossDomainMessenger: "0x58Cc85b8D04EA49cC6DBd3CbFFd00B4B8D6cb3ef",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build-evm": "hardhat compile",
     "build-svm": "echo 'Generating IDLs...' && anchor build > /dev/null 2>&1 || true && anchor run generateExternalTypes && anchor build",
     "build-ts": "tsc && rsync -a --include '*/' --include '*.d.ts' --exclude '*' ./typechain ./dist/",
-    "build": "yarn build-evm && yarn build-ts",
+    "build": "yarn build-evm && yarn build-svm && yarn build-ts",
     "test-evm": "IS_TEST=true hardhat test",
     "test-svm": "anchor test",
     "test": "yarn test-evm && yarn test-svm",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build-evm": "hardhat compile",
     "build-svm": "echo 'Generating IDLs...' && anchor build > /dev/null 2>&1 || true && anchor run generateExternalTypes && anchor build",
     "build-ts": "tsc && rsync -a --include '*/' --include '*.d.ts' --exclude '*' ./typechain ./dist/",
-    "build": "yarn build-evm && yarn build-svm && yarn build-ts",
+    "build": "yarn build-evm && yarn build-ts",
     "test-evm": "IS_TEST=true hardhat test",
     "test-svm": "anchor test",
     "test": "yarn test-evm && yarn test-svm",

--- a/test/evm/hardhat/chain-adapters/WorldChain_Adapter.ts
+++ b/test/evm/hardhat/chain-adapters/WorldChain_Adapter.ts
@@ -1,0 +1,93 @@
+/* eslint-disable no-unused-expressions */
+import { CHAIN_IDs } from "@across-protocol/constants";
+import * as consts from "../constants";
+import {
+  ethers,
+  expect,
+  Contract,
+  createFake,
+  createFakeFromABI,
+  FakeContract,
+  SignerWithAddress,
+  toWei,
+  getContractFactory,
+  seedWallet,
+} from "../../../../utils/utils";
+import { hubPoolFixture, enableTokensForLP } from "../fixtures/HubPool.Fixture";
+import { constructSingleChainTree } from "../MerkleLib.utils";
+
+let hubPool: Contract, adapter: Contract, weth: Contract, usdc: Contract, mockSpoke: Contract, timer: Contract;
+let l2Weth: string, l2Usdc: string;
+let owner: SignerWithAddress, dataWorker: SignerWithAddress;
+let liquidityProvider: SignerWithAddress;
+let l1CrossDomainMessenger: FakeContract, l1StandardBridge: FakeContract, opUSDCBridge: FakeContract;
+
+const { WORLD_CHAIN } = CHAIN_IDs;
+const opUSDCBridgeABI = [
+  {
+    inputs: [
+      { internalType: "address", name: "_to", type: "address" },
+      { internalType: "uint256", name: "_amount", type: "uint256" },
+      { internalType: "uint32", name: "_minGasLimit", type: "uint32" },
+    ],
+    name: "sendMessage",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+];
+
+describe("World Chain Adapter", function () {
+  beforeEach(async function () {
+    [owner, dataWorker, liquidityProvider] = await ethers.getSigners();
+    ({ weth, l2Weth, usdc, l2Usdc, hubPool, mockSpoke, timer } = await hubPoolFixture());
+    await seedWallet(dataWorker, [usdc], weth, consts.amountToLp);
+    await seedWallet(liquidityProvider, [usdc], weth, consts.amountToLp.mul(10));
+
+    await enableTokensForLP(owner, hubPool, weth, [weth, usdc]);
+    await weth.connect(liquidityProvider).approve(hubPool.address, consts.amountToLp);
+    await hubPool.connect(liquidityProvider).addLiquidity(weth.address, consts.amountToLp);
+    await weth.connect(dataWorker).approve(hubPool.address, consts.bondAmount.mul(10));
+    await usdc.connect(liquidityProvider).approve(hubPool.address, consts.amountToLp);
+    await hubPool.connect(liquidityProvider).addLiquidity(usdc.address, consts.amountToLp);
+    await usdc.connect(dataWorker).approve(hubPool.address, consts.bondAmount.mul(10));
+
+    l1CrossDomainMessenger = await createFake("L1CrossDomainMessenger");
+    l1StandardBridge = await createFake("L1StandardBridge");
+    opUSDCBridge = await createFakeFromABI(opUSDCBridgeABI);
+
+    adapter = await (
+      await getContractFactory("WorldChain_Adapter", owner)
+    ).deploy(
+      weth.address,
+      usdc.address,
+      l1CrossDomainMessenger.address,
+      l1StandardBridge.address,
+      opUSDCBridge.address
+    );
+    // Seed the HubPool some funds so it can send L1->L2 messages.
+    await hubPool.connect(liquidityProvider).loadEthForL2Calls({ value: toWei("1") });
+
+    await hubPool.setCrossChainContracts(WORLD_CHAIN, adapter.address, mockSpoke.address);
+    await hubPool.setPoolRebalanceRoute(WORLD_CHAIN, usdc.address, l2Usdc);
+    await hubPool.setPoolRebalanceRoute(WORLD_CHAIN, weth.address, l2Weth);
+  });
+
+  it("Correctly routes USDC via WorldChain's OP USDC bridge", async function () {
+    // Seed the HubPool some funds so it can send L1->L2 messages.
+    await hubPool.connect(liquidityProvider).loadEthForL2Calls({ value: toWei("1") });
+
+    // Create an action that will send an L1->L2 tokens transfer and bundle. For this, create a relayer repayment bundle
+    // and check that at it's finalization the L2 bridge contracts are called as expected.
+    const { leaves, tree, tokensSendToL2 } = await constructSingleChainTree(usdc.address, 1, WORLD_CHAIN);
+    await hubPool
+      .connect(dataWorker)
+      .proposeRootBundle([3117], 1, tree.getHexRoot(), consts.mockTreeRoot, consts.mockTreeRoot);
+    await timer.setCurrentTime(Number(await timer.getCurrentTime()) + consts.refundProposalLiveness + 1);
+
+    await hubPool.connect(dataWorker).executeRootBundle(...Object.values(leaves[0]), tree.getHexProof(leaves[0]));
+
+    expect(opUSDCBridge.sendMessage).to.have.been.calledOnce;
+    expect(opUSDCBridge.sendMessage).to.have.been.calledWith(mockSpoke.address, tokensSendToL2, 200000);
+  });
+});

--- a/test/evm/hardhat/chain-adapters/WorldChain_Adapter.ts
+++ b/test/evm/hardhat/chain-adapters/WorldChain_Adapter.ts
@@ -87,7 +87,8 @@ describe("World Chain Adapter", function () {
 
     await hubPool.connect(dataWorker).executeRootBundle(...Object.values(leaves[0]), tree.getHexProof(leaves[0]));
 
+    const l2Gas = await adapter.L2_GAS_LIMIT();
     expect(opUSDCBridge.sendMessage).to.have.been.calledOnce;
-    expect(opUSDCBridge.sendMessage).to.have.been.calledWith(mockSpoke.address, tokensSendToL2, 200000);
+    expect(opUSDCBridge.sendMessage).to.have.been.calledWith(mockSpoke.address, tokensSendToL2, l2Gas);
   });
 });


### PR DESCRIPTION
World Chain implements Circle's bridged USDC standard. Deposits & withdrawals cannot be initiated via the L1StandardBridge and L2StandardBridge contracts respectively. Instead they must be sent to World Chain's own implementations of Circle's bridged USDC standard.

Circle's standard is described here: https://github.com/circlefin/stablecoin-evm/blob/master/doc/bridged_USDC_standard.md

The process for bridged USDC deposits & withdrawals is here:
https://github.com/defi-wonderland/opUSDC/tree/main?tab=readme-ov-file#l1--l2-usdc-canonical-bridging