### PR TITLE
fix(svm): remove redundant accounts

### DIFF
--- a/programs/svm-spoke/src/error.rs
+++ b/programs/svm-spoke/src/error.rs
@@ -68,8 +68,6 @@ pub enum CustomError {
     ExceededPendingBridgeAmount,
     #[msg("Deposits are currently paused!")]
     DepositsArePaused,
-    #[msg("Invalid fill recipient!")]
-    InvalidFillRecipient,
     #[msg("Invalid quote timestamp!")]
     InvalidQuoteTimestamp,
     #[msg("Ivalid fill deadline!")]

--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -30,11 +30,6 @@ pub struct FillV3Relay<'info> {
     pub relayer: SystemAccount<'info>, // TODO: should this be the same as signer?
 
     #[account(
-        address = relay_data.recipient @ CustomError::InvalidFillRecipient
-    )]
-    pub recipient: SystemAccount<'info>, // TODO: this might be redundant.
-
-    #[account(
         token::token_program = token_program, // TODO: consistent token imports
         address = relay_data.output_token @ CustomError::InvalidMint
     )]
@@ -51,7 +46,7 @@ pub struct FillV3Relay<'info> {
     #[account(
         mut,
         associated_token::mint = mint_account,
-        associated_token::authority = recipient, // TODO: use relay_data.recipient
+        associated_token::authority = relay_data.recipient,
         associated_token::token_program = token_program
     )]
     pub recipient_token_account: InterfaceAccount<'info, TokenAccount>,

--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -27,8 +27,6 @@ pub struct FillV3Relay<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    pub relayer: SystemAccount<'info>, // TODO: should this be the same as signer?
-
     #[account(
         token::token_program = token_program, // TODO: consistent token imports
         address = relay_data.output_token @ CustomError::InvalidMint
@@ -38,7 +36,7 @@ pub struct FillV3Relay<'info> {
     #[account(
         mut,
         associated_token::mint = mint_account, // TODO: consistent token imports
-        associated_token::authority = relayer,
+        associated_token::authority = signer,
         associated_token::token_program = token_program
     )]
     pub relayer_token_account: InterfaceAccount<'info, TokenAccount>,

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -149,11 +149,6 @@ pub struct ExecuteV3SlowRelayLeaf<'info> {
     pub fill_status: Account<'info, FillStatusAccount>,
 
     #[account(
-        address = slow_fill_leaf.relay_data.recipient @ CustomError::InvalidFillRecipient
-    )]
-    pub recipient: SystemAccount<'info>,
-
-    #[account(
         token::token_program = token_program,
         address = slow_fill_leaf.relay_data.output_token @ CustomError::InvalidMint
     )]
@@ -162,7 +157,7 @@ pub struct ExecuteV3SlowRelayLeaf<'info> {
     #[account(
         mut,
         associated_token::mint = mint,
-        associated_token::authority = recipient,
+        associated_token::authority = slow_fill_leaf.relay_data.recipient,
         associated_token::token_program = token_program
     )]
     pub recipient_token_account: InterfaceAccount<'info, TokenAccount>,

--- a/scripts/svm/simpleFill.ts
+++ b/scripts/svm/simpleFill.ts
@@ -126,7 +126,6 @@ async function fillV3Relay(): Promise<void> {
       state: statePda,
       signer: signer,
       relayer: signer,
-      recipient: recipient,
       mintAccount: outputToken,
       relayerTokenAccount: relayerTokenAccount,
       recipientTokenAccount: recipientTokenAccount,

--- a/scripts/svm/simpleFill.ts
+++ b/scripts/svm/simpleFill.ts
@@ -125,7 +125,6 @@ async function fillV3Relay(): Promise<void> {
     .accounts({
       state: statePda,
       signer: signer,
-      relayer: signer,
       mintAccount: outputToken,
       relayerTokenAccount: relayerTokenAccount,
       recipientTokenAccount: recipientTokenAccount,

--- a/test/svm/SvmSpoke.Fill.ts
+++ b/test/svm/SvmSpoke.Fill.ts
@@ -37,7 +37,6 @@ describe("svm_spoke.fill", () => {
     accounts = {
       state,
       signer: relayer.publicKey,
-      relayer: relayer.publicKey,
       mintAccount: mint,
       relayerTokenAccount: relayerTA,
       recipientTokenAccount: recipientTA,
@@ -137,7 +136,6 @@ describe("svm_spoke.fill", () => {
 
   it("Fails to fill a V3 relay by non-exclusive relayer before exclusivity deadline", async () => {
     accounts.signer = otherRelayer.publicKey;
-    accounts.relayer = otherRelayer.publicKey;
     accounts.relayerTokenAccount = otherRelayerTA;
 
     const relayHash = Array.from(calculateRelayHashUint8Array(relayData, chainId));
@@ -157,7 +155,6 @@ describe("svm_spoke.fill", () => {
     updateRelayData({ ...relayData, exclusivityDeadline: new BN(Math.floor(Date.now() / 1000) - 100) });
 
     accounts.signer = otherRelayer.publicKey;
-    accounts.relayer = otherRelayer.publicKey;
     accounts.relayerTokenAccount = otherRelayerTA;
 
     const recipientAccountBefore = await getAccount(connection, recipientTA);

--- a/test/svm/SvmSpoke.SlowFill.ts
+++ b/test/svm/SvmSpoke.SlowFill.ts
@@ -324,7 +324,6 @@ describe("svm_spoke.slow_fill", () => {
       vault: vault,
       tokenProgram: TOKEN_PROGRAM_ID,
       mint: mint,
-      recipient,
       recipientTokenAccount: recipientTA,
       program: program.programId,
     };
@@ -412,7 +411,7 @@ describe("svm_spoke.slow_fill", () => {
       .signers([relayer])
       .rpc();
 
-    // Try to execute V3 slow relay leaf with wrong recipient should fail.
+    // Try to execute V3 slow relay leaf with wrong recipient token account should fail.
     const wrongRecipient = Keypair.generate().publicKey;
     const wrongRecipientTA = (await getOrCreateAssociatedTokenAccount(connection, payer, mint, wrongRecipient)).address;
     try {
@@ -424,7 +423,6 @@ describe("svm_spoke.slow_fill", () => {
         vault: vault,
         tokenProgram: TOKEN_PROGRAM_ID,
         mint: mint,
-        recipient: wrongRecipient,
         recipientTokenAccount: wrongRecipientTA,
         program: program.programId,
       };
@@ -437,10 +435,10 @@ describe("svm_spoke.slow_fill", () => {
         )
         .accounts(executeSlowRelayLeafAccounts)
         .rpc();
-      assert.fail("Execution should have failed due to wrong recipient");
+      assert.fail("Execution should have failed due to wrong recipient token account");
     } catch (err: any) {
       assert.instanceOf(err, anchor.AnchorError);
-      assert.strictEqual(err.error.errorCode.code, "InvalidFillRecipient", "Expected error code InvalidFillRecipient");
+      assert.strictEqual(err.error.errorCode.code, "ConstraintTokenOwner", "Expected error code ConstraintTokenOwner");
     }
   });
 
@@ -484,7 +482,6 @@ describe("svm_spoke.slow_fill", () => {
       vault,
       tokenProgram: TOKEN_PROGRAM_ID,
       mint,
-      recipient: firstRecipient,
       recipientTokenAccount: firstRecipientTA,
       program: program.programId,
     };
@@ -515,7 +512,6 @@ describe("svm_spoke.slow_fill", () => {
         vault,
         tokenProgram: TOKEN_PROGRAM_ID,
         mint,
-        recipient: firstRecipient,
         recipientTokenAccount: firstRecipientTA,
         program: program.programId,
       };
@@ -560,7 +556,6 @@ describe("svm_spoke.slow_fill", () => {
         vault: wrongVault,
         tokenProgram: TOKEN_PROGRAM_ID,
         mint: wrongMint,
-        recipient,
         recipientTokenAccount: wrongRecipientTA,
         program: program.programId,
       };
@@ -604,7 +599,6 @@ describe("svm_spoke.slow_fill", () => {
         vault,
         tokenProgram: TOKEN_PROGRAM_ID,
         mint,
-        recipient,
         recipientTokenAccount: recipientTA,
         program: program.programId,
       };

--- a/test/svm/SvmSpoke.SlowFill.ts
+++ b/test/svm/SvmSpoke.SlowFill.ts
@@ -65,7 +65,6 @@ describe("svm_spoke.slow_fill", () => {
     fillAccounts = {
       state,
       signer: relayer.publicKey,
-      relayer: relayer.publicKey,
       mintAccount: mint,
       relayerTokenAccount: relayerTA,
       recipientTokenAccount: recipientTA,

--- a/test/svm/SvmSpoke.SlowFill.ts
+++ b/test/svm/SvmSpoke.SlowFill.ts
@@ -66,10 +66,9 @@ describe("svm_spoke.slow_fill", () => {
       state,
       signer: relayer.publicKey,
       relayer: relayer.publicKey,
-      recipient: relayData.recipient, // This could be different from global recipient.
       mintAccount: mint,
-      relayerTA: relayerTA,
-      recipientTA: recipientTA,
+      relayerTokenAccount: relayerTA,
+      recipientTokenAccount: recipientTA,
       fillStatus,
       tokenProgram: TOKEN_PROGRAM_ID,
       associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,


### PR DESCRIPTION
This removes redundant accounts from fill and slow fill instructions.

Fixes: https://linear.app/uma/issue/ACX-3020/instructionsfillrs-recipient-systemaccount-might-be-redundant
Fixes: https://linear.app/uma/issue/ACX-3019/instructionsfillrs-should-relayer-be-the-same-as-signer