### PR TITLE
fix(svm): remove redundant mutables

### DIFF
--- a/programs/svm-spoke/src/instructions/admin.rs
+++ b/programs/svm-spoke/src/instructions/admin.rs
@@ -58,7 +58,6 @@ pub fn initialize(
 #[derive(Accounts)]
 pub struct PauseDeposits<'info> {
     #[account(
-        mut,
         constraint = is_local_or_remote_owner(&signer, &state) @ CustomError::NotOwner
     )]
     pub signer: Signer<'info>,
@@ -80,7 +79,6 @@ pub fn pause_deposits(ctx: Context<PauseDeposits>, pause: bool) -> Result<()> {
 #[derive(Accounts)]
 pub struct PauseFills<'info> {
     #[account(
-        mut,
         constraint = is_local_or_remote_owner(&signer, &state) @ CustomError::NotOwner
     )]
     pub signer: Signer<'info>,
@@ -104,7 +102,6 @@ pub struct TransferOwnership<'info> {
     pub state: Account<'info, State>,
 
     #[account(
-        mut,
         address = state.owner @ CustomError::NotOwner // TODO: test permissioning with a multi-sig and Squads
     )]
     pub signer: Signer<'info>,
@@ -121,7 +118,6 @@ pub fn transfer_ownership(ctx: Context<TransferOwnership>, new_owner: Pubkey) ->
 #[derive(Accounts)]
 pub struct SetCrossDomainAdmin<'info> {
     #[account(
-        mut,
         constraint = is_local_or_remote_owner(&signer, &state) @ CustomError::NotOwner
     )]
     pub signer: Signer<'info>,
@@ -150,7 +146,6 @@ pub fn set_cross_domain_admin(
 #[instruction(origin_token: Pubkey, destination_chain_id: u64)]
 pub struct SetEnableRoute<'info> {
     #[account(
-        mut,
         constraint = is_local_or_remote_owner(&signer, &state) @ CustomError::NotOwner
     )]
     pub signer: Signer<'info>,
@@ -158,8 +153,7 @@ pub struct SetEnableRoute<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
 
-    // TODO: check if state needs to be mut here and in other places
-    #[account(mut, seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
+    #[account(seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
     pub state: Account<'info, State>,
 
     #[account(
@@ -212,7 +206,7 @@ pub fn set_enable_route(
 #[derive(Accounts)]
 pub struct RelayRootBundle<'info> {
     #[account(
-        mut,
+        mut, // TODO: remove this mut and have separate payer when adding support to invoke this via CCTP.
         constraint = is_local_or_remote_owner(&signer, &state) @ CustomError::NotOwner
     )]
     pub signer: Signer<'info>,

--- a/programs/svm-spoke/src/instructions/bundle.rs
+++ b/programs/svm-spoke/src/instructions/bundle.rs
@@ -20,7 +20,7 @@ pub struct ExecuteRelayerRefundLeaf<'info> {
     )]
     pub instruction_params: Account<'info, ExecuteRelayerRefundLeafParams>,
 
-    #[account(mut, seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
+    #[account(seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
     pub state: Account<'info, State>,
 
     #[account(
@@ -47,7 +47,6 @@ pub struct ExecuteRelayerRefundLeaf<'info> {
     pub vault: InterfaceAccount<'info, TokenAccount>,
 
     #[account(
-        mut,
         mint::token_program = token_program,
         address = instruction_params.relayer_refund_leaf.mint_public_key @ CustomError::InvalidMint
     )]
@@ -119,7 +118,7 @@ where
     let relayer_refund_leaf = instruction_params.relayer_refund_leaf.to_owned();
     let proof = instruction_params.proof.to_owned();
 
-    let state = &mut ctx.accounts.state;
+    let state = &ctx.accounts.state;
 
     let root = ctx.accounts.root_bundle.relayer_refund_root;
     let leaf = relayer_refund_leaf.to_keccak_hash();

--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -36,10 +36,9 @@ pub struct DepositV3<'info> {
     pub state: Account<'info, State>,
 
     // TODO: linter to format this line
-    #[account(mut, seeds = [b"route", input_token.as_ref(), state.key().as_ref(), destination_chain_id.to_le_bytes().as_ref()], bump)]
+    #[account(seeds = [b"route", input_token.as_ref(), state.key().as_ref(), destination_chain_id.to_le_bytes().as_ref()], bump)]
     pub route: Account<'info, Route>,
 
-    #[account(mut)]
     pub signer: Signer<'info>,
 
     #[account(
@@ -60,7 +59,6 @@ pub struct DepositV3<'info> {
 
     // TODO: why are we using mint::token_program,token::token_program and associated_token::token_program?
     #[account(
-        mut,
         mint::token_program = token_program,
         // IDL build fails when requiring `address = input_token` for mint, thus using a custom constraint.
         constraint = mint.key() == input_token @ CustomError::InvalidMint

--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -18,7 +18,6 @@ use crate::{
 #[instruction(relay_hash: [u8; 32], relay_data: V3RelayData)]
 pub struct FillV3Relay<'info> {
     #[account(
-        mut,
         seeds = [b"state", state.seed.to_le_bytes().as_ref()], // TODO: make consistent decision where to put owner constraints
         bump,
         constraint = !state.paused_fills @ CustomError::FillsArePaused
@@ -28,17 +27,14 @@ pub struct FillV3Relay<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(mut)]
     pub relayer: SystemAccount<'info>, // TODO: should this be the same as signer?
 
     #[account(
-        mut,
         address = relay_data.recipient @ CustomError::InvalidFillRecipient
     )]
     pub recipient: SystemAccount<'info>, // TODO: this might be redundant.
 
     #[account(
-        mut,
         token::token_program = token_program, // TODO: consistent token imports
         address = relay_data.output_token @ CustomError::InvalidMint
     )]
@@ -100,7 +96,7 @@ pub fn fill_v3_relay(
     relay_data: V3RelayData,
     repayment_chain_id: u64,
 ) -> Result<()> {
-    let state = &mut ctx.accounts.state;
+    let state = &ctx.accounts.state;
     let current_time = get_current_time(state)?;
 
     // Check if the exclusivity deadline has passed or if the caller is the exclusive relayer
@@ -181,7 +177,7 @@ pub fn fill_v3_relay(
 #[derive(Accounts)]
 #[instruction(relay_hash: [u8; 32], relay_data: V3RelayData)]
 pub struct CloseFillPda<'info> {
-    #[account(mut, seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
+    #[account(seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
     pub state: Account<'info, State>,
 
     #[account(
@@ -206,7 +202,7 @@ pub fn close_fill_pda(
     _relay_hash: [u8; 32], // TODO: check if we can use underscore in functions while in context macro leave as is?
     relay_data: V3RelayData,
 ) -> Result<()> {
-    let state = &mut ctx.accounts.state;
+    let state = &ctx.accounts.state;
     let current_time = get_current_time(state)?;
 
     // Check if the fill status is filled

--- a/programs/svm-spoke/src/instructions/handle_receive_message.rs
+++ b/programs/svm-spoke/src/instructions/handle_receive_message.rs
@@ -48,10 +48,7 @@ pub struct HandleReceiveMessageParams {
 }
 
 impl<'info> HandleReceiveMessage<'info> {
-    pub fn handle_receive_message(
-        &mut self,
-        params: &HandleReceiveMessageParams,
-    ) -> Result<Vec<u8>> {
+    pub fn handle_receive_message(&self, params: &HandleReceiveMessageParams) -> Result<Vec<u8>> {
         // Return instruction data for the self invoked CPI based on the received message body.
         translate_message(&params.message_body)
     }
@@ -100,9 +97,10 @@ pub fn invoke_self<'info>(
 
     let mut accounts = Vec::with_capacity(1 + ctx.remaining_accounts.len());
 
-    // Signer in self-invoked instructions is mutable when called by owner on Solana.
-    // We might need to reconsider signer to be separate from fee payer and self_authority can become read-only.
-    accounts.push(AccountMeta::new(ctx.accounts.self_authority.key(), true));
+    accounts.push(AccountMeta::new_readonly(
+        ctx.accounts.self_authority.key(),
+        true,
+    ));
 
     for acc in ctx.remaining_accounts {
         if acc.is_writable {

--- a/programs/svm-spoke/src/instructions/instruction_params.rs
+++ b/programs/svm-spoke/src/instructions/instruction_params.rs
@@ -24,7 +24,6 @@ pub struct InitializeInstructionParams<'info> {
 #[derive(Accounts)]
 #[instruction(offset: u32, fragment: Vec<u8>)]
 pub struct WriteInstructionParamsFragment<'info> {
-    #[account(mut)]
     pub signer: Signer<'info>,
 
     /// CHECK: use unchecked account in order to be able writing raw data fragments.

--- a/programs/svm-spoke/src/instructions/refund_claims.rs
+++ b/programs/svm-spoke/src/instructions/refund_claims.rs
@@ -42,7 +42,6 @@ pub fn initialize_claim_account(
 #[event_cpi]
 #[derive(Accounts)]
 pub struct ClaimRelayerRefund<'info> {
-    #[account(mut)]
     pub signer: Signer<'info>,
 
     /// CHECK: We don't need any additional checks as long as this is the same account that initialized the claim account.
@@ -52,7 +51,7 @@ pub struct ClaimRelayerRefund<'info> {
     )]
     pub initializer: UncheckedAccount<'info>,
 
-    #[account(mut, seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
+    #[account(seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
     pub state: Account<'info, State>,
 
     #[account(

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -21,7 +21,6 @@ use crate::V3RelayData; // Pulled type definition from fill.rs.
 #[instruction(relay_hash: [u8; 32], relay_data: V3RelayData)]
 pub struct SlowFillV3Relay<'info> {
     #[account(
-        mut,
         seeds = [b"state", state.seed.to_le_bytes().as_ref()],
         bump,
         constraint = !state.paused_fills @ CustomError::FillsArePaused
@@ -49,7 +48,7 @@ pub fn request_v3_slow_fill(
     relay_hash: [u8; 32], // include in props, while not using it, to enable us to access it from the #Instruction Attribute within the accounts. This enables us to pass in the relay_hash PDA.
     relay_data: V3RelayData,
 ) -> Result<()> {
-    let state = &mut ctx.accounts.state;
+    let state = &ctx.accounts.state;
 
     let current_time = get_current_time(state)?;
 
@@ -132,13 +131,12 @@ impl V3SlowFill {
 #[derive(Accounts)]
 #[instruction(relay_hash: [u8; 32], slow_fill_leaf: V3SlowFill, root_bundle_id: u32)]
 pub struct ExecuteV3SlowRelayLeaf<'info> {
-    #[account(mut, seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
+    #[account(seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
     pub state: Account<'info, State>,
 
-    #[account(mut, seeds =[b"root_bundle", state.key().as_ref(), root_bundle_id.to_le_bytes().as_ref()], bump)]
+    #[account(seeds =[b"root_bundle", state.key().as_ref(), root_bundle_id.to_le_bytes().as_ref()], bump)]
     pub root_bundle: Account<'info, RootBundle>,
 
-    #[account(mut)]
     pub signer: Signer<'info>,
 
     #[account(
@@ -151,13 +149,11 @@ pub struct ExecuteV3SlowRelayLeaf<'info> {
     pub fill_status: Account<'info, FillStatusAccount>,
 
     #[account(
-        mut,
         address = slow_fill_leaf.relay_data.recipient @ CustomError::InvalidFillRecipient
     )]
     pub recipient: SystemAccount<'info>,
 
     #[account(
-        mut,
         token::token_program = token_program,
         address = slow_fill_leaf.relay_data.output_token @ CustomError::InvalidMint
     )]

--- a/programs/svm-spoke/src/instructions/testable.rs
+++ b/programs/svm-spoke/src/instructions/testable.rs
@@ -7,7 +7,6 @@ pub struct SetCurrentTime<'info> {
     #[account(mut, seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
     pub state: Account<'info, State>,
 
-    #[account(mut)]
     pub signer: Signer<'info>,
 }
 

--- a/programs/svm-spoke/src/instructions/token_bridge.rs
+++ b/programs/svm-spoke/src/instructions/token_bridge.rs
@@ -13,7 +13,6 @@ use crate::{
 
 #[derive(Accounts)]
 pub struct BridgeTokensToHubPool<'info> {
-    #[account(mut)]
     pub signer: Signer<'info>,
 
     #[account(mut)]
@@ -22,7 +21,7 @@ pub struct BridgeTokensToHubPool<'info> {
     #[account(mut, mint::token_program = token_program)]
     pub mint: InterfaceAccount<'info, Mint>,
 
-    #[account(mut, seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
+    #[account(seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
     pub state: Account<'info, State>,
 
     #[account(mut, seeds = [b"transfer_liability", mint.key().as_ref()], bump)]

--- a/scripts/svm/remotePauseDeposits.ts
+++ b/scripts/svm/remotePauseDeposits.ts
@@ -176,8 +176,7 @@ async function remotePauseDeposits(): Promise<void> {
   // self_authority in HandleReceiveMessage accounts, also signer in self-invoked CPIs.
   remainingAccounts.push({
     isSigner: false,
-    // signer in self-invoked CPIs is mutable, as Solana owner is also fee payer when not using CCTP.
-    isWritable: true,
+    isWritable: false,
     pubkey: selfAuthority,
   });
   // program in HandleReceiveMessage accounts.

--- a/test/svm/SvmSpoke.HandleReceiveMessage.ts
+++ b/test/svm/SvmSpoke.HandleReceiveMessage.ts
@@ -323,7 +323,7 @@ describe("svm_spoke.handle_receive_message", () => {
     // state in self-invoked SetEnableRoute.
     enableRouteRemainingAccounts.push({
       isSigner: false,
-      isWritable: true,
+      isWritable: false,
       pubkey: state,
     });
     // route in self-invoked SetEnableRoute.

--- a/test/svm/SvmSpoke.HandleReceiveMessage.ts
+++ b/test/svm/SvmSpoke.HandleReceiveMessage.ts
@@ -82,8 +82,7 @@ describe("svm_spoke.handle_receive_message", () => {
     // self_authority in HandleReceiveMessage accounts, also signer in self-invoked CPIs.
     remainingAccounts.push({
       isSigner: false,
-      // signer in self-invoked CPIs is mutable, as Solana owner is also fee payer when not using CCTP.
-      isWritable: true,
+      isWritable: false,
       pubkey: selfAuthority,
     });
     // program in HandleReceiveMessage accounts.


### PR DESCRIPTION
Removes redundant mutables. This also allows changing the signer PDA in self-invoked remote CCTP calls to readonly.

Fixes: https://linear.app/uma/issue/ACX-2918/instructionsadminrs-check-if-state-needs-to-be-mut-here-and-in-other