### PR TITLE
fix(svm): remove msg logs

### DIFF
--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -147,9 +147,6 @@ pub fn fill_v3_relay(
     fill_status_account.status = FillStatus::Filled;
     fill_status_account.relayer = *ctx.accounts.signer.key;
 
-    // TODO: remove msg! everywhere
-    msg!("Tokens transferred successfully.");
-
     // TODO: there might be a better way to do this
     // Emit the FilledV3Relay event
     let message_clone = relay_data.message.clone(); // Clone the message before it is moved

--- a/programs/svm-spoke/src/utils/merkle_proof_utils.rs
+++ b/programs/svm-spoke/src/utils/merkle_proof_utils.rs
@@ -5,19 +5,15 @@ use crate::{error::CustomError, instructions::V3RelayData};
 pub fn get_v3_relay_hash(relay_data: &V3RelayData, chain_id: u64) -> [u8; 32] {
     let mut input = relay_data.try_to_vec().unwrap();
     input.extend_from_slice(&chain_id.to_le_bytes());
-    // Log the input that will be hashed
-    msg!("Input to be hashed: {:?}", input);
     keccak::hash(&input).0
 }
 
 pub fn verify_merkle_proof(root: [u8; 32], leaf: [u8; 32], proof: Vec<[u8; 32]>) -> Result<()> {
-    msg!("Verifying merkle proof");
     let computed_root = process_proof(&proof, &leaf);
     if computed_root != root {
-        msg!("Invalid proof: computed root does not match provided root");
         return err!(CustomError::InvalidMerkleProof);
     }
-    msg!("Merkle proof verified successfully");
+
     Ok(())
 }
 

--- a/programs/test/src/lib.rs
+++ b/programs/test/src/lib.rs
@@ -74,10 +74,9 @@ pub mod test {
     ) -> Result<()> {
         let computed_root = process_proof(&proof, &leaf);
         if computed_root != root {
-            msg!("Invalid proof: computed root does not match provided root");
             return err!(CustomError::InvalidMerkleProof);
         }
-        msg!("Merkle proof verified successfully");
+
         Ok(())
     }
 


### PR DESCRIPTION
msg logs are memory expensive, especially when formatting variables.

fixes: https://linear.app/uma/issue/ACX-2930/instructionsfillrs-remove-msg-everywhere