### PR TITLE
fix(svm): use cargo feature to set time in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build-ts": "tsc && rsync -a --include '*/' --include '*.d.ts' --exclude '*' ./typechain ./dist/",
     "build": "yarn build-evm && yarn build-svm && yarn build-ts",
     "test-evm": "IS_TEST=true hardhat test",
-    "test-svm": "anchor test",
+    "test-svm": "anchor test -- --features test",
     "test": "yarn test-evm && yarn test-svm",
     "test:report-gas": "IS_TEST=true REPORT_GAS=true hardhat test",
     "generate-contract-types": "rm -rf typechain && TYPECHAIN=ethers yarn hardhat typechain",

--- a/programs/svm-spoke/Cargo.toml
+++ b/programs/svm-spoke/Cargo.toml
@@ -16,6 +16,7 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
+test = []
 
 [dependencies]
 anchor-lang = { version = "0.30.1", features = ["init-if-needed","event-cpi"]}

--- a/programs/svm-spoke/src/instructions/admin.rs
+++ b/programs/svm-spoke/src/instructions/admin.rs
@@ -37,7 +37,6 @@ pub fn initialize(
     chain_id: u64,                  // Across definition of chainId for Solana.
     remote_domain: u32,             // CCTP domain for Mainnet Ethereum.
     cross_domain_admin: Pubkey,     // HubPool on Mainnet Ethereum.
-    testable_mode: bool, // If the contract is in testable mode, enabling time manipulation.
     deposit_quote_time_buffer: u32, // Deposit quote times can't be set more than this amount into the past/future.
     fill_deadline_buffer: u32, // Fill deadlines can't be set more than this amount into the future.
 ) -> Result<()> {
@@ -48,13 +47,11 @@ pub fn initialize(
     state.chain_id = chain_id;
     state.remote_domain = remote_domain;
     state.cross_domain_admin = cross_domain_admin;
-    state.current_time = if testable_mode {
-        Clock::get()?.unix_timestamp as u32
-    } else {
-        0
-    }; // Set current_time to system time if testable_mode is true, else 0
     state.deposit_quote_time_buffer = deposit_quote_time_buffer;
     state.fill_deadline_buffer = fill_deadline_buffer;
+
+    state.initialize_current_time()?; // Stores current time in test build (no-op in production).
+
     Ok(())
 }
 

--- a/programs/svm-spoke/src/instructions/admin.rs
+++ b/programs/svm-spoke/src/instructions/admin.rs
@@ -9,6 +9,7 @@ use crate::constraints::is_local_or_remote_owner;
 use crate::{
     error::CustomError,
     event::{EnabledDepositRoute, PausedDeposits, PausedFills, SetXDomainAdmin},
+    initialize_current_time,
     state::{RootBundle, Route, State},
 };
 
@@ -50,7 +51,7 @@ pub fn initialize(
     state.deposit_quote_time_buffer = deposit_quote_time_buffer;
     state.fill_deadline_buffer = fill_deadline_buffer;
 
-    state.initialize_current_time()?; // Stores current time in test build (no-op in production).
+    initialize_current_time(state)?; // Stores current time in test build (no-op in production).
 
     Ok(())
 }

--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -3,6 +3,7 @@ use anchor_lang::prelude::*;
 use crate::{
     error::CustomError,
     event::V3FundsDeposited,
+    get_current_time,
     state::{Route, State},
 };
 
@@ -87,7 +88,7 @@ pub fn deposit_v3(
 
     require!(ctx.accounts.route.enabled, CustomError::DisabledRoute);
 
-    let current_time = state.get_current_time()?;
+    let current_time = get_current_time(state)?;
 
     if current_time - quote_timestamp > state.deposit_quote_time_buffer {
         return Err(CustomError::InvalidQuoteTimestamp.into());

--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -87,11 +87,7 @@ pub fn deposit_v3(
 
     require!(ctx.accounts.route.enabled, CustomError::DisabledRoute);
 
-    let current_time = if state.current_time != 0 {
-        state.current_time
-    } else {
-        Clock::get()?.unix_timestamp as u32
-    };
+    let current_time = state.get_current_time()?;
 
     if current_time - quote_timestamp > state.deposit_quote_time_buffer {
         return Err(CustomError::InvalidQuoteTimestamp.into());

--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -10,6 +10,7 @@ use crate::{
     constraints::is_relay_hash_valid,
     error::CustomError,
     event::{FillType, FilledV3Relay, V3RelayExecutionEventInfo},
+    get_current_time,
     state::{FillStatus, FillStatusAccount, State},
 };
 
@@ -99,7 +100,7 @@ pub fn fill_v3_relay(
     repayment_chain_id: u64,
 ) -> Result<()> {
     let state = &mut ctx.accounts.state;
-    let current_time = state.get_current_time()?;
+    let current_time = get_current_time(state)?;
 
     // Check the fill status
     let fill_status_account = &mut ctx.accounts.fill_status;
@@ -204,7 +205,7 @@ pub fn close_fill_pda(
     relay_data: V3RelayData,
 ) -> Result<()> {
     let state = &mut ctx.accounts.state;
-    let current_time = state.get_current_time()?;
+    let current_time = get_current_time(state)?;
 
     // Check if the fill status is filled
     require!(

--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -99,12 +99,7 @@ pub fn fill_v3_relay(
     repayment_chain_id: u64,
 ) -> Result<()> {
     let state = &mut ctx.accounts.state;
-    // TODO: Try again to pull this into a helper function. for some reason I was not able to due to passing context around of state.
-    let current_time = if state.current_time != 0 {
-        state.current_time
-    } else {
-        Clock::get()?.unix_timestamp as u32
-    };
+    let current_time = state.get_current_time()?;
 
     // Check the fill status
     let fill_status_account = &mut ctx.accounts.fill_status;
@@ -209,12 +204,7 @@ pub fn close_fill_pda(
     relay_data: V3RelayData,
 ) -> Result<()> {
     let state = &mut ctx.accounts.state;
-    // TODO: Try again to pull this into a helper function. for some reason I was not able to due to passing context around of state.
-    let current_time = if state.current_time != 0 {
-        state.current_time
-    } else {
-        Clock::get()?.unix_timestamp as u32
-    };
+    let current_time = state.get_current_time()?;
 
     // Check if the fill status is filled
     require!(

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -10,6 +10,7 @@ use crate::{
     constants::DISCRIMINATOR_SIZE,
     constraints::is_relay_hash_valid,
     error::CustomError,
+    get_current_time,
     state::{FillStatus, FillStatusAccount, RootBundle, State},
     utils::verify_merkle_proof,
 };
@@ -53,7 +54,7 @@ pub fn request_v3_slow_fill(
 ) -> Result<()> {
     let state = &mut ctx.accounts.state;
 
-    let current_time = state.get_current_time()?;
+    let current_time = get_current_time(state)?;
 
     // Check if the fill is within the exclusivity window & fill deadline.
     //TODO: ensure the require blocks here are equivilelent to evm.

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -53,12 +53,7 @@ pub fn request_v3_slow_fill(
 ) -> Result<()> {
     let state = &mut ctx.accounts.state;
 
-    // TODO: Try again to pull this into a helper function. for some reason I was not able to due to passing context around of state.
-    let current_time = if state.current_time != 0 {
-        state.current_time
-    } else {
-        Clock::get()?.unix_timestamp as u32
-    };
+    let current_time = state.get_current_time()?;
 
     // Check if the fill is within the exclusivity window & fill deadline.
     //TODO: ensure the require blocks here are equivilelent to evm.

--- a/programs/svm-spoke/src/instructions/testable.rs
+++ b/programs/svm-spoke/src/instructions/testable.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::{error::CustomError, state::State};
+use crate::state::State;
 
 #[derive(Accounts)]
 pub struct SetCurrentTime<'info> {
@@ -13,7 +13,5 @@ pub struct SetCurrentTime<'info> {
 
 pub fn set_current_time(ctx: Context<SetCurrentTime>, new_time: u32) -> Result<()> {
     let state = &mut ctx.accounts.state;
-    require!(state.current_time != 0, CustomError::CannotSetCurrentTime); // Ensure current_time is not zero
-    state.current_time = new_time;
-    Ok(())
+    state.set_current_time(new_time) // Stores new time in test build (error in production).
 }

--- a/programs/svm-spoke/src/instructions/testable.rs
+++ b/programs/svm-spoke/src/instructions/testable.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::state::State;
+use crate::{error::CustomError, state::State};
 
 #[derive(Accounts)]
 pub struct SetCurrentTime<'info> {
@@ -11,7 +11,38 @@ pub struct SetCurrentTime<'info> {
     pub signer: Signer<'info>,
 }
 
-pub fn set_current_time(ctx: Context<SetCurrentTime>, new_time: u32) -> Result<()> {
-    let state = &mut ctx.accounts.state;
-    state.set_current_time(new_time) // Stores new time in test build (error in production).
+pub fn set_current_time(ctx: Context<SetCurrentTime>, _new_time: u32) -> Result<()> {
+    let _state = &mut ctx.accounts.state;
+
+    #[cfg(not(feature = "test"))]
+    {
+        return err!(CustomError::CannotSetCurrentTime);
+    }
+
+    #[cfg(feature = "test")]
+    {
+        _state.current_time = _new_time;
+        Ok(())
+    }
+}
+
+pub fn initialize_current_time(_state: &mut State) -> Result<()> {
+    #[cfg(feature = "test")]
+    {
+        _state.current_time = Clock::get()?.unix_timestamp as u32;
+    }
+
+    Ok(())
+}
+
+pub fn get_current_time(_state: &State) -> Result<u32> {
+    #[cfg(not(feature = "test"))]
+    {
+        Ok(Clock::get()?.unix_timestamp as u32)
+    }
+
+    #[cfg(feature = "test")]
+    {
+        Ok(_state.current_time)
+    }
 }

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -29,7 +29,6 @@ pub mod svm_spoke {
         chain_id: u64,
         remote_domain: u32,
         cross_domain_admin: Pubkey,
-        testable_mode: bool,
         deposit_quote_time_buffer: u32,
         fill_deadline_buffer: u32,
     ) -> Result<()> {
@@ -40,7 +39,6 @@ pub mod svm_spoke {
             chain_id,
             remote_domain,
             cross_domain_admin,
-            testable_mode,
             deposit_quote_time_buffer,
             fill_deadline_buffer,
         )

--- a/programs/svm-spoke/src/state/state.rs
+++ b/programs/svm-spoke/src/state/state.rs
@@ -1,7 +1,5 @@
 use anchor_lang::prelude::*;
 
-use crate::error::CustomError;
-
 #[account]
 #[derive(InitSpace)]
 pub struct State {
@@ -17,41 +15,4 @@ pub struct State {
     pub root_bundle_id: u32,
     pub deposit_quote_time_buffer: u32, // Deposit quote times can't be set more than this amount into the past/future.
     pub fill_deadline_buffer: u32, // Fill deadlines can't be set more than this amount into the future.
-}
-
-impl State {
-    pub fn initialize_current_time(&mut self) -> Result<()> {
-        #[cfg(feature = "test")]
-        {
-            self.current_time = Clock::get()?.unix_timestamp as u32;
-        }
-
-        Ok(())
-    }
-
-    pub fn set_current_time(&mut self, new_time: u32) -> Result<()> {
-        #[cfg(not(feature = "test"))]
-        {
-            let _ = new_time; // Suppress warning about `new_time` being unused in non-test builds.
-            return err!(CustomError::CannotSetCurrentTime);
-        }
-
-        #[cfg(feature = "test")]
-        {
-            self.current_time = new_time;
-            Ok(())
-        }
-    }
-
-    pub fn get_current_time(&self) -> Result<u32> {
-        #[cfg(not(feature = "test"))]
-        {
-            Ok(Clock::get()?.unix_timestamp as u32)
-        }
-
-        #[cfg(feature = "test")]
-        {
-            Ok(self.current_time)
-        }
-    }
 }

--- a/programs/test/Cargo.toml
+++ b/programs/test/Cargo.toml
@@ -15,6 +15,7 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
+test = []
 
 [dependencies]
 anchor-lang = { version = "0.30.1", features = ["init-if-needed","event-cpi"]}

--- a/scripts/svm/initialize.ts
+++ b/scripts/svm/initialize.ts
@@ -40,7 +40,6 @@ async function initialize(): Promise<void> {
   const chainId = new BN(resolvedArgv.chainId);
   const remoteDomain = resolvedArgv.remoteDomain;
   const crossDomainAdmin = evmAddressToPublicKey(resolvedArgv.crossDomainAdmin); // Use the function to cast the value
-  const testableMode = false; // Hardcode testableMode to false
   const depositQuoteTimeBuffer = resolvedArgv.depositQuoteTimeBuffer;
   const fillDeadlineBuffer = resolvedArgv.fillDeadlineBuffer;
 
@@ -65,7 +64,6 @@ async function initialize(): Promise<void> {
     { Property: "chainId", Value: chainId.toString() },
     { Property: "remoteDomain", Value: remoteDomain.toString() },
     { Property: "crossDomainAdmin", Value: crossDomainAdmin.toString() },
-    { Property: "testableMode", Value: testableMode.toString() },
     { Property: "depositQuoteTimeBuffer", Value: depositQuoteTimeBuffer.toString() },
     { Property: "fillDeadlineBuffer", Value: fillDeadlineBuffer.toString() },
   ]);
@@ -77,7 +75,6 @@ async function initialize(): Promise<void> {
       chainId,
       remoteDomain,
       crossDomainAdmin,
-      testableMode,
       depositQuoteTimeBuffer,
       fillDeadlineBuffer
     ) as any

--- a/test/svm/SvmSpoke.Ownership.ts
+++ b/test/svm/SvmSpoke.Ownership.ts
@@ -25,7 +25,6 @@ describe("svm_spoke.ownership", () => {
       chainId: new BN(420), // Set the chainId
       remoteDomain: new BN(11), // Set the remoteDomain
       crossDomainAdmin, // Use the existing crossDomainAdmin
-      testableMode: true,
       depositQuoteTimeBuffer: new BN(3600), // Set the depositQuoteTimeBuffer
       fillDeadlineBuffer: new BN(14400), // Set the fillDeadlineBuffer (4 hours)
     };
@@ -38,15 +37,12 @@ describe("svm_spoke.ownership", () => {
 
     // Assert other properties as needed
     Object.keys(initialState).forEach((key) => {
-      if (key !== "testableMode") {
-        // We dont store testableMode in state.
-        const adjustedKey = key === "initialNumberOfDeposits" ? "numberOfDeposits" : key; // stored with diff key in state.
-        assertSE(
-          stateData[adjustedKey as keyof typeof stateData],
-          initialState[key as keyof typeof initialState],
-          `${key} should match`
-        );
-      }
+      const adjustedKey = key === "initialNumberOfDeposits" ? "numberOfDeposits" : key; // stored with diff key in state.
+      assertSE(
+        stateData[adjustedKey as keyof typeof stateData],
+        initialState[key as keyof typeof initialState],
+        `${key} should match`
+      );
     });
   });
 

--- a/test/svm/SvmSpoke.common.ts
+++ b/test/svm/SvmSpoke.common.ts
@@ -36,7 +36,6 @@ const initializeState = async (
     chainId: BN;
     remoteDomain: BN;
     crossDomainAdmin: PublicKey;
-    testableMode: boolean;
     depositQuoteTimeBuffer: BN;
     fillDeadlineBuffer: BN;
   }
@@ -50,7 +49,6 @@ const initializeState = async (
       chainId,
       remoteDomain,
       crossDomainAdmin,
-      testableMode: true,
       depositQuoteTimeBuffer,
       fillDeadlineBuffer,
     };
@@ -63,7 +61,6 @@ const initializeState = async (
       initialState.chainId,
       initialState.remoteDomain.toNumber(),
       initialState.crossDomainAdmin,
-      initialState.testableMode,
       initialState.depositQuoteTimeBuffer.toNumber(),
       initialState.fillDeadlineBuffer.toNumber()
     )


### PR DESCRIPTION
Simplifies the code by handling current time using cargo features. Only when built with test feature enabled, the implementation stores and gets time via state account. In production build actual current time is fetched.