### PR TITLE
fix(svm): use pubkey in origin token

### DIFF
--- a/programs/svm-spoke/src/instructions/admin.rs
+++ b/programs/svm-spoke/src/instructions/admin.rs
@@ -147,7 +147,7 @@ pub fn set_cross_domain_admin(
 
 #[event_cpi]
 #[derive(Accounts)]
-#[instruction(origin_token: [u8; 32], destination_chain_id: u64)] // TODO: is it possible to replace origin_token with Pubkey?
+#[instruction(origin_token: Pubkey, destination_chain_id: u64)]
 pub struct SetEnableRoute<'info> {
     #[account(
         mut,
@@ -182,8 +182,8 @@ pub struct SetEnableRoute<'info> {
 
     #[account(
         mint::token_program = token_program,
-        // IDL build fails when requiring `address = input_token` for mint, thus using a custom constraint.
-        constraint = origin_token_mint.key() == origin_token.into() @ CustomError::InvalidMint
+        // IDL build fails when requiring `address = origin_token` for mint, thus using a custom constraint.
+        constraint = origin_token_mint.key() == origin_token @ CustomError::InvalidMint
     )]
     pub origin_token_mint: InterfaceAccount<'info, Mint>,
 
@@ -194,14 +194,14 @@ pub struct SetEnableRoute<'info> {
 
 pub fn set_enable_route(
     ctx: Context<SetEnableRoute>,
-    origin_token: [u8; 32],
+    origin_token: Pubkey,
     destination_chain_id: u64,
     enabled: bool,
 ) -> Result<()> {
     ctx.accounts.route.enabled = enabled;
 
     emit_cpi!(EnabledDepositRoute {
-        origin_token: Pubkey::new_from_array(origin_token),
+        origin_token,
         destination_chain_id,
         enabled,
     });

--- a/programs/svm-spoke/src/instructions/handle_receive_message.rs
+++ b/programs/svm-spoke/src/instructions/handle_receive_message.rs
@@ -77,7 +77,7 @@ fn translate_message(data: &Vec<u8>) -> Result<Vec<u8>> {
         }
         // TODO: Make sure to change EVM SpokePool interface using bytes32 for token addresses and uint64 for chain IDs.
         s if s == utils::encode_solidity_selector("setEnableRoute(bytes32,uint64,bool)") => {
-            let origin_token = utils::get_solidity_arg(data, 0)?;
+            let origin_token = Pubkey::new_from_array(utils::get_solidity_arg(data, 0)?);
             let destination_chain_id =
                 utils::decode_solidity_uint64(&utils::get_solidity_arg(data, 1)?)?;
             let enabled = utils::decode_solidity_bool(&utils::get_solidity_arg(data, 2)?)?;

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -79,7 +79,7 @@ pub mod svm_spoke {
 
     pub fn set_enable_route(
         ctx: Context<SetEnableRoute>,
-        origin_token: [u8; 32],
+        origin_token: Pubkey,
         destination_chain_id: u64,
         enabled: bool,
     ) -> Result<()> {

--- a/scripts/svm/enableRoute.ts
+++ b/scripts/svm/enableRoute.ts
@@ -25,7 +25,7 @@ const argv = yargs(hideBin(process.argv))
 async function enableRoute(): Promise<void> {
   const resolvedArgv = await argv;
   const seed = new BN(resolvedArgv.seed);
-  const originToken = Array.from(new PublicKey(resolvedArgv.originToken).toBytes());
+  const originToken = new PublicKey(resolvedArgv.originToken);
   const chainId = new BN(resolvedArgv.chainId);
   const enabled = resolvedArgv.enabled;
 
@@ -37,7 +37,7 @@ async function enableRoute(): Promise<void> {
 
   // Define the route account PDA
   const [routePda] = PublicKey.findProgramAddressSync(
-    [Buffer.from("route"), Buffer.from(originToken), statePda.toBytes(), chainId.toArrayLike(Buffer, "le", 8)],
+    [Buffer.from("route"), originToken.toBytes(), statePda.toBytes(), chainId.toArrayLike(Buffer, "le", 8)],
     programId
   );
 
@@ -47,7 +47,7 @@ async function enableRoute(): Promise<void> {
   console.log("Enabling route...");
   console.table([
     { Property: "seed", Value: seed.toString() },
-    { Property: "originToken", Value: new PublicKey(originToken).toString() },
+    { Property: "originToken", Value: originToken.toString() },
     { Property: "chainId", Value: chainId.toString() },
     { Property: "enabled", Value: enabled },
     { Property: "programId", Value: programId.toString() },
@@ -58,7 +58,7 @@ async function enableRoute(): Promise<void> {
 
   // Create ATA for the origin token to be stored by state (vault).
   const vault = getAssociatedTokenAddressSync(
-    new PublicKey(originToken),
+    originToken,
     statePda,
     true,
     TOKEN_PROGRAM_ID,
@@ -72,7 +72,7 @@ async function enableRoute(): Promise<void> {
       state: statePda,
       route: routePda,
       vault: vault,
-      originTokenMint: new PublicKey(originToken),
+      originTokenMint: originToken,
       tokenProgram: TOKEN_PROGRAM_ID,
       associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
       systemProgram: SystemProgram.programId,

--- a/test/svm/SvmSpoke.Deposit.ts
+++ b/test/svm/SvmSpoke.Deposit.ts
@@ -48,10 +48,7 @@ describe("svm_spoke.deposit", () => {
       systemProgram: anchor.web3.SystemProgram.programId,
     };
 
-    await program.methods
-      .setEnableRoute(Array.from(inputToken.toBuffer()), routeChainId, true)
-      .accounts(setEnableRouteAccounts)
-      .rpc();
+    await program.methods.setEnableRoute(inputToken, routeChainId, true).accounts(setEnableRouteAccounts).rpc();
 
     // Set known fields in the depositData.
     depositData.depositor = depositor.publicKey;
@@ -197,7 +194,7 @@ describe("svm_spoke.deposit", () => {
   it("Fails to deposit tokens to a route that is explicitly disabled", async () => {
     // Disable the route
     await program.methods
-      .setEnableRoute(Array.from(depositData.inputToken!.toBuffer()), depositData.destinationChainId, false)
+      .setEnableRoute(depositData.inputToken!, depositData.destinationChainId, false)
       .accounts(setEnableRouteAccounts)
       .rpc();
 
@@ -363,10 +360,7 @@ describe("svm_spoke.deposit", () => {
       program: program.programId,
     };
 
-    await program.methods
-      .setEnableRoute(Array.from(inputToken.toBuffer()), fakeRouteChainId, true)
-      .accounts(fakeSetEnableRouteAccounts)
-      .rpc();
+    await program.methods.setEnableRoute(inputToken, fakeRouteChainId, true).accounts(fakeSetEnableRouteAccounts).rpc();
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 

--- a/test/svm/SvmSpoke.Routes.ts
+++ b/test/svm/SvmSpoke.Routes.ts
@@ -43,10 +43,7 @@ describe("svm_spoke.routes", () => {
 
   it("Sets, retrieves, and controls access to route enablement", async () => {
     // Enable the route as owner
-    await program.methods
-      .setEnableRoute(Array.from(tokenMint.toBytes()), routeChainId, true)
-      .accounts(setEnableRouteAccounts)
-      .rpc();
+    await program.methods.setEnableRoute(tokenMint, routeChainId, true).accounts(setEnableRouteAccounts).rpc();
     await new Promise((resolve) => setTimeout(resolve, 500));
 
     // Retrieve and verify the route is enabled
@@ -63,10 +60,7 @@ describe("svm_spoke.routes", () => {
     assert.isTrue(event.enabled, "enabledDepositRoute enabled");
 
     // Disable the route as owner
-    await program.methods
-      .setEnableRoute(Array.from(tokenMint.toBytes()), routeChainId, false)
-      .accounts(setEnableRouteAccounts)
-      .rpc();
+    await program.methods.setEnableRoute(tokenMint, routeChainId, false).accounts(setEnableRouteAccounts).rpc();
     await new Promise((resolve) => setTimeout(resolve, 500));
 
     // Retrieve and verify the route is disabled
@@ -85,7 +79,7 @@ describe("svm_spoke.routes", () => {
     // Try to enable the route as non-owner
     try {
       await program.methods
-        .setEnableRoute(Array.from(tokenMint.toBytes()), routeChainId, true)
+        .setEnableRoute(tokenMint, routeChainId, true)
         .accounts({ ...setEnableRouteAccounts, signer: nonOwner.publicKey })
         .signers([nonOwner])
         .rpc();
@@ -113,7 +107,7 @@ describe("svm_spoke.routes", () => {
 
     try {
       await program.methods
-        .setEnableRoute(Array.from(wrongOriginToken.toBytes()), routeChainId, true)
+        .setEnableRoute(wrongOriginToken, routeChainId, true)
         .accounts({ ...setEnableRouteAccounts, route: wrongRoutePda })
         .rpc();
       assert.fail("Setting route with wrong origin token should fail");


### PR DESCRIPTION
It is easier to use Pubkey as origin_token parameter in set_enable_route.

Fixes: https://linear.app/uma/issue/ACX-2917/instructionsadminrs-is-it-possible-to-replace-origin-token-with-pubkey