### PR TITLE
fix(svm): make svm spoke pool logic more consistent with evm

### DIFF
--- a/programs/svm-spoke/src/error.rs
+++ b/programs/svm-spoke/src/error.rs
@@ -29,7 +29,7 @@ pub enum CustomError {
     ExpiredFillDeadline,
     #[msg("Caller is not the exclusive relayer and exclusivity deadline has not passed!")]
     NotExclusiveRelayer,
-    #[msg("The Deposit is still within the exclusivity or deadline window!")]
+    #[msg("The Deposit is still within the exclusivity window!")]
     NoSlowFillsInExclusivityWindow,
     #[msg("Invalid route PDA!")]
     InvalidRoutePDA,
@@ -52,7 +52,7 @@ pub enum CustomError {
     #[msg("Invalid remote sender!")]
     InvalidRemoteSender,
     #[msg("Invalid Merkle proof!")]
-    InvalidProof,
+    InvalidMerkleProof,
     #[msg("Account not found!")]
     AccountNotFound,
     #[msg("Fills are currently paused!")]
@@ -62,7 +62,7 @@ pub enum CustomError {
     #[msg("Invalid mint!")]
     InvalidMint,
     #[msg("Leaf already claimed!")]
-    LeafAlreadyClaimed,
+    ClaimedMerkleLeaf,
     #[msg("Exceeded pending bridge amount to HubPool!")]
     ExceededPendingBridgeAmount,
     #[msg("Deposits are currently paused!")]

--- a/programs/svm-spoke/src/instructions/bundle.rs
+++ b/programs/svm-spoke/src/instructions/bundle.rs
@@ -122,14 +122,14 @@ pub fn execute_relayer_refund_leaf<'info>(
     verify_merkle_proof(root, leaf, proof)?;
 
     if relayer_refund_leaf.chain_id != state.chain_id {
-        return Err(CustomError::InvalidChainId.into());
+        return err!(CustomError::InvalidChainId);
     }
 
     if is_claimed(
         &ctx.accounts.root_bundle.claimed_bitmap,
         relayer_refund_leaf.leaf_id,
     ) {
-        return Err(CustomError::LeafAlreadyClaimed.into());
+        return err!(CustomError::ClaimedMerkleLeaf);
     }
 
     set_claimed(

--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -85,7 +85,9 @@ pub fn deposit_v3(
 ) -> Result<()> {
     let state = &mut ctx.accounts.state;
 
-    require!(ctx.accounts.route.enabled, CustomError::DisabledRoute);
+    if !ctx.accounts.route.enabled {
+        return err!(CustomError::DisabledRoute);
+    }
 
     let current_time = if state.current_time != 0 {
         state.current_time
@@ -94,11 +96,11 @@ pub fn deposit_v3(
     };
 
     if current_time - quote_timestamp > state.deposit_quote_time_buffer {
-        return Err(CustomError::InvalidQuoteTimestamp.into());
+        return err!(CustomError::InvalidQuoteTimestamp);
     }
 
     if fill_deadline < current_time || fill_deadline > current_time + state.fill_deadline_buffer {
-        return Err(CustomError::InvalidFillDeadline.into());
+        return err!(CustomError::InvalidFillDeadline);
     }
 
     let transfer_accounts = TransferChecked {

--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -107,9 +107,9 @@ pub fn fill_v3_relay(
     };
 
     // Check if the exclusivity deadline has passed or if the caller is the exclusive relayer
-    if relay_data.exclusive_relayer != Pubkey::default()
-        && relay_data.exclusive_relayer != ctx.accounts.signer.key()
+    if relay_data.exclusive_relayer != ctx.accounts.signer.key()
         && relay_data.exclusivity_deadline >= current_time
+        && relay_data.exclusive_relayer != Pubkey::default()
     {
         return err!(CustomError::NotExclusiveRelayer);
     }

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -60,23 +60,19 @@ pub fn request_v3_slow_fill(
         Clock::get()?.unix_timestamp as u32
     };
 
-    // Check if the fill is within the exclusivity window & fill deadline.
-    //TODO: ensure the require blocks here are equivilelent to evm.
-    require!(
-        relay_data.exclusivity_deadline < current_time,
-        CustomError::NoSlowFillsInExclusivityWindow
-    );
-    require!(
-        relay_data.fill_deadline < current_time,
-        CustomError::ExpiredFillDeadline
-    );
+    // Check if the fill is past the exclusivity window & within the fill deadline.
+    if relay_data.exclusivity_deadline >= current_time {
+        return err!(CustomError::NoSlowFillsInExclusivityWindow);
+    }
+    if relay_data.fill_deadline < current_time {
+        return err!(CustomError::ExpiredFillDeadline);
+    }
 
     // Check the fill status
     let fill_status_account = &mut ctx.accounts.fill_status;
-    require!(
-        fill_status_account.status == FillStatus::Unfilled,
-        CustomError::InvalidSlowFillRequest
-    );
+    if fill_status_account.status != FillStatus::Unfilled {
+        return err!(CustomError::InvalidSlowFillRequest);
+    }
 
     // Update the fill status to RequestedSlowFill
     fill_status_account.status = FillStatus::RequestedSlowFill;
@@ -201,6 +197,13 @@ pub fn execute_v3_slow_relay_leaf(
     root_bundle_id: u32,
     proof: Vec<[u8; 32]>,
 ) -> Result<()> {
+    // TODO: Try again to pull this into a helper function. for some reason I was not able to due to passing context around of state.
+    let current_time = if ctx.accounts.state.current_time != 0 {
+        ctx.accounts.state.current_time
+    } else {
+        Clock::get()?.unix_timestamp as u32
+    };
+
     let relay_data = slow_fill_leaf.relay_data;
 
     let slow_fill = V3SlowFill {
@@ -213,12 +216,16 @@ pub fn execute_v3_slow_relay_leaf(
     let leaf = slow_fill.to_keccak_hash();
     verify_merkle_proof(root, leaf, proof)?;
 
-    // Check if the fill status is unfilled
+    // Check if the fill deadline has passed
+    if relay_data.fill_deadline < current_time {
+        return err!(CustomError::ExpiredFillDeadline);
+    }
+
+    // Check if the fill status is not filled
     let fill_status_account = &mut ctx.accounts.fill_status;
-    require!(
-        fill_status_account.status == FillStatus::RequestedSlowFill,
-        CustomError::InvalidSlowFillRequest
-    );
+    if fill_status_account.status == FillStatus::Filled {
+        return err!(CustomError::RelayFilled);
+    }
 
     // Derive the signer seeds for the state
     let state_seed_bytes = ctx.accounts.state.seed.to_le_bytes();

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -193,12 +193,7 @@ pub fn execute_v3_slow_relay_leaf(
     root_bundle_id: u32,
     proof: Vec<[u8; 32]>,
 ) -> Result<()> {
-    // TODO: Try again to pull this into a helper function. for some reason I was not able to due to passing context around of state.
-    let current_time = if ctx.accounts.state.current_time != 0 {
-        ctx.accounts.state.current_time
-    } else {
-        Clock::get()?.unix_timestamp as u32
-    };
+    let current_time = get_current_time(&ctx.accounts.state)?;
 
     let relay_data = slow_fill_leaf.relay_data;
 

--- a/programs/svm-spoke/src/instructions/token_bridge.rs
+++ b/programs/svm-spoke/src/instructions/token_bridge.rs
@@ -78,10 +78,9 @@ impl<'info> BridgeTokensToHubPool<'info> {
         amount: u64,
         bumps: &BridgeTokensToHubPoolBumps,
     ) -> Result<()> {
-        require!(
-            amount <= self.transfer_liability.pending_to_hub_pool,
-            CustomError::ExceededPendingBridgeAmount
-        );
+        if amount > self.transfer_liability.pending_to_hub_pool {
+            return err!(CustomError::ExceededPendingBridgeAmount);
+        }
         self.transfer_liability.pending_to_hub_pool -= amount;
 
         // Invoke CCTP to bridge vault tokens from state account.

--- a/programs/svm-spoke/src/utils/cctp_utils.rs
+++ b/programs/svm-spoke/src/utils/cctp_utils.rs
@@ -49,9 +49,9 @@ pub fn decode_solidity_bool(data: &[u8; 32]) -> Result<bool> {
         0 => match l_value {
             0 => Ok(false),
             1 => Ok(true),
-            _ => return Err(CalldataError::InvalidBool.into()),
+            _ => return err!(CalldataError::InvalidBool),
         },
-        _ => return Err(CalldataError::InvalidBool.into()),
+        _ => return err!(CalldataError::InvalidBool),
     }
 }
 
@@ -64,7 +64,7 @@ pub fn decode_solidity_uint64(data: &[u8; 32]) -> Result<u64> {
     let h_value = u128::from_be_bytes(data[..16].try_into().unwrap());
     let l_value = u128::from_be_bytes(data[16..].try_into().unwrap());
     if h_value > 0 || l_value > u64::MAX as u128 {
-        return Err(CalldataError::InvalidUint64.into());
+        return err!(CalldataError::InvalidUint64);
     }
     Ok(l_value as u64)
 }
@@ -72,7 +72,7 @@ pub fn decode_solidity_uint64(data: &[u8; 32]) -> Result<u64> {
 pub fn decode_solidity_address(data: &[u8; 32]) -> Result<Pubkey> {
     for i in 0..12 {
         if data[i] != 0 {
-            return Err(CalldataError::InvalidAddress.into());
+            return err!(CalldataError::InvalidAddress);
         }
     }
     Ok(Pubkey::new_from_array(*data))

--- a/programs/svm-spoke/src/utils/merkle_proof_utils.rs
+++ b/programs/svm-spoke/src/utils/merkle_proof_utils.rs
@@ -17,7 +17,7 @@ pub fn verify_merkle_proof(root: [u8; 32], leaf: [u8; 32], proof: Vec<[u8; 32]>)
     let computed_root = process_proof(&proof, &leaf);
     if computed_root != root {
         msg!("Invalid proof: computed root does not match provided root");
-        return Err(CustomError::InvalidProof.into());
+        return err!(CustomError::InvalidMerkleProof);
     }
     msg!("Merkle proof verified successfully");
     Ok(())

--- a/programs/test/src/lib.rs
+++ b/programs/test/src/lib.rs
@@ -74,7 +74,7 @@ pub mod test {
         let computed_root = process_proof(&proof, &leaf);
         if computed_root != root {
             msg!("Invalid proof: computed root does not match provided root");
-            return Err(CustomError::InvalidProof.into());
+            return err!(CustomError::InvalidMerkleProof);
         }
         msg!("Merkle proof verified successfully");
         Ok(())

--- a/test/svm/SvmSpoke.SlowFill.ts
+++ b/test/svm/SvmSpoke.SlowFill.ts
@@ -93,8 +93,8 @@ describe("svm_spoke.slow_fill", () => {
         outputAmount: new BN(relayAmount),
         originChainId: new BN(1),
         depositId: new BN(Math.floor(Math.random() * 1000000)), // Unique ID for each test.
-        fillDeadline: new BN(Math.floor(Date.now() / 1000) - 30), // Note we set time in past to avoid fill deadline.
-        exclusivityDeadline: new BN(Math.floor(Date.now() / 1000) - 60),
+        fillDeadline: new BN(Math.floor(Date.now() / 1000) + 60), // 1 minute from now
+        exclusivityDeadline: new BN(Math.floor(Date.now() / 1000) - 30), // Note we set time in past to avoid exclusivity deadline
         message: Buffer.from("Test message"),
       },
       chainId: slowRelayLeafChainId,
@@ -178,7 +178,7 @@ describe("svm_spoke.slow_fill", () => {
   });
 
   it("Requests a V3 slow fill, verify the event & state change", async () => {
-    // Attempt to request a slow fill before the fillDeadline
+    // Attempt to request a slow fill before the exclusivityDeadline
     const relayHash = Array.from(calculateRelayHashUint8Array(relayData, chainId));
 
     try {
@@ -187,13 +187,13 @@ describe("svm_spoke.slow_fill", () => {
         .accounts(requestAccounts)
         .signers([relayer])
         .rpc();
-      assert.fail("Request should have failed due to fill deadline not passed");
+      assert.fail("Request should have failed due to exclusivity deadline not passed");
     } catch (err: any) {
       assert.include(err.toString(), "NoSlowFillsInExclusivityWindow", "Expected NoSlowFillsInExclusivityWindow error");
     }
 
-    // Set the contract time to be after the fillDeadline
-    await setCurrentTime(program, state, relayer, relayData.fillDeadline.add(new BN(1)));
+    // Set the contract time to be after the exclusivityDeadline
+    await setCurrentTime(program, state, relayer, relayData.exclusivityDeadline.add(new BN(1)));
 
     await program.methods
       .requestV3SlowFill(relayHash, formatRelayData(relayData))
@@ -238,8 +238,8 @@ describe("svm_spoke.slow_fill", () => {
       assert.include(err.toString(), "NoSlowFillsInExclusivityWindow", "Expected NoSlowFillsInExclusivityWindow error");
     }
 
-    // Set the contract time to be after the fillDeadline.
-    await setCurrentTime(program, state, relayer, relayData.fillDeadline.add(new BN(1)));
+    // Set the contract time to be after the exclusivityDeadline.
+    await setCurrentTime(program, state, relayer, relayData.exclusivityDeadline.add(new BN(1)));
 
     // Attempt to request a slow fill after the relay has been filled.
     try {
@@ -262,8 +262,8 @@ describe("svm_spoke.slow_fill", () => {
     let fillStatusAccount = await program.account.fillStatusAccount.fetchNullable(fillStatusPDA);
     assert.isNull(fillStatusAccount, "FillStatusAccount should be uninitialized before requestV3SlowFill");
 
-    // Set the contract time to be after the fillDeadline
-    await setCurrentTime(program, state, relayer, relayData.fillDeadline.add(new BN(1)));
+    // Set the contract time to be after the exclusivityDeadline
+    await setCurrentTime(program, state, relayer, relayData.exclusivityDeadline.add(new BN(1)));
 
     // Request a slow fill
     await program.methods
@@ -286,8 +286,8 @@ describe("svm_spoke.slow_fill", () => {
   it("Fails to request a V3 slow fill multiple times for the same fill", async () => {
     const relayHash = calculateRelayHashUint8Array(relayData, chainId);
 
-    // Set the contract time to be after the fillDeadline
-    await setCurrentTime(program, state, relayer, relayData.fillDeadline.add(new BN(1)));
+    // Set the contract time to be after the exclusivityDeadline
+    await setCurrentTime(program, state, relayer, relayData.exclusivityDeadline.add(new BN(1)));
 
     // Request a slow fill
     await program.methods
@@ -389,9 +389,6 @@ describe("svm_spoke.slow_fill", () => {
     await program.methods.pauseFills(true).accounts(pauseFillsAccounts).rpc();
     const stateAccountData = await program.account.state.fetch(state);
     assert.isTrue(stateAccountData.pausedFills, "Fills should be paused");
-
-    // Set the contract time to be after the fillDeadline
-    await setCurrentTime(program, state, relayer, relayData.fillDeadline.add(new BN(1)));
 
     // Attempt to request a slow fill. This should fail because fills are paused.
     try {
@@ -625,7 +622,7 @@ describe("svm_spoke.slow_fill", () => {
       assert.fail("Execution should have failed for another chain");
     } catch (err: any) {
       assert.instanceOf(err, anchor.AnchorError);
-      assert.strictEqual(err.error.errorCode.code, "InvalidProof", "Expected error code InvalidProof");
+      assert.strictEqual(err.error.errorCode.code, "InvalidMerkleProof", "Expected error code InvalidMerkleProof");
     }
   });
 });


### PR DESCRIPTION
Improves SVM SpokePool to be more consistent with EVM implementation. This replaces require statements with if/revert pattern used in EVM, and fixes the reverse logic error in slow fill deadline checks.