### PR TITLE
fix(svm): consistent anchor token constraints

### DIFF
--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -57,7 +57,6 @@ pub struct DepositV3<'info> {
     )]
     pub vault: InterfaceAccount<'info, TokenAccount>,
 
-    // TODO: why are we using mint::token_program,token::token_program and associated_token::token_program?
     #[account(
         mint::token_program = token_program,
         // IDL build fails when requiring `address = input_token` for mint, thus using a custom constraint.

--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -28,16 +28,16 @@ pub struct FillV3Relay<'info> {
     pub signer: Signer<'info>,
 
     #[account(
-        token::token_program = token_program, // TODO: consistent token imports
+        mint::token_program = token_program,
         address = relay_data.output_token @ CustomError::InvalidMint
     )]
     pub mint_account: InterfaceAccount<'info, Mint>,
 
     #[account(
         mut,
-        associated_token::mint = mint_account, // TODO: consistent token imports
-        associated_token::authority = signer,
-        associated_token::token_program = token_program
+        token::mint = mint_account,
+        token::authority = signer,
+        token::token_program = token_program
     )]
     pub relayer_token_account: InterfaceAccount<'info, TokenAccount>,
 

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -149,7 +149,7 @@ pub struct ExecuteV3SlowRelayLeaf<'info> {
     pub fill_status: Account<'info, FillStatusAccount>,
 
     #[account(
-        token::token_program = token_program,
+        mint::token_program = token_program,
         address = slow_fill_leaf.relay_data.output_token @ CustomError::InvalidMint
     )]
     pub mint: InterfaceAccount<'info, Mint>,

--- a/test/svm/SvmSpoke.Fill.ts
+++ b/test/svm/SvmSpoke.Fill.ts
@@ -398,9 +398,9 @@ describe("svm_spoke.fill", () => {
     const customRelayerTA = await createAccount(connection, payer, mint, relayer.publicKey, customKeypair);
     await mintTo(connection, payer, mint, customRelayerTA, owner, seedBalance);
 
-    // Verify relayer's balance before the fill
-    let relayerAccount = await getAccount(connection, customRelayerTA);
-    assertSE(relayerAccount.amount, seedBalance, "Relayer's balance should be equal to seed balance before the fill");
+    // Save balances before the the fill
+    const iRelayerBal = (await getAccount(connection, customRelayerTA)).amount;
+    const iRecipientBal = (await getAccount(connection, recipientTA)).amount;
 
     // Fill relay from custom relayer token account
     accounts.relayerTokenAccount = customRelayerTA;
@@ -411,16 +411,14 @@ describe("svm_spoke.fill", () => {
       .signers([relayer])
       .rpc();
 
-    // Verify relayer's balance after the fill
-    relayerAccount = await getAccount(connection, customRelayerTA);
+    // Verify balances after the fill
+    const fRelayerBal = (await getAccount(connection, customRelayerTA)).amount;
+    const fRecipientBal = (await getAccount(connection, recipientTA)).amount;
+    assertSE(fRelayerBal, iRelayerBal - BigInt(relayAmount), "Relayer's balance should be reduced by the relay amount");
     assertSE(
-      relayerAccount.amount,
-      seedBalance - relayAmount,
-      "Relayer's balance should be reduced by the relay amount"
+      fRecipientBal,
+      iRecipientBal + BigInt(relayAmount),
+      "Recipient's balance should be increased by the relay amount"
     );
-
-    // Verify recipient's balance after the fill
-    const recipientAccount = await getAccount(connection, recipientTA);
-    assertSE(recipientAccount.amount, relayAmount, "Recipient's balance should be increased by the relay amount");
   });
 });


### PR DESCRIPTION
We were unnecessarily restricting relayer token account in the fill instruction to be canonically derived from the relayer and mint addresses. By replacing associated_token constraints with token constraints this would allow the relayer to pass any token account as long as its mint and authority matches.

Overall, we want to use canonical token accounts for vault and fill/slow fill recipients (hence, associated_token constraints) and any valid token accounts for all others.

Also, some of mint accounts were incorrectly using token constraints for their program account checks. Event the checks are implemented the same way (account being owned by the token program), Anchor error message is slightly different.

Fixes: https://linear.app/uma/issue/ACX-2925/instructionsfillrs-consistent-token-imports