### PR TITLE
fix(svm): close claim account manually

### DIFF
--- a/programs/svm-spoke/src/error.rs
+++ b/programs/svm-spoke/src/error.rs
@@ -80,6 +80,8 @@ pub enum CustomError {
     InvalidRefund,
     #[msg("Zero relayer refund claim!")]
     ZeroRefundClaim,
+    #[msg("Cannot close non-zero relayer refund claim!")]
+    NonZeroRefundClaim,
     #[msg("Invalid claim initializer!")]
     InvalidClaimInitializer,
 }

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -219,4 +219,12 @@ pub mod svm_spoke {
     pub fn claim_relayer_refund(ctx: Context<ClaimRelayerRefund>) -> Result<()> {
         instructions::claim_relayer_refund(ctx)
     }
+
+    pub fn close_claim_account(
+        ctx: Context<CloseClaimAccount>,
+        _mint: Pubkey, // Only used in account constraints.
+        _token_account: Pubkey, // Only used in account constraints.
+    ) -> Result<()> {
+        instructions::close_claim_account(ctx)
+    }
 }

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -222,7 +222,7 @@ pub mod svm_spoke {
 
     pub fn close_claim_account(
         ctx: Context<CloseClaimAccount>,
-        _mint: Pubkey, // Only used in account constraints.
+        _mint: Pubkey,          // Only used in account constraints.
         _token_account: Pubkey, // Only used in account constraints.
     ) -> Result<()> {
         instructions::close_claim_account(ctx)

--- a/test/svm/SvmSpoke.RefundClaims.ts
+++ b/test/svm/SvmSpoke.RefundClaims.ts
@@ -268,4 +268,56 @@ describe("svm_spoke.refund_claims", () => {
     assertSE(BigInt(iVaultBal) - BigInt(fVaultBal), relayerRefund, "Vault balance");
     assertSE(BigInt(fRelayerBal) - BigInt(iRelayerBal), relayerRefund, "Relayer balance");
   });
+
+  it("Close empty claim account", async () => {
+    // Initialize the claim account.
+    await initializeClaimAccount(claimInitializer);
+
+    // Should not be able to close the claim account from default wallet as the initializer was different.
+    try {
+      await program.methods.closeClaimAccount(mint, tokenAccount).accounts({ signer: payer.publicKey }).rpc();
+      assert.fail("Closing claim account from different initializer should fail");
+    } catch (error: any) {
+      assert.instanceOf(error, AnchorError);
+      assert.strictEqual(
+        error.error.errorCode.code,
+        "InvalidClaimInitializer",
+        "Expected error code InvalidClaimInitializer"
+      );
+    }
+
+    // Close the claim account from initializer before executing relayer refunds.
+    await program.methods
+      .closeClaimAccount(mint, tokenAccount)
+      .accounts({ signer: claimInitializer.publicKey })
+      .signers([claimInitializer])
+      .rpc();
+
+    // Claim account should be closed now.
+    try {
+      await program.account.claimAccount.fetch(claimAccount);
+      assert.fail("Claim account should be closed");
+    } catch (error: any) {
+      assert.include(error.toString(), "Account does not exist or has no data", "Expected non-existent account error");
+    }
+  });
+
+  it("Cannot close non-empty claim account", async () => {
+    // Execute relayer refund using claim account.
+    const relayerRefund = new BN(500000);
+    await executeRelayerRefundToClaim(relayerRefund);
+
+    // It should be not possible to close the claim account with non-zero refund liability.
+    try {
+      await program.methods
+        .closeClaimAccount(mint, tokenAccount)
+        .accounts({ signer: claimInitializer.publicKey })
+        .signers([claimInitializer])
+        .rpc();
+      assert.fail("Closing claim account with non-zero refund liability should fail");
+    } catch (error: any) {
+      assert.instanceOf(error, AnchorError);
+      assert.strictEqual(error.error.errorCode.code, "NonZeroRefundClaim", "Expected error code NonZeroRefundClaim");
+    }
+  });
 });


### PR DESCRIPTION
Though claim accounts are being closed automatically when claiming the refund, there might be a scenario where relayer refunds were executed with ATA after initializing the claim account. In such cases, the initializer should be able to close the claim account manually.

Fixes: https://linear.app/uma/issue/ACX-3024/instructionsrefund-claimsrs-add-manual-instruction-to-close-claim
