### PR TITLE
feat: world chain spoke pool

### DIFF
--- a/contracts/WorldChain_SpokePool.sol
+++ b/contracts/WorldChain_SpokePool.sol
@@ -5,11 +5,25 @@ import "@eth-optimism/contracts/libraries/constants/Lib_PredeployAddresses.sol";
 import "./Ovm_SpokePool.sol";
 import "./external/interfaces/CCTPInterfaces.sol";
 
+// https://github.com/defi-wonderland/opUSDC/blob/ef22e5731f1655bf5249b2160452cce9aa06ff3f/src/contracts/L2OpUSDCBridgeAdapter.sol#L150
+interface UsdcBridgeInterface {
+    function sendMessage(
+        address to,
+        uint256 amount,
+        uint32 minGasLimit
+    ) external;
+}
+
 /**
- * @notice World Chain Spoke pool.
+ * @notice WorldChain Spoke pool.
  * @custom:security-contact bugs@across.to
  */
 contract WorldChain_SpokePool is Ovm_SpokePool {
+    using SafeERC20 for IERC20;
+
+    // Address of the custom L2 USDC bridge.
+    address private constant USDC_BRIDGE = 0xbD80b06d3dbD0801132c6689429aC09Ca6D27f82;
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
         address _wrappedNativeTokenAddress,
@@ -28,17 +42,32 @@ contract WorldChain_SpokePool is Ovm_SpokePool {
     {} // solhint-disable-line no-empty-blocks
 
     /**
-     * @notice Construct the OVM World Chain SpokePool.
+     * @notice Construct the OVM WorldChain SpokePool.
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
-     * @param _hubPool Hub pool address to set. Can be changed by admin.
+     * @param _withdrawalRecipient Address which receives token withdrawals. Can be changed by admin. For Spoke Pools on L2, this will
+     * likely be the hub pool.
      */
     function initialize(
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _withdrawalRecipient
     ) public initializer {
-        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, Lib_PredeployAddresses.OVM_ETH);
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _withdrawalRecipient, Lib_PredeployAddresses.OVM_ETH);
+    }
+
+    function _bridgeTokensToHubPool(uint256 amountToReturn, address l2TokenAddress) internal virtual override {
+        // Handle custom USDC bridge which doesn't conform to the standard bridge interface. In the future, CCTP may be used to bridge USDC to mainnet, in which
+        // case bridging logic is handled by the Ovm_SpokePool code. In the meantime, if CCTP is not enabled, then use the USDC bridge. Once CCTP is activated on
+        // WorldChain, this block of code will be unused.
+        if (l2TokenAddress == address(usdcToken) && !_isCCTPEnabled()) {
+            usdcToken.safeIncreaseAllowance(USDC_BRIDGE, amountToReturn);
+            UsdcBridgeInterface(USDC_BRIDGE).sendMessage(
+                withdrawalRecipient, // _to. Withdraw, over the bridge, to the l1 pool contract.
+                amountToReturn, // _amount.
+                l1Gas // _minGasLimit. Same value used in other OpStack bridges.
+            );
+        } else super._bridgeTokensToHubPool(amountToReturn, l2TokenAddress);
     }
 }

--- a/deploy/051_deploy_worldchain_spokepool.ts
+++ b/deploy/051_deploy_worldchain_spokepool.ts
@@ -16,7 +16,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     WETH[spokeChainId],
     QUOTE_TIME_BUFFER,
     FILL_DEADLINE_BUFFER,
-    ZERO_ADDRESS,
+    USDC[spokeChainId],
     // L2_ADDRESS_MAP[spokeChainId].cctpTokenMessenger,
     // For now, we are not using the CCTP bridge and can disable by setting
     // the cctpTokenMessenger to the zero address.


### PR DESCRIPTION
This makes a slightly modified world chain spoke pool, which is largely based on `Optimism_SpokePool`. The contract of the USDC bridge can be found here: https://worldchain-mainnet.explorer.alchemy.com/address/0xbD80b06d3dbD0801132c6689429aC09Ca6D27f82?tab=contract_code. We need to approve this contract due to this line of code, https://github.com/defi-wonderland/opUSDC/blob/ef22e5731f1655bf5249b2160452cce9aa06ff3f/src/contracts/L2OpUSDCBridgeAdapter.sol#L304. Finally, I make the assumption that USDC is now passed in as a constructor argument and NOT set as the zero address. This required a change to the deploy script (and will require a change to the constants repository). This should be OK, since we check whether CCTP is activated by looking at the token messenger contract, which should still be set to the zero address.