### PR TITLE
fix: type roots config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "outDir": "./dist",
     "declaration": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "typeRoots": ["./node_modules/@types", "./src/types"]
   },
   "include": [
     "./scripts",
@@ -19,6 +20,5 @@
     "utils/utils.ts",
     "src/types"
   ],
-  "files": ["./hardhat.config.ts"],
-  "typeRoots": ["./node_modules/@types", "./src/types"]
+  "files": ["./hardhat.config.ts"]
 }


### PR DESCRIPTION
typeRoots should have been placed under compilerOptions in tsconfig.json