### PR TITLE
fix: supply decimals and CCTP domain in custom token adapter

### DIFF
--- a/contracts/chain-adapters/Arbitrum_CustomGasToken_Adapter.sol
+++ b/contracts/chain-adapters/Arbitrum_CustomGasToken_Adapter.sol
@@ -51,9 +51,9 @@ contract Arbitrum_CustomGasToken_Adapter is AdapterInterface, CircleCCTPAdapter 
     // The Arbitrum Inbox requires that this is specified in gWei (e.g. 1e9 = 1 gWei)
     uint256 public immutable L2_GAS_PRICE;
 
-    // Native token expected to be sent in L2 message. Should be 0 for all use cases of this constant, which
-    // includes sending messages from L1 to L2 and sending Custom gas token ERC20's, which won't be the native token
-    // on the L2 by definition.
+    // Native token expected to be sent in L2 message. Should be 0 for most use cases of this constant. This
+    // constant is unused when sending the native gas token over the inbox since the inbox interprets `l2CallValue`
+    // as the amount of the L2 native token to send.
     uint256 public constant L2_CALL_VALUE = 0;
 
     // Gas limit for L2 execution of a cross chain token transfer sent via the inbox.
@@ -184,7 +184,7 @@ contract Arbitrum_CustomGasToken_Adapter is AdapterInterface, CircleCCTPAdapter 
                 CUSTOM_GAS_TOKEN.safeIncreaseAllowance(address(L1_INBOX), amountToBridge);
                 L1_INBOX.createRetryableTicket(
                     to, // destAddr destination L2 contract address
-                    L2_CALL_VALUE, // l2CallValue call value for retryable L2 message
+                    amount, // l2CallValue call value for retryable L2 message
                     L2_MAX_SUBMISSION_COST, // maxSubmissionCost Max gas deducted from user's L2 balance to cover base fee
                     L2_REFUND_L2_ADDRESS, // excessFeeRefundAddress maxgas * gasprice - execution cost gets credited here on L2
                     L2_REFUND_L2_ADDRESS, // callValueRefundAddress l2Callvalue gets credited here on L2 if retryable txn times out or gets cancelled

--- a/deploy/052_deploy_donation_box.ts
+++ b/deploy/052_deploy_donation_box.ts
@@ -4,9 +4,6 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
 
-  // @note if deploying this contract on a chain like Linea that only supports up to
-  // solc 0.8.19, the hardhat.config solc version needs to be overridden and this
-  // contract needs to be recompiled.
   await hre.deployments.deploy("DonationBox", {
     contract: "DonationBox",
     from: deployer,

--- a/deploy/052_deploy_donation_box.ts
+++ b/deploy/052_deploy_donation_box.ts
@@ -1,0 +1,19 @@
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployer } = await hre.getNamedAccounts();
+
+  // @note if deploying this contract on a chain like Linea that only supports up to
+  // solc 0.8.19, the hardhat.config solc version needs to be overridden and this
+  // contract needs to be recompiled.
+  await hre.deployments.deploy("DonationBox", {
+    contract: "DonationBox",
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+    args: [],
+  });
+};
+module.exports = func;
+func.tags = ["DonationBox"];

--- a/deploy/053_deploy_alephzero_adapter.ts
+++ b/deploy/053_deploy_alephzero_adapter.ts
@@ -1,0 +1,35 @@
+import { L1_ADDRESS_MAP, ZERO_ADDRESS, AZERO, ARBITRUM_MAX_SUBMISSION_COST, AZERO_GAS_PRICE } from "./consts";
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployer } = await hre.getNamedAccounts();
+  const chainId = parseInt(await hre.getChainId());
+
+  // This address receives gas refunds on the L2 after messages are relayed. Currently
+  // set to the Risk Labs relayer address. The deployer should change this if necessary.
+  const l2RefundAddress = "0x07aE8551Be970cB1cCa11Dd7a11F47Ae82e70E67";
+
+  const args = [
+    L1_ADDRESS_MAP[chainId].l1AlephZeroInbox,
+    L1_ADDRESS_MAP[chainId].l1AlephZeroERC20GatewayRouter,
+    l2RefundAddress,
+    ZERO_ADDRESS,
+    ZERO_ADDRESS,
+    0, // No Circle CCTP domain ID.
+    L1_ADDRESS_MAP[chainId].donationBox,
+    AZERO.decimals,
+    ARBITRUM_MAX_SUBMISSION_COST,
+    AZERO_GAS_PRICE,
+  ];
+  const instance = await hre.deployments.deploy("Arbitrum_CustomGasToken_Adapter", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: false,
+    args,
+  });
+  await hre.run("verify:verify", { address: instance.address, constructorArguments: args });
+};
+
+module.exports = func;
+func.tags = ["ArbitrumCustomGasTokenAdapter", "mainnet"];

--- a/deploy/consts.ts
+++ b/deploy/consts.ts
@@ -5,9 +5,12 @@ import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../utils";
 export const USDC = TOKEN_SYMBOLS_MAP.USDC.addresses;
 export const WETH = TOKEN_SYMBOLS_MAP.WETH.addresses;
 export const WMATIC = TOKEN_SYMBOLS_MAP.WMATIC.addresses;
+export const AZERO = TOKEN_SYMBOLS_MAP.AZERO;
 
 export const QUOTE_TIME_BUFFER = 3600;
 export const FILL_DEADLINE_BUFFER = 6 * 3600;
+export const ARBITRUM_MAX_SUBMISSION_COST = "10000000000000000";
+export const AZERO_GAS_PRICE = "240000000000";
 
 export const L1_ADDRESS_MAP: { [key: number]: { [contractName: string]: string } } = {
   [CHAIN_IDs.MAINNET]: {
@@ -48,6 +51,9 @@ export const L1_ADDRESS_MAP: { [key: number]: { [contractName: string]: string }
     zoraStandardBridge: "0x3e2Ea9B92B7E48A52296fD261dc26fd995284631",
     worldChainCrossDomainMessenger: "0xf931a81D18B1766d15695ffc7c1920a62b7e710a",
     worldChainStandardBridge: "0x470458C91978D2d929704489Ad730DC3E3001113",
+    l1AlephZeroInbox: "0x56D8EC76a421063e1907503aDd3794c395256AEb",
+    l1AlephZeroERC20GatewayRouter: "0xeBb17f398ed30d02F2e8733e7c1e5cf566e17812",
+    donationBox: "0x5e40a88E302Da80089Dd13178b8DD6b15534419c",
   },
   [CHAIN_IDs.SEPOLIA]: {
     optimismCrossDomainMessenger: "0x58Cc85b8D04EA49cC6DBd3CbFFd00B4B8D6cb3ef",

--- a/deploy/consts.ts
+++ b/deploy/consts.ts
@@ -53,7 +53,7 @@ export const L1_ADDRESS_MAP: { [key: number]: { [contractName: string]: string }
     worldChainStandardBridge: "0x470458C91978D2d929704489Ad730DC3E3001113",
     l1AlephZeroInbox: "0x56D8EC76a421063e1907503aDd3794c395256AEb",
     l1AlephZeroERC20GatewayRouter: "0xeBb17f398ed30d02F2e8733e7c1e5cf566e17812",
-    donationBox: "0x5e40a88E302Da80089Dd13178b8DD6b15534419c",
+    donationBox: "0x90285a96F5955A7279EF0C1e89A1B4f66d8E4dA7",
   },
   [CHAIN_IDs.SEPOLIA]: {
     optimismCrossDomainMessenger: "0x58Cc85b8D04EA49cC6DBd3CbFFd00B4B8D6cb3ef",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prepublish": "yarn build && hardhat export --export-all ./cache/massExport.json && ts-node ./scripts/processHardhatExport.ts && prettier --write ./deployments/deployments.json && yarn generate-contract-types"
   },
   "dependencies": {
-    "@across-protocol/constants": "^3.1.16",
+    "@across-protocol/constants": "^3.1.17",
     "@coral-xyz/anchor": "^0.30.1",
     "@defi-wonderland/smock": "^2.3.4",
     "@eth-optimism/contracts": "^0.5.40",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@across-protocol/constants@^3.1.16":
-  version "3.1.16"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.16.tgz#c126085d29d4d051fd02a04c833d804d37c3c219"
-  integrity sha512-+U+AecGWnfY4b4sSfKBvsDj/+yXKEqpTXcZgI8GVVmUTkUhs1efA0kN4q3q10yy5TXI5TtagaG7R9yZg1zgKKg==
+"@across-protocol/constants@^3.1.17":
+  version "3.1.17"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.17.tgz#1e43c87fbab06df3a1aab8993d7c5f746838e25d"
+  integrity sha512-mW++45vP04ahogsHFM5nE7ZKV8vmdxSO8gbBeP24VFxijrIYWqhISG67EU9pnAbgAIB58pT+ZmqdXI25iDmctA==
 
 "@across-protocol/contracts@^0.1.4":
   version "0.1.4"


### PR DESCRIPTION
Three changes needed to be made:
1. The Arbitrum "default ERC20 bridge" contract does not have a `nativeTokenDecimals` function we can call, so we instead define the decimals of the native token it in the constructor. We do not resolve this dynamically since decimals is not required to implement ERC20, so we can't rely on IERC20 to call `decimals()`. 
2. We need to swap the CCTP domain ID from Arbitrum to some arbitrary number, which can be defined in the constructor.
3. When calling `createRetryableTicket` to bridge the native gas token, `l2CallValue` must actually be the amount of the native gas token to send, not zero. This is because `l2CallValue` is with respect to the L2's native token, not ETH.