### PR TITLE
fix(SpokePool): Enforce exclusivity consistently

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -936,7 +936,6 @@ abstract contract SpokePool is
         // this deadline, not slow filled. As a simplifying assumption, we will not allow slow fills to be requested
         // during this exclusivity period.
         if (
-            relayData.exclusiveRelayer != msg.sender &&
             relayData.exclusivityDeadline >= getCurrentTime() &&
             relayData.exclusiveRelayer != address(0)
         ) {

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -935,7 +935,13 @@ abstract contract SpokePool is
         // fast fill within this deadline. Moreover, the depositor should expect to get *fast* filled within
         // this deadline, not slow filled. As a simplifying assumption, we will not allow slow fills to be requested
         // during this exclusivity period.
-        if (relayData.exclusivityDeadline >= getCurrentTime()) revert NoSlowFillsInExclusivityWindow();
+        if (
+            relayData.exclusiveRelayer != msg.sender &&
+            relayData.exclusivityDeadline >= getCurrentTime() &&
+            relayData.exclusiveRelayer != address(0)
+        ) {
+            revert NotExclusiveRelayer();
+        }
         if (relayData.fillDeadline < getCurrentTime()) revert ExpiredFillDeadline();
 
         bytes32 relayHash = _getV3RelayHash(relayData);

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -319,7 +319,7 @@ abstract contract SpokePool is
     /**
      * @notice Pauses deposit-related functions. This is intended to be used if this contract is deprecated or when
      * something goes awry.
-     * @dev Affects `deposit()` but not `speedUpDeposit()`, so that existing deposits can be sped up and still
+     * @dev Affects `deposit()` but not `speedUpV3Deposit()`, so that existing deposits can be sped up and still
      * relayed.
      * @param pause true if the call is meant to pause the system, false if the call is meant to unpause it.
      */

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -839,9 +839,8 @@ abstract contract SpokePool is
         // Exclusivity deadline is inclusive and is the latest timestamp that the exclusive relayer has sole right
         // to fill the relay.
         if (
-            relayData.exclusiveRelayer != msg.sender &&
-            relayData.exclusivityDeadline >= getCurrentTime() &&
-            relayData.exclusiveRelayer != address(0)
+            _fillIsExclusive(relayData.exclusiveRelayer, relayData.exclusivityDeadline) &&
+            relayData.exclusiveRelayer != msg.sender
         ) {
             revert NotExclusiveRelayer();
         }
@@ -886,9 +885,8 @@ abstract contract SpokePool is
         // Exclusivity deadline is inclusive and is the latest timestamp that the exclusive relayer has sole right
         // to fill the relay.
         if (
-            relayData.exclusiveRelayer != msg.sender &&
-            relayData.exclusivityDeadline >= getCurrentTime() &&
-            relayData.exclusiveRelayer != address(0)
+            _fillIsExclusive(relayData.exclusiveRelayer, relayData.exclusivityDeadline) &&
+            relayData.exclusiveRelayer != msg.sender
         ) {
             revert NotExclusiveRelayer();
         }
@@ -935,7 +933,7 @@ abstract contract SpokePool is
         // fast fill within this deadline. Moreover, the depositor should expect to get *fast* filled within
         // this deadline, not slow filled. As a simplifying assumption, we will not allow slow fills to be requested
         // during this exclusivity period.
-        if (relayData.exclusivityDeadline >= getCurrentTime() && relayData.exclusiveRelayer != address(0)) {
+        if (_fillIsExclusive(relayData.exclusiveRelayer, relayData.exclusivityDeadline)) {
             revert NotExclusiveRelayer();
         }
         if (relayData.fillDeadline < getCurrentTime()) revert ExpiredFillDeadline();
@@ -1412,6 +1410,11 @@ abstract contract SpokePool is
                 updatedMessage
             );
         }
+    }
+
+    // Determine whether the combination of exlcusiveRelayer and exclusivityDeadline implies active exclusivity.
+    function _fillIsExclusive(address exclusiveRelayer, uint32 exclusivityDeadline) internal returns (bool) {
+        return exclusivityDeadline >= getCurrentTime() && exclusiveRelayer != address(0);
     }
 
     // Implementing contract needs to override this to ensure that only the appropriate cross chain admin can execute

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -935,10 +935,7 @@ abstract contract SpokePool is
         // fast fill within this deadline. Moreover, the depositor should expect to get *fast* filled within
         // this deadline, not slow filled. As a simplifying assumption, we will not allow slow fills to be requested
         // during this exclusivity period.
-        if (
-            relayData.exclusivityDeadline >= getCurrentTime() &&
-            relayData.exclusiveRelayer != address(0)
-        ) {
+        if (relayData.exclusivityDeadline >= getCurrentTime() && relayData.exclusiveRelayer != address(0)) {
             revert NotExclusiveRelayer();
         }
         if (relayData.fillDeadline < getCurrentTime()) revert ExpiredFillDeadline();

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -885,7 +885,11 @@ abstract contract SpokePool is
     ) public override nonReentrant unpausedFills {
         // Exclusivity deadline is inclusive and is the latest timestamp that the exclusive relayer has sole right
         // to fill the relay.
-        if (relayData.exclusivityDeadline >= getCurrentTime() && relayData.exclusiveRelayer != msg.sender) {
+        if (
+            relayData.exclusiveRelayer != msg.sender &&
+            relayData.exclusivityDeadline >= getCurrentTime() &&
+            relayData.exclusiveRelayer != address(0)
+        ) {
             revert NotExclusiveRelayer();
         }
 

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1413,7 +1413,7 @@ abstract contract SpokePool is
     }
 
     // Determine whether the combination of exlcusiveRelayer and exclusivityDeadline implies active exclusivity.
-    function _fillIsExclusive(address exclusiveRelayer, uint32 exclusivityDeadline) internal returns (bool) {
+    function _fillIsExclusive(address exclusiveRelayer, uint32 exclusivityDeadline) internal pure returns (bool) {
         return exclusivityDeadline >= getCurrentTime() && exclusiveRelayer != address(0);
     }
 

--- a/contracts/interfaces/V3SpokePoolInterface.sol
+++ b/contracts/interfaces/V3SpokePoolInterface.sol
@@ -222,7 +222,6 @@ interface V3SpokePoolInterface {
     error DisabledRoute();
     error InvalidQuoteTimestamp();
     error InvalidFillDeadline();
-    error InvalidExclusiveRelayer();
     error InvalidExclusivityDeadline();
     error MsgValueDoesNotMatchInputAmount();
     error NotExclusiveRelayer();

--- a/test/evm/hardhat/SpokePool.Relay.ts
+++ b/test/evm/hardhat/SpokePool.Relay.ts
@@ -413,6 +413,23 @@ describe("SpokePool Relayer Logic", async function () {
           updatedMessage
         );
       });
+      it("in absence of exclusivity", async function () {
+        // Clock drift between spokes can mean exclusivityDeadline is in future even when no exclusivity was applied.
+        await spokePool.setCurrentTime(relayData.exclusivityDeadline - 1);
+        await expect(
+          spokePool.connect(relayer).fillV3RelayWithUpdatedDeposit(
+            {
+              ...relayData,
+              exclusiveRelayer: consts.zeroAddress,
+            },
+            consts.repaymentChainId,
+            updatedOutputAmount,
+            updatedRecipient,
+            updatedMessage,
+            signature
+          )
+        ).to.emit(spokePool, "FilledV3Relay");
+      });
       it("must be exclusive relayer before exclusivity deadline", async function () {
         const _relayData = {
           ...relayData,

--- a/test/evm/hardhat/SpokePool.SlowRelay.ts
+++ b/test/evm/hardhat/SpokePool.SlowRelay.ts
@@ -51,6 +51,13 @@ describe("SpokePool Slow Relay Logic", async function () {
       relayData.fillDeadline = (await spokePool.getCurrentTime()).sub(1);
       await expect(spokePool.connect(relayer).requestV3SlowFill(relayData)).to.be.revertedWith("ExpiredFillDeadline");
     });
+    it("in absence of exclusivity", async function () {
+      // Clock drift between spokes can mean exclusivityDeadline is in future even when no exclusivity was applied.
+      await spokePool.setCurrentTime(relayData.exclusivityDeadline - 1);
+      await expect(
+        spokePool.connect(relayer).requestV3SlowFill({ ...relayData, exclusiveRelayer: consts.zeroAddress })
+      ).to.emit(spokePool, "RequestedV3SlowFill");
+    });
     it("during exclusivity deadline", async function () {
       await spokePool.setCurrentTime(relayData.exclusivityDeadline);
       await expect(spokePool.connect(relayer).requestV3SlowFill(relayData)).to.be.revertedWith(


### PR DESCRIPTION
The new relative exclusivity check has not been propagated to fillV3RelayWithUpdatedDeposit() or requestV3SlowFill(). Identified via test case failures in the relayer.

This is a very-low criticality issue. It's very unlikely that any relayer would be trying to call `fillV3RelayWithUpdatedDeposit()` within the exclusivity window. There's a slightly higher chance of hitting this issue on slow fill requests because the RL relayer is fast enough to hit the probable exclusivity windows on some routes for larger transfers, which is where a token shortfall is more likely.