### PR TITLE
fix(svm): check invalid refund leaf

### DIFF
--- a/programs/svm-spoke/src/error.rs
+++ b/programs/svm-spoke/src/error.rs
@@ -63,6 +63,8 @@ pub enum CustomError {
     InvalidMint,
     #[msg("Leaf already claimed!")]
     ClaimedMerkleLeaf,
+    #[msg("Invalid Merkle leaf!")]
+    InvalidMerkleLeaf,
     #[msg("Exceeded pending bridge amount to HubPool!")]
     ExceededPendingBridgeAmount,
     #[msg("Deposits are currently paused!")]

--- a/programs/svm-spoke/src/instructions/bundle.rs
+++ b/programs/svm-spoke/src/instructions/bundle.rs
@@ -138,6 +138,10 @@ pub fn execute_relayer_refund_leaf<'info>(
     // TODO: execute remaining parts of leaf structure such as amountToReturn.
     // TODO: emit events.
 
+    if relayer_refund_leaf.refund_accounts.len() != relayer_refund_leaf.refund_amounts.len() {
+        return err!(CustomError::InvalidMerkleLeaf);
+    }
+
     // Derive the signer seeds for the state. The vault owns the state PDA so we need to derive this to create the
     // signer seeds to execute the CPI transfer from the vault to the refund recipient.
     let state_seed_bytes = state.seed.to_le_bytes();


### PR DESCRIPTION
SVM implementation of SpokePool lacked the check on the matching length for refund account and amount arrays when executing relayer refund leaf.