### PR TITLE
fix: allow the forwarder to receive wrapped native tokens

### DIFF
--- a/contracts/chain-adapters/Arbitrum_Forwarder.sol
+++ b/contracts/chain-adapters/Arbitrum_Forwarder.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import { ForwarderBase } from "./ForwarderBase.sol";
 import { CrossDomainAddressUtils } from "../libraries/CrossDomainAddressUtils.sol";
+import { WETH9Interface } from "../external/interfaces/WETH9Interface.sol";
 
 /**
  * @title Arbitrum_Forwarder
@@ -19,10 +20,9 @@ contract Arbitrum_Forwarder is ForwarderBase {
 
     /**
      * @notice Constructs an Arbitrum-specific forwarder contract.
-     * @dev Since this is a proxy contract, we only set immutable variables in the constructor, and leave everything else to be initialized.
-     * This includes variables like the cross domain admin.
+     * @param _wrappedNativeToken Address of the wrapped native token contract on the L2.
      */
-    constructor() ForwarderBase() {}
+    constructor(WETH9Interface _wrappedNativeToken) ForwarderBase(_wrappedNativeToken) {}
 
     /**
      * @notice Initializes the forwarder contract.

--- a/contracts/chain-adapters/Ovm_Forwarder.sol
+++ b/contracts/chain-adapters/Ovm_Forwarder.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import { ForwarderBase } from "./ForwarderBase.sol";
 import { LibOptimismUpgradeable } from "@openzeppelin/contracts-upgradeable/crosschain/optimism/LibOptimismUpgradeable.sol";
 import { Lib_PredeployAddresses } from "@eth-optimism/contracts/libraries/constants/Lib_PredeployAddresses.sol";
+import { WETH9Interface } from "../external/interfaces/WETH9Interface.sol";
 
 /**
  * @title Ovm_Forwarder
@@ -22,8 +23,9 @@ contract Ovm_Forwarder is ForwarderBase {
 
     /**
      * @notice Constructs an Ovm specific forwarder contract.
+     * @param _wrappedNativeToken Address of the wrapped native token contract on the L2.
      */
-    constructor() ForwarderBase() {}
+    constructor(WETH9Interface _wrappedNativeToken) ForwarderBase(_wrappedNativeToken) {}
 
     /**
      * @notice Initializes the forwarder contract.

--- a/test/evm/foundry/local/Forwarder.t.sol
+++ b/test/evm/foundry/local/Forwarder.t.sol
@@ -64,7 +64,7 @@ contract ForwarderTest is Test {
             ITokenMessenger(address(0))
         );
 
-        arbitrumForwarder = new Arbitrum_Forwarder();
+        arbitrumForwarder = new Arbitrum_Forwarder(WETH9Interface(address(l2Weth)));
         address proxy = address(
             new ERC1967Proxy(address(arbitrumForwarder), abi.encodeCall(Arbitrum_Forwarder.initialize, (owner)))
         );
@@ -121,7 +121,7 @@ contract ForwarderTest is Test {
     // Test access control on proxy upgrades.
     function testUpgrade(address random) public {
         vm.assume(random != aliasedOwner);
-        address newImplementation = address(new Arbitrum_Forwarder());
+        address newImplementation = address(new Arbitrum_Forwarder(WETH9Interface(address(l2Weth))));
         vm.startPrank(random);
         vm.expectRevert();
         arbitrumForwarder.upgradeTo(newImplementation);


### PR DESCRIPTION
> When tokens are being bridged from L1 to L3, the Router_Adapter contract bridges the token to the forwarder on L2 and sends an additional transaction, which causes the forwarder to relay the tokens to L3. The L2 token passed to that transaction is taken from the poolRebalanceRoute function of the HubPool. The problem is that it doesn't always correspond to the real token being bridged. For example, for WETH on Ethereum, the poolRebalanceRoute returns the WETH address on Optimism, but whenever WETH is bridged to Optimism by the Optimism_Adapter contract, ETH is in fact bridged. It means that assets will be correctly transferred to L2, but they will not be transferred to L3 by the forwarder as it will receive a different token than the one it will attempt to transfer. 

The fix is similar to the one [here](https://github.com/across-protocol/contracts/pull/648). We automatically wrap incoming native token transfers except for when we are calling the native token contract to withdraw. This should allow the contract to keep all of its native token supply in a wrapped balance, thereby also keeping the token addresses passed in on L1 correct.