### PR TITLE
refactor(svm): relayer refund leaf order

### DIFF
--- a/programs/svm-spoke/src/instructions/bundle.rs
+++ b/programs/svm-spoke/src/instructions/bundle.rs
@@ -66,7 +66,7 @@ pub struct ExecuteRelayerRefundLeaf<'info> {
     pub system_program: Program<'info, System>,
 }
 
-// TODO: update UMIP to consider different encoding for different chains.
+// TODO: update UMIP to consider different encoding for different chains (evm and svm).
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)] // TODO: check if all derives are needed.
 pub struct RelayerRefundLeaf {
     pub amount_to_return: u64,

--- a/programs/svm-spoke/src/instructions/bundle.rs
+++ b/programs/svm-spoke/src/instructions/bundle.rs
@@ -70,13 +70,12 @@ pub struct ExecuteRelayerRefundLeaf<'info> {
 // TODO: update UMIP to consider different encoding for different chains.
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)] // TODO: check if all derives are needed.
 pub struct RelayerRefundLeaf {
-    // TODO: at least the same ordering as in EVM.
     pub amount_to_return: u64,
     pub chain_id: u64,
-    pub leaf_id: u32,
-    pub mint_public_key: Pubkey,
     #[max_len(0)]
     pub refund_amounts: Vec<u64>,
+    pub leaf_id: u32,
+    pub mint_public_key: Pubkey,
     #[max_len(0)]
     pub refund_accounts: Vec<Pubkey>,
 }
@@ -87,12 +86,11 @@ impl RelayerRefundLeaf {
 
         bytes.extend_from_slice(&self.amount_to_return.to_le_bytes());
         bytes.extend_from_slice(&self.chain_id.to_le_bytes());
-        bytes.extend_from_slice(&self.leaf_id.to_le_bytes());
-        bytes.extend_from_slice(self.mint_public_key.as_ref());
-
         for amount in &self.refund_amounts {
             bytes.extend_from_slice(&amount.to_le_bytes());
         }
+        bytes.extend_from_slice(&self.leaf_id.to_le_bytes());
+        bytes.extend_from_slice(self.mint_public_key.as_ref());
         for account in &self.refund_accounts {
             bytes.extend_from_slice(account.as_ref());
         }

--- a/programs/svm-spoke/src/instructions/bundle.rs
+++ b/programs/svm-spoke/src/instructions/bundle.rs
@@ -66,7 +66,6 @@ pub struct ExecuteRelayerRefundLeaf<'info> {
     pub system_program: Program<'info, System>,
 }
 
-// TODO: add multichain test to check if its possible to verify both EVM and SVM leaves in the same bundle.
 // TODO: update UMIP to consider different encoding for different chains.
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)] // TODO: check if all derives are needed.
 pub struct RelayerRefundLeaf {

--- a/test/svm/utils.ts
+++ b/test/svm/utils.ts
@@ -164,9 +164,9 @@ export function calculateRelayerRefundLeafHashUint8Array(relayData: RelayerRefun
   const contentToHash = Buffer.concat([
     relayData.amountToReturn.toArrayLike(Buffer, "le", 8),
     relayData.chainId.toArrayLike(Buffer, "le", 8),
+    refundAmountsBuffer,
     relayData.leafId.toArrayLike(Buffer, "le", 4),
     relayData.mintPublicKey.toBuffer(),
-    refundAmountsBuffer,
     refundAccountsBuffer,
   ]);
 


### PR DESCRIPTION
Changes proposed in this PR:
- relayer refund leaf ordering to match [evm's one](https://github.com/across-protocol/contracts/blob/f5e48d9321bb239047ad22178b89d725ec9efb8b/contracts/interfaces/SpokePoolInterface.sol#L9)