### PR TITLE
fix: add receive() to withdrawal helpers

### DIFF
--- a/contracts/chain-adapters/l2/Arbitrum_WithdrawalHelper.sol
+++ b/contracts/chain-adapters/l2/Arbitrum_WithdrawalHelper.sol
@@ -9,6 +9,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ArbitrumL2ERC20GatewayLike } from "../../interfaces/ArbitrumBridge.sol";
 import { WithdrawalHelperBase } from "./WithdrawalHelperBase.sol";
 import { ITokenMessenger } from "../../external/interfaces/CCTPInterfaces.sol";
+import { WETH9Interface } from "../../external/interfaces/WETH9Interface.sol";
 import { CrossDomainAddressUtils } from "../../libraries/CrossDomainAddressUtils.sol";
 
 /**
@@ -27,6 +28,7 @@ contract Arbitrum_WithdrawalHelper is WithdrawalHelperBase {
      * @notice Constructs the Arbitrum_WithdrawalHelper.
      * @param _l2Usdc Address of native USDC on the L2.
      * @param _cctpTokenMessenger Address of the CCTP token messenger contract on L2.
+     * @param _wrappedNativeToken Address of the wrapped native token contract on L2.
      * @param _destinationCircleDomainId Circle's assigned CCTP domain ID for the destination network. For Ethereum, this is 0.
      * @param _l2GatewayRouter Address of the Arbitrum l2 gateway router contract.
      * @param _tokenRecipient L1 Address which will unconditionally receive tokens withdrawn from this contract.
@@ -34,6 +36,7 @@ contract Arbitrum_WithdrawalHelper is WithdrawalHelperBase {
     constructor(
         IERC20 _l2Usdc,
         ITokenMessenger _cctpTokenMessenger,
+        WETH9Interface _wrappedNativeToken,
         uint32 _destinationCircleDomainId,
         address _l2GatewayRouter,
         address _tokenRecipient
@@ -41,6 +44,7 @@ contract Arbitrum_WithdrawalHelper is WithdrawalHelperBase {
         WithdrawalHelperBase(
             _l2Usdc,
             _cctpTokenMessenger,
+            _wrappedNativeToken,
             _destinationCircleDomainId,
             _l2GatewayRouter,
             _tokenRecipient

--- a/contracts/chain-adapters/l2/Arbitrum_WithdrawalHelper.sol
+++ b/contracts/chain-adapters/l2/Arbitrum_WithdrawalHelper.sol
@@ -74,6 +74,7 @@ contract Arbitrum_WithdrawalHelper is WithdrawalHelperBase {
         if (l2Token == address(usdcToken) && _isCCTPEnabled()) {
             _transferUsdc(TOKEN_RECIPIENT, amountToReturn);
         } else {
+            if (l2Token == address(WRAPPED_NATIVE_TOKEN)) _depositNativeToken();
             // Otherwise, we use the Arbitrum ERC20 Gateway router.
             ArbitrumL2ERC20GatewayLike tokenBridge = ArbitrumL2ERC20GatewayLike(L2_TOKEN_GATEWAY);
             // If the gateway router's expected L2 token address does not match then revert. This check does not actually

--- a/contracts/chain-adapters/l2/Ovm_WithdrawalHelper.sol
+++ b/contracts/chain-adapters/l2/Ovm_WithdrawalHelper.sol
@@ -115,6 +115,10 @@ contract Ovm_WithdrawalHelper is WithdrawalHelperBase {
         // If the token being bridged is WETH then we need to first unwrap it to ETH and then send ETH over the
         // canonical bridge. On Optimism, this is address 0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000.
         if (l2Token == address(WRAPPED_NATIVE_TOKEN)) {
+            // Wrap the contract's balance of the native token if we are withdrawing the L2's native token. We need wrap the contract's balance
+            // and then unwrap the amount to send to account for cases where `amountToReturn` is greater than the contract's native token balance
+            // and wrapped native token balance, but less than their sum.
+            _depositNativeToken();
             WETH9Interface(l2Token).withdraw(amountToReturn); // Unwrap into ETH.
             l2Token = l2Eth; // Set the l2Token to ETH.
             IL2ERC20Bridge(Lib_PredeployAddresses.L2_STANDARD_BRIDGE).withdrawTo{ value: amountToReturn }(

--- a/contracts/chain-adapters/l2/WithdrawalHelperBase.sol
+++ b/contracts/chain-adapters/l2/WithdrawalHelperBase.sol
@@ -72,13 +72,9 @@ abstract contract WithdrawalHelperBase is CircleCCTPAdapter, MultiCaller, UUPSUp
     /**
      * @notice Receives the native token from bridge contracts.
      * @dev When bridging from L3 to the L2's native token, OpStack bridges will send the "unwrapped"/native token to the recipient on L2
-     * during withdrawals. This means that this contract must be able to accept value transfers. By default, we automatically wrap incoming
-     * ETH transfers, with the exception of an ETH transfer originating from the wrapped token contract. This is because this contract does
-     * want to send value transfers, but only after unwrapping WETH.
+     * during withdrawals. This means that this contract must be able to accept value transfers.
      */
-    receive() external payable {
-        if (msg.sender != address(WRAPPED_NATIVE_TOKEN)) WRAPPED_NATIVE_TOKEN.deposit{ value: msg.value }();
-    }
+    receive() external payable {}
 
     /**
      * @notice Initializes the withdrawal helper contract.
@@ -116,6 +112,13 @@ abstract contract WithdrawalHelperBase is CircleCCTPAdapter, MultiCaller, UUPSUp
         address l2Token,
         uint256 amountToReturn
     ) public virtual;
+
+    /*
+     * @notice Wraps the contract's entire balance of the native token.
+     */
+    function _depositNativeToken() internal virtual {
+        if (address(this).balance > 0) WRAPPED_NATIVE_TOKEN.deposit{ value: address(this).balance }();
+    }
 
     /*
      * @notice Checks that the L1 msg.sender is the `crossDomainAdmin` address.

--- a/contracts/chain-adapters/l2/WithdrawalHelperBase.sol
+++ b/contracts/chain-adapters/l2/WithdrawalHelperBase.sol
@@ -64,6 +64,13 @@ abstract contract WithdrawalHelperBase is CircleCCTPAdapter, MultiCaller, UUPSUp
     }
 
     /**
+     * @notice Receives the native token from bridge contracts.
+     * @dev When bridging from L3 to the L2's native token, OpStack bridges will send the "unwrapped"/native token to the recipient on L2
+     * during withdrawals. This means that this contract must be able to accept value transfers.
+     */
+    receive() external payable {}
+
+    /**
      * @notice Initializes the withdrawal helper contract.
      * @param _crossDomainAdmin L1 address of the contract which can send root bundles/messages to this forwarder contract.
      */

--- a/test/evm/foundry/local/WithdrawalHelper.t.sol
+++ b/test/evm/foundry/local/WithdrawalHelper.t.sol
@@ -36,8 +36,6 @@ contract Mock_Ovm_WithdrawalHelper is Ovm_WithdrawalHelper {
             _spokePool
         )
     {}
-
-    receive() external payable {}
 }
 
 contract Token_ERC20 is ERC20 {


### PR DESCRIPTION
The issue:
> When handling WETH withdrawals the withdrawToken function of the Ovm_WithdrawalHelper attempts to unwrap WETH and bridge the ether received to the recipient. However, the Ovm_WithdrawalHelper contract does not expose a receive() function to accept ether transfers. This means that calls to the WETH contract to unwrap the ether will fail. As a consequence any call to withdrawToken function of the Ovm_WithdrawalHelper contract which specifies the L2 wrappedNativeToken will fail.
As there is no other way to withdraw tokens from the contract the L2 wrapped native token sent to this contract cannot be retrieved without a contract upgrade.