### PR TITLE
test: multi-chain verifiable merkle tree

### DIFF
--- a/test/evm/hardhat/SpokePool.ExecuteRootBundle.ts
+++ b/test/evm/hardhat/SpokePool.ExecuteRootBundle.ts
@@ -1,4 +1,5 @@
 import { SignerWithAddress, seedContract, toBN, expect, Contract, ethers, BigNumber } from "../../../utils/utils";
+import { buildRelayerRefundMerkleTree } from "../../svm/utils";
 import * as consts from "./constants";
 import { spokePoolFixture } from "./fixtures/SpokePool.Fixture";
 import { buildRelayerRefundTree, buildRelayerRefundLeaves } from "./MerkleLib.utils";
@@ -74,6 +75,78 @@ describe("SpokePool Root Bundle Execution", function () {
     expect(relayTokensEvents.length).to.equal(2);
     tokensBridgedEvents = await spokePool.queryFilter(spokePool.filters.TokensBridged());
     expect(tokensBridgedEvents.length).to.equal(1);
+  });
+
+  it("Execute relayer root correctly with mixed solana and evm leaves", async function () {
+    const totalDistributions = 10;
+    const evmDistributions = totalDistributions / 2;
+    const { relayerRefundLeaves: leaves, merkleTree: tree } = buildRelayerRefundMerkleTree({
+      totalEvmDistributions: evmDistributions,
+      totalSolanaDistributions: evmDistributions,
+      mixLeaves: true,
+      chainId: destinationChainId,
+      evmTokenAddress: destErc20.address,
+      evmRelayers: [relayer.address, rando.address],
+      evmRefundAmounts: [consts.amountToRelay.div(evmDistributions), consts.amountToRelay.div(evmDistributions)],
+    });
+
+    const leavesRefundAmount = leaves
+      .filter((leaf) => !leaf.isSolana)
+      .map((leaf) => (leaf.refundAmounts as BigNumber[]).reduce((bn1, bn2) => bn1.add(bn2), toBN(0)))
+      .reduce((bn1, bn2) => bn1.add(bn2), toBN(0));
+
+    // Store new tree.
+    await spokePool.connect(dataWorker).relayRootBundle(
+      tree.getHexRoot(), // relayer refund root. Generated from the merkle tree constructed before.
+      consts.mockSlowRelayRoot
+    );
+
+    // Distribute all non-Solana leaves.
+    for (let i = 0; i < leaves.length; i++) {
+      if (leaves[i].isSolana) continue;
+      await spokePool.connect(dataWorker).executeRelayerRefundLeaf(0, leaves[i], tree.getHexProof(leaves[i]));
+    }
+
+    // Relayers should be refunded
+    expect(await destErc20.balanceOf(spokePool.address)).to.equal(consts.amountHeldByPool.sub(leavesRefundAmount));
+    expect(await destErc20.balanceOf(relayer.address)).to.equal(consts.amountToRelay);
+    expect(await destErc20.balanceOf(rando.address)).to.equal(consts.amountToRelay);
+  });
+
+  it("Execute relayer root correctly with sorted solana and evm leaves", async function () {
+    const totalDistributions = 10;
+    const evmDistributions = totalDistributions / 2;
+    const { relayerRefundLeaves: leaves, merkleTree: tree } = buildRelayerRefundMerkleTree({
+      totalEvmDistributions: evmDistributions,
+      totalSolanaDistributions: evmDistributions,
+      mixLeaves: false,
+      chainId: destinationChainId,
+      evmTokenAddress: destErc20.address,
+      evmRelayers: [relayer.address, rando.address],
+      evmRefundAmounts: [consts.amountToRelay.div(evmDistributions), consts.amountToRelay.div(evmDistributions)],
+    });
+
+    const leavesRefundAmount = leaves
+      .filter((leaf) => !leaf.isSolana)
+      .map((leaf) => (leaf.refundAmounts as BigNumber[]).reduce((bn1, bn2) => bn1.add(bn2), toBN(0)))
+      .reduce((bn1, bn2) => bn1.add(bn2), toBN(0));
+
+    // Store new tree.
+    await spokePool.connect(dataWorker).relayRootBundle(
+      tree.getHexRoot(), // relayer refund root. Generated from the merkle tree constructed before.
+      consts.mockSlowRelayRoot
+    );
+
+    // Distribute all non-Solana leaves.
+    for (let i = 0; i < leaves.length; i++) {
+      if (leaves[i].isSolana) continue;
+      await spokePool.connect(dataWorker).executeRelayerRefundLeaf(0, leaves[i], tree.getHexProof(leaves[i]));
+    }
+
+    // Relayers should be refunded
+    expect(await destErc20.balanceOf(spokePool.address)).to.equal(consts.amountHeldByPool.sub(leavesRefundAmount));
+    expect(await destErc20.balanceOf(relayer.address)).to.equal(consts.amountToRelay);
+    expect(await destErc20.balanceOf(rando.address)).to.equal(consts.amountToRelay);
   });
 
   it("Execution rejects invalid leaf, tree, proof combinations", async function () {

--- a/test/svm/SvmSpoke.Bundle.ts
+++ b/test/svm/SvmSpoke.Bundle.ts
@@ -15,7 +15,6 @@ import {
   TransactionMessage,
   VersionedTransaction,
 } from "@solana/web3.js";
-import { MerkleTree } from "@uma/common/dist/MerkleTree";
 import { assert } from "chai";
 import * as crypto from "crypto";
 import { common } from "./SvmSpoke.common";
@@ -29,6 +28,7 @@ import {
   RelayerRefundLeafSolana,
   RelayerRefundLeafType,
 } from "./utils";
+import { MerkleTree } from "../../utils";
 
 const { provider, program, owner, initializeState, connection, chainId, assertSE } = common;
 

--- a/test/svm/SvmSpoke.Bundle.ts
+++ b/test/svm/SvmSpoke.Bundle.ts
@@ -546,6 +546,101 @@ describe("svm_spoke.bundle", () => {
     );
   });
 
+  it("Test Merkle Proof Verification with Sorted Solana and EVM Leaves", async () => {
+    const evmDistributions = 5;
+    const solanaDistributions = 5;
+    const { relayerRefundLeaves, merkleTree } = buildRelayerRefundMerkleTree({
+      totalEvmDistributions: evmDistributions,
+      totalSolanaDistributions: solanaDistributions,
+      mixLeaves: false,
+      chainId: chainId.toNumber(),
+      mint,
+      svmRelayers: [relayerTA, relayerTB],
+      svmRefundAmounts: [new BN(randomBigInt(2).toString()), new BN(randomBigInt(2).toString())],
+    });
+
+    const root = merkleTree.getRoot();
+    let stateAccountData = await program.account.state.fetch(state);
+    const rootBundleId = stateAccountData.rootBundleId;
+    const rootBundleIdBuffer = Buffer.alloc(4);
+    rootBundleIdBuffer.writeUInt32LE(rootBundleId);
+    const seeds = [Buffer.from("root_bundle"), state.toBuffer(), rootBundleIdBuffer];
+    const [rootBundle] = PublicKey.findProgramAddressSync(seeds, program.programId);
+
+    // Relay root bundle
+    let relayRootBundleAccounts = { state, rootBundle, signer: owner, program: program.programId };
+    await program.methods.relayRootBundle(Array.from(root), Array.from(root)).accounts(relayRootBundleAccounts).rpc();
+
+    const remainingAccounts = [
+      { pubkey: relayerTA, isWritable: true, isSigner: false },
+      { pubkey: relayerTB, isWritable: true, isSigner: false },
+    ];
+
+    const iVaultBal = (await connection.getTokenAccountBalance(vault)).value.amount;
+    const iRelayerABal = (await connection.getTokenAccountBalance(relayerTA)).value.amount;
+    const iRelayerBBal = (await connection.getTokenAccountBalance(relayerTB)).value.amount;
+
+    // Execute each Solana leaf
+    for (let i = 0; i < relayerRefundLeaves.length; i += 1) {
+      // Only Solana leaves
+      if (!relayerRefundLeaves[i].isSolana) continue;
+
+      const leaf = relayerRefundLeaves[i] as RelayerRefundLeafSolana;
+      const proof = merkleTree.getProof(leaf);
+      const proofAsNumbers = proof.map((p) => Array.from(p));
+
+      let executeRelayerRefundLeafAccounts = {
+        state: state,
+        rootBundle: rootBundle,
+        signer: owner,
+        vault: vault,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        mint: mint,
+        transferLiability,
+        systemProgram: web3.SystemProgram.programId,
+        program: program.programId,
+      };
+      await loadExecuteRelayerRefundLeafParams(program, owner, stateAccountData.rootBundleId, leaf, proofAsNumbers);
+
+      await program.methods
+        .executeRelayerRefundLeaf()
+        .accounts(executeRelayerRefundLeafAccounts)
+        .remainingAccounts(remainingAccounts)
+        .rpc();
+    }
+
+    const fVaultBal = (await connection.getTokenAccountBalance(vault)).value.amount;
+    const fRelayerABal = (await connection.getTokenAccountBalance(relayerTA)).value.amount;
+    const fRelayerBBal = (await connection.getTokenAccountBalance(relayerTB)).value.amount;
+
+    const totalRefund = relayerRefundLeaves
+      .filter((leaf) => leaf.isSolana)
+      .reduce((acc, leaf) => acc.add((leaf.refundAmounts[0] as BN).add(leaf.refundAmounts[1] as BN)), new BN(0))
+      .toString();
+
+    assert.strictEqual(BigInt(iVaultBal) - BigInt(fVaultBal), BigInt(totalRefund), "Vault balance");
+    assert.strictEqual(
+      BigInt(fRelayerABal) - BigInt(iRelayerABal),
+      BigInt(
+        relayerRefundLeaves
+          .filter((leaf) => leaf.isSolana)
+          .reduce((acc, leaf) => acc.add(leaf.refundAmounts[0] as BN), new BN(0))
+          .toString()
+      ),
+      "Relayer A bal"
+    );
+    assert.strictEqual(
+      BigInt(fRelayerBBal) - BigInt(iRelayerBBal),
+      BigInt(
+        relayerRefundLeaves
+          .filter((leaf) => leaf.isSolana)
+          .reduce((acc, leaf) => acc.add(leaf.refundAmounts[1] as BN), new BN(0))
+          .toString()
+      ),
+      "Relayer B bal"
+    );
+  });
+
   it("Execute Leaf Refunds Relayers with invalid chain id", async () => {
     const relayerRefundLeaves: RelayerRefundLeafType[] = [];
     const relayerARefund = new BN(400000);

--- a/test/svm/utils.ts
+++ b/test/svm/utils.ts
@@ -1,6 +1,6 @@
 import { BN, Program } from "@coral-xyz/anchor";
-import { PublicKey } from "@solana/web3.js";
-import { ethers } from "ethers";
+import { Keypair, PublicKey } from "@solana/web3.js";
+import { BigNumber, ethers } from "ethers";
 import * as crypto from "crypto";
 import { SvmSpoke } from "../../target/types/svm_spoke";
 
@@ -11,6 +11,9 @@ import {
   findProgramAddress,
   LargeAccountsCoder,
 } from "../../src/SvmUtils";
+import { MerkleTree } from "@uma/common";
+import { getParamType, keccak256 } from "../../test-utils";
+import { ParamType } from "ethers/lib/utils";
 
 export { readEvents, readProgramEvents, calculateRelayHashUint8Array, findProgramAddress };
 
@@ -50,10 +53,10 @@ export function randomBigInt(bytes = 8, signed = false) {
 
 export interface RelayerRefundLeaf {
   isSolana: boolean;
-  amountToReturn: bigint;
-  chainId: bigint;
-  refundAmounts: bigint[];
-  leafId: bigint;
+  amountToReturn: BigNumber;
+  chainId: BigNumber;
+  refundAmounts: BigNumber[];
+  leafId: BigNumber;
   l2TokenAddress: string;
   refundAddresses: string[];
 }
@@ -72,6 +75,79 @@ export type RelayerRefundLeafType = RelayerRefundLeaf | RelayerRefundLeafSolana;
 
 export function convertLeafIdToNumber(leaf: RelayerRefundLeafSolana) {
   return { ...leaf, leafId: leaf.leafId.toNumber() };
+}
+
+export function buildRelayerRefundMerkleTree({
+  totalEvmDistributions,
+  totalSolanaDistributions,
+  mixLeaves,
+  chainId,
+  mint,
+  svmRelayers,
+  evmRelayers,
+  evmTokenAddress,
+  evmRefundAmounts,
+  svmRefundAmounts,
+}: {
+  totalEvmDistributions: number;
+  totalSolanaDistributions: number;
+  chainId: number;
+  mixLeaves?: boolean;
+  mint?: PublicKey;
+  svmRelayers?: PublicKey[];
+  evmRelayers?: string[];
+  evmTokenAddress?: string;
+  evmRefundAmounts?: BigNumber[];
+  svmRefundAmounts?: BN[];
+}): { relayerRefundLeaves: RelayerRefundLeafType[]; merkleTree: MerkleTree<RelayerRefundLeafType> } {
+  const relayerRefundLeaves: RelayerRefundLeafType[] = [];
+
+  const createSolanaLeaf = (index: number) => ({
+    isSolana: true,
+    leafId: new BN(index),
+    chainId: new BN(chainId),
+    amountToReturn: new BN(0),
+    mintPublicKey: mint ?? Keypair.generate().publicKey,
+    refundAccounts: svmRelayers || [Keypair.generate().publicKey, Keypair.generate().publicKey],
+    refundAmounts: svmRefundAmounts || [new BN(randomBigInt(2).toString()), new BN(randomBigInt(2).toString())],
+  });
+
+  const createEvmLeaf = (index: number) =>
+    ({
+      isSolana: false,
+      leafId: BigNumber.from(index),
+      chainId: BigNumber.from(chainId),
+      amountToReturn: BigNumber.from(0),
+      l2TokenAddress: evmTokenAddress ?? randomAddress(),
+      refundAddresses: evmRelayers || [randomAddress(), randomAddress()],
+      refundAmounts: evmRefundAmounts || [BigNumber.from(randomBigInt()), BigNumber.from(randomBigInt())],
+    } as RelayerRefundLeaf);
+
+  if (mixLeaves) {
+    let solanaIndex = 0;
+    let evmIndex = 0;
+    const totalDistributions = totalSolanaDistributions + totalEvmDistributions;
+    for (let i = 0; i < totalDistributions; i++) {
+      if (solanaIndex < totalSolanaDistributions && (i % 2 === 0 || evmIndex >= totalEvmDistributions)) {
+        relayerRefundLeaves.push(createSolanaLeaf(solanaIndex));
+        solanaIndex++;
+      } else if (evmIndex < totalEvmDistributions) {
+        relayerRefundLeaves.push(createEvmLeaf(evmIndex));
+        evmIndex++;
+      }
+    }
+  } else {
+    for (let i = 0; i < totalSolanaDistributions; i++) {
+      relayerRefundLeaves.push(createSolanaLeaf(i));
+    }
+    for (let i = 0; i < totalEvmDistributions; i++) {
+      relayerRefundLeaves.push(createEvmLeaf(i + totalSolanaDistributions));
+    }
+  }
+
+  const merkleTree = new MerkleTree<RelayerRefundLeafType>(relayerRefundLeaves, relayerRefundHashFn);
+
+  return { relayerRefundLeaves, merkleTree };
 }
 
 export function calculateRelayerRefundLeafHashUint8Array(relayData: RelayerRefundLeafSolana): string {
@@ -103,7 +179,7 @@ export const relayerRefundHashFn = (input: RelayerRefundLeaf | RelayerRefundLeaf
     const abiCoder = new ethers.utils.AbiCoder();
     const encodedData = abiCoder.encode(
       [
-        "tuple(uint256 leafId, uint256 chainId, uint256 amountToReturn, address l2TokenAddress, address[] refundAddresses, uint256[] refundAmounts)",
+        "tuple( uint256 amountToReturn, uint256 chainId, uint256[] refundAmounts, uint256 leafId, address l2TokenAddress, address[] refundAddresses)",
       ],
       [
         {


### PR DESCRIPTION
Changes proposed in this PR:
- Add tests in hardhat to verify that a tree with mixed leaves (sorted by chain and mixed together) using different hashing functions is fully verifiable on the EVM.
- Add equivalent tests for the SVM.