### PR TITLE
fix: rust linting

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+max_width = 120

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "lint": "yarn lint-solidity && yarn lint-js && yarn lint-rust",
     "lint-solidity": "yarn solhint ./contracts/**/*.sol",
     "lint-js": "yarn prettier --list-different **/*.js **/*.ts",
-    "lint-rust": "yarn prettier --list-different ./programs/**/*.rs",
-    "lint-fix": "yarn prettier --write **/*.js **/*.ts ./programs/**/*.rs ./contracts**/*.sol",
+    "lint-rust": "cargo fmt --all -- --check && cargo clippy",
+    "lint-fix": "yarn prettier --write **/*.js **/*.ts ./programs/**/*.rs ./contracts**/*.sol && cargo fmt --all",
     "clean-fast": "for dir in node_modules cache cache-zk artifacts artifacts-zk dist typechain; do mv \"${dir}\" \"_${dir}\"; rm -rf \"_${dir}\" &; done",
     "clean": "rm -rf node_modules cache cache-zk artifacts artifacts-zk dist typechain",
     "build-evm": "hardhat compile",
@@ -35,7 +35,8 @@
     "test": "yarn test-evm && yarn test-svm",
     "test:report-gas": "IS_TEST=true REPORT_GAS=true hardhat test",
     "generate-contract-types": "rm -rf typechain && TYPECHAIN=ethers yarn hardhat typechain",
-    "prepublish": "yarn build && hardhat export --export-all ./cache/massExport.json && ts-node ./scripts/processHardhatExport.ts && prettier --write ./deployments/deployments.json && yarn generate-contract-types"
+    "prepublish": "yarn build && hardhat export --export-all ./cache/massExport.json && ts-node ./scripts/processHardhatExport.ts && prettier --write ./deployments/deployments.json && yarn generate-contract-types",
+    "pre-commit-hook": "sh scripts/preCommitHook.sh"
   },
   "dependencies": {
     "@across-protocol/constants": "^3.1.16",
@@ -114,7 +115,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "echo '🏃‍♂️ Running pretty-quick on staged files' && pretty-quick --staged"
+      "pre-commit": "echo '🏃‍♂️ Running pre-commit hook on staged files' && yarn pre-commit-hook"
     }
   },
   "publishConfig": {

--- a/programs/svm-spoke/src/constraints.rs
+++ b/programs/svm-spoke/src/constraints.rs
@@ -1,6 +1,10 @@
 use anchor_lang::prelude::*;
 
-use crate::{ state::State, utils::{ get_self_authority_pda, get_v3_relay_hash }, V3RelayData };
+use crate::{
+    state::State,
+    utils::{get_self_authority_pda, get_v3_relay_hash},
+    V3RelayData,
+};
 
 pub fn is_local_or_remote_owner(signer: &Signer, state: &Account<State>) -> bool {
     signer.key() == state.owner || signer.key() == get_self_authority_pda()

--- a/programs/svm-spoke/src/instructions/admin.rs
+++ b/programs/svm-spoke/src/instructions/admin.rs
@@ -1,21 +1,18 @@
 use anchor_lang::prelude::*;
-use anchor_spl::{ associated_token::AssociatedToken, token_interface::{ Mint, TokenAccount, TokenInterface } };
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token_interface::{Mint, TokenAccount, TokenInterface},
+};
 
 use crate::{
     constants::DISCRIMINATOR_SIZE,
     constraints::is_local_or_remote_owner,
     error::SvmError,
     event::{
-        EmergencyDeleteRootBundle,
-        EnabledDepositRoute,
-        PausedDeposits,
-        PausedFills,
-        RelayedRootBundle,
-        SetXDomainAdmin,
+        EmergencyDeleteRootBundle, EnabledDepositRoute, PausedDeposits, PausedFills, RelayedRootBundle, SetXDomainAdmin,
     },
-    initialize_current_time,
-    set_seed,
-    state::{ RootBundle, Route, State },
+    initialize_current_time, set_seed,
+    state::{RootBundle, Route, State},
 };
 
 #[derive(Accounts)]
@@ -40,11 +37,11 @@ pub fn initialize(
     ctx: Context<Initialize>,
     seed: u64,
     initial_number_of_deposits: u32,
-    chain_id: u64, // Across definition of chainId for Solana.
-    remote_domain: u32, // CCTP domain for Mainnet Ethereum.
-    cross_domain_admin: Pubkey, // HubPool on Mainnet Ethereum.
+    chain_id: u64,                  // Across definition of chainId for Solana.
+    remote_domain: u32,             // CCTP domain for Mainnet Ethereum.
+    cross_domain_admin: Pubkey,     // HubPool on Mainnet Ethereum.
     deposit_quote_time_buffer: u32, // Deposit quote times can't be set more than this amount into the past/future.
-    fill_deadline_buffer: u32 // Fill deadlines can't be set more than this amount into the future.
+    fill_deadline_buffer: u32,      // Fill deadlines can't be set more than this amount into the future.
 ) -> Result<()> {
     let state = &mut ctx.accounts.state;
     state.owner = *ctx.accounts.signer.key;
@@ -131,7 +128,9 @@ pub fn set_cross_domain_admin(ctx: Context<SetCrossDomainAdmin>, cross_domain_ad
     let state = &mut ctx.accounts.state;
     state.cross_domain_admin = cross_domain_admin;
 
-    emit_cpi!(SetXDomainAdmin { new_admin: cross_domain_admin });
+    emit_cpi!(SetXDomainAdmin {
+        new_admin: cross_domain_admin,
+    });
 
     Ok(())
 }
@@ -183,11 +182,15 @@ pub fn set_enable_route(
     ctx: Context<SetEnableRoute>,
     origin_token: Pubkey,
     destination_chain_id: u64,
-    enabled: bool
+    enabled: bool,
 ) -> Result<()> {
     ctx.accounts.route.enabled = enabled;
 
-    emit_cpi!(EnabledDepositRoute { origin_token, destination_chain_id, enabled });
+    emit_cpi!(EnabledDepositRoute {
+        origin_token,
+        destination_chain_id,
+        enabled,
+    });
 
     Ok(())
 }
@@ -221,14 +224,18 @@ pub struct RelayRootBundle<'info> {
 pub fn relay_root_bundle(
     ctx: Context<RelayRootBundle>,
     relayer_refund_root: [u8; 32],
-    slow_relay_root: [u8; 32]
+    slow_relay_root: [u8; 32],
 ) -> Result<()> {
     let state = &mut ctx.accounts.state;
     let root_bundle = &mut ctx.accounts.root_bundle;
     root_bundle.relayer_refund_root = relayer_refund_root;
     root_bundle.slow_relay_root = slow_relay_root;
 
-    emit_cpi!(RelayedRootBundle { root_bundle_id: state.root_bundle_id, relayer_refund_root, slow_relay_root });
+    emit_cpi!(RelayedRootBundle {
+        root_bundle_id: state.root_bundle_id,
+        relayer_refund_root,
+        slow_relay_root,
+    });
 
     state.root_bundle_id += 1;
     Ok(())

--- a/programs/svm-spoke/src/instructions/bundle.rs
+++ b/programs/svm-spoke/src/instructions/bundle.rs
@@ -1,12 +1,12 @@
-use anchor_lang::{ prelude::*, solana_program::keccak };
-use anchor_spl::token_interface::{ transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked };
+use anchor_lang::{prelude::*, solana_program::keccak};
+use anchor_spl::token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked};
 
 use crate::{
     constants::DISCRIMINATOR_SIZE,
-    error::{ CommonError, SvmError },
+    error::{CommonError, SvmError},
     event::ExecutedRelayerRefundRoot,
-    state::{ ExecuteRelayerRefundLeafParams, RefundAccount, RootBundle, State, TransferLiability },
-    utils::{ is_claimed, set_claimed, verify_merkle_proof },
+    state::{ExecuteRelayerRefundLeafParams, RefundAccount, RootBundle, State, TransferLiability},
+    utils::{is_claimed, set_claimed, verify_merkle_proof},
 };
 
 #[event_cpi]
@@ -99,10 +99,10 @@ impl RelayerRefundLeaf {
 }
 
 pub fn execute_relayer_refund_leaf<'c, 'info>(
-    ctx: Context<'_, '_, 'c, 'info, ExecuteRelayerRefundLeaf<'info>>
+    ctx: Context<'_, '_, 'c, 'info, ExecuteRelayerRefundLeaf<'info>>,
 ) -> Result<()>
-    where
-        'c: 'info // TODO: add explaining comments on some of more complex syntax.
+where
+    'c: 'info, // TODO: add explaining comments on some of more complex syntax.
 {
     // Get pre-loaded instruction parameters.
     let instruction_params = &ctx.accounts.instruction_params;
@@ -124,7 +124,10 @@ pub fn execute_relayer_refund_leaf<'c, 'info>(
         return err!(CommonError::ClaimedMerkleLeaf);
     }
 
-    set_claimed(&mut ctx.accounts.root_bundle.claimed_bitmap, relayer_refund_leaf.leaf_id);
+    set_claimed(
+        &mut ctx.accounts.root_bundle.claimed_bitmap,
+        relayer_refund_leaf.leaf_id,
+    );
 
     // TODO: execute remaining parts of leaf structure such as amountToReturn.
     // TODO: emit events.
@@ -152,7 +155,7 @@ pub fn execute_relayer_refund_leaf<'c, 'info>(
             i,
             &relayer_refund_leaf.refund_accounts[i],
             &ctx.accounts.mint.key(),
-            &ctx.accounts.token_program.key()
+            &ctx.accounts.token_program.key(),
         )?;
 
         match refund_account {
@@ -167,7 +170,7 @@ pub fn execute_relayer_refund_leaf<'c, 'info>(
                 let cpi_context = CpiContext::new_with_signer(
                     ctx.accounts.token_program.to_account_info(),
                     transfer_accounts,
-                    signer_seeds
+                    signer_seeds,
                 );
                 transfer_checked(cpi_context, amount, ctx.accounts.mint.decimals)?;
             }

--- a/programs/svm-spoke/src/instructions/create_token_accounts.rs
+++ b/programs/svm-spoke/src/instructions/create_token_accounts.rs
@@ -1,5 +1,8 @@
 use anchor_lang::prelude::*;
-use anchor_spl::{ associated_token::{ self, AssociatedToken }, token_interface::{ Mint, TokenInterface } };
+use anchor_spl::{
+    associated_token::{self, AssociatedToken},
+    token_interface::{Mint, TokenInterface},
+};
 
 use crate::error::SvmError;
 

--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -1,7 +1,12 @@
 use anchor_lang::prelude::*;
-use anchor_spl::token_interface::{ transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked };
+use anchor_spl::token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked};
 
-use crate::{ error::{ CommonError, SvmError }, event::V3FundsDeposited, get_current_time, state::{ Route, State } };
+use crate::{
+    error::{CommonError, SvmError},
+    event::V3FundsDeposited,
+    get_current_time,
+    state::{Route, State},
+};
 
 #[event_cpi]
 #[derive(Accounts)]
@@ -75,7 +80,7 @@ pub fn deposit_v3(
     quote_timestamp: u32,
     fill_deadline: u32,
     exclusivity_deadline: u32,
-    message: Vec<u8>
+    message: Vec<u8>,
 ) -> Result<()> {
     let state = &mut ctx.accounts.state;
 

--- a/programs/svm-spoke/src/instructions/handle_receive_message.rs
+++ b/programs/svm-spoke/src/instructions/handle_receive_message.rs
@@ -1,10 +1,13 @@
-use anchor_lang::{ prelude::*, solana_program::{ instruction::Instruction, program } };
+use anchor_lang::{
+    prelude::*,
+    solana_program::{instruction::Instruction, program},
+};
 
 use crate::{
     constants::MESSAGE_TRANSMITTER_PROGRAM_ID,
-    error::{ CallDataError, SvmError },
+    error::{CallDataError, SvmError},
     program::SvmSpoke,
-    utils::{ self, EncodeInstructionData },
+    utils::{self, EncodeInstructionData},
     State,
 };
 
@@ -107,12 +110,16 @@ pub fn invoke_self<'info>(ctx: &Context<'_, '_, '_, 'info, HandleReceiveMessage<
         }
     }
 
-    let instruction = Instruction { program_id: crate::ID, accounts, data: data.to_owned() };
+    let instruction = Instruction {
+        program_id: crate::ID,
+        accounts,
+        data: data.to_owned(),
+    };
 
     program::invoke_signed(
         &instruction,
         &[&[ctx.accounts.self_authority.to_account_info()], ctx.remaining_accounts].concat(),
-        self_authority_seeds
+        self_authority_seeds,
     )?;
 
     Ok(())

--- a/programs/svm-spoke/src/instructions/instruction_params.rs
+++ b/programs/svm-spoke/src/instructions/instruction_params.rs
@@ -1,4 +1,4 @@
-use anchor_lang::{ prelude::*, solana_program::system_program };
+use anchor_lang::{prelude::*, solana_program::system_program};
 
 use crate::error::SvmError;
 
@@ -36,7 +36,7 @@ pub struct WriteInstructionParamsFragment<'info> {
 pub fn write_instruction_params_fragment<'info>(
     ctx: Context<WriteInstructionParamsFragment<'info>>,
     offset: u32,
-    fragment: Vec<u8>
+    fragment: Vec<u8>,
 ) -> Result<()> {
     let account_info = ctx.accounts.instruction_params.to_account_info();
 

--- a/programs/svm-spoke/src/instructions/mod.rs
+++ b/programs/svm-spoke/src/instructions/mod.rs
@@ -1,6 +1,6 @@
 mod admin;
-mod create_token_accounts;
 mod bundle;
+mod create_token_accounts;
 mod deposit;
 mod fill;
 mod handle_receive_message;
@@ -11,8 +11,8 @@ mod testable;
 mod token_bridge;
 
 pub use admin::*;
-pub use create_token_accounts::*;
 pub use bundle::*;
+pub use create_token_accounts::*;
 pub use deposit::*;
 pub use fill::*;
 pub use handle_receive_message::*;

--- a/programs/svm-spoke/src/instructions/refund_claims.rs
+++ b/programs/svm-spoke/src/instructions/refund_claims.rs
@@ -1,11 +1,11 @@
 use anchor_lang::prelude::*;
-use anchor_spl::token_interface::{ transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked };
+use anchor_spl::token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked};
 
 use crate::{
     constants::DISCRIMINATOR_SIZE,
     error::SvmError,
     event::ClaimedRelayerRefund,
-    state::{ ClaimAccount, State },
+    state::{ClaimAccount, State},
 };
 
 #[derive(Accounts)]
@@ -94,7 +94,7 @@ pub fn claim_relayer_refund(ctx: Context<ClaimRelayerRefund>) -> Result<()> {
     let cpi_context = CpiContext::new_with_signer(
         ctx.accounts.token_program.to_account_info(),
         transfer_accounts,
-        signer_seeds
+        signer_seeds,
     );
     transfer_checked(cpi_context, claim_amount, ctx.accounts.mint.decimals)?;
 

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -1,17 +1,17 @@
-use anchor_lang::{ prelude::*, solana_program::keccak };
-use anchor_spl::token_interface::{ transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked };
+use anchor_lang::{prelude::*, solana_program::keccak};
+use anchor_spl::token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked};
 
 use crate::{
+    common::V3RelayData,
     constants::DISCRIMINATOR_SIZE,
     constraints::is_relay_hash_valid,
-    error::{ CommonError, SvmError },
+    error::{CommonError, SvmError},
     get_current_time,
-    state::{ FillStatus, FillStatusAccount, RootBundle, State },
-    common::V3RelayData,
+    state::{FillStatus, FillStatusAccount, RootBundle, State},
     utils::verify_merkle_proof,
 };
 
-use crate::event::{ FillType, FilledV3Relay, RequestedV3SlowFill, V3RelayExecutionEventInfo };
+use crate::event::{FillType, FilledV3Relay, RequestedV3SlowFill, V3RelayExecutionEventInfo};
 
 #[event_cpi]
 #[derive(Accounts)]
@@ -169,14 +169,14 @@ pub struct ExecuteV3SlowRelayLeaf<'info> {
 pub fn execute_v3_slow_relay_leaf(
     ctx: Context<ExecuteV3SlowRelayLeaf>,
     slow_fill_leaf: V3SlowFill,
-    proof: Vec<[u8; 32]>
+    proof: Vec<[u8; 32]>,
 ) -> Result<()> {
     let current_time = get_current_time(&ctx.accounts.state)?;
 
     let relay_data = slow_fill_leaf.relay_data;
 
     let slow_fill = V3SlowFill {
-        relay_data: relay_data.clone(), // Clone relay_data to avoid move
+        relay_data: relay_data.clone(),        // Clone relay_data to avoid move
         chain_id: ctx.accounts.state.chain_id, // This overrides caller provided chain_id, same as in EVM SpokePool.
         updated_output_amount: slow_fill_leaf.updated_output_amount,
     };
@@ -206,14 +206,18 @@ pub fn execute_v3_slow_relay_leaf(
         from: ctx.accounts.vault.to_account_info(), // Pull from the vault
         mint: ctx.accounts.mint.to_account_info(),
         to: ctx.accounts.recipient_token_account.to_account_info(), // Send to the recipient
-        authority: ctx.accounts.state.to_account_info(), // Authority is the state (owner of the vault)
+        authority: ctx.accounts.state.to_account_info(),            // Authority is the state (owner of the vault)
     };
     let cpi_context = CpiContext::new_with_signer(
         ctx.accounts.token_program.to_account_info(),
         transfer_accounts,
-        signer_seeds
+        signer_seeds,
     );
-    transfer_checked(cpi_context, slow_fill_leaf.updated_output_amount, ctx.accounts.mint.decimals)?;
+    transfer_checked(
+        cpi_context,
+        slow_fill_leaf.updated_output_amount,
+        ctx.accounts.mint.decimals,
+    )?;
 
     // Update the fill status to Filled. Note we don't set the relayer here as it is set when the slow fill was requested.
     fill_status_account.status = FillStatus::Filled;

--- a/programs/svm-spoke/src/instructions/token_bridge.rs
+++ b/programs/svm-spoke/src/instructions/token_bridge.rs
@@ -1,18 +1,14 @@
 use anchor_lang::prelude::*;
-use anchor_spl::token_interface::{ Mint, TokenAccount, TokenInterface };
+use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
 use crate::{
     error::SvmError,
     event::BridgedToHubPool,
     message_transmitter::program::MessageTransmitter,
     token_messenger_minter::{
-        self,
-        cpi::accounts::DepositForBurn,
-        program::TokenMessengerMinter,
-        types::DepositForBurnParams,
+        self, cpi::accounts::DepositForBurn, program::TokenMessengerMinter, types::DepositForBurnParams,
     },
-    State,
-    TransferLiability,
+    State, TransferLiability,
 };
 
 #[event_cpi]
@@ -117,7 +113,10 @@ pub fn bridge_tokens_to_hub_pool(ctx: Context<BridgeTokensToHubPool>, amount: u6
     };
     token_messenger_minter::cpi::deposit_for_burn(cpi_ctx, params)?;
 
-    emit_cpi!(BridgedToHubPool { amount, mint: ctx.accounts.mint.key() });
+    emit_cpi!(BridgedToHubPool {
+        amount,
+        mint: ctx.accounts.mint.key(),
+    });
 
     Ok(())
 }

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -6,6 +6,7 @@ declare_id!("Fdedr2RqfufUiE1sbVEfpSQ3NADJqxrvu1zojWpQJj4q");
 declare_program!(message_transmitter);
 declare_program!(token_messenger_minter);
 
+pub mod common;
 pub mod constants;
 mod constraints;
 pub mod error;
@@ -13,11 +14,10 @@ pub mod event;
 mod instructions;
 mod state;
 pub mod utils;
-pub mod common;
 
+use common::*;
 use instructions::*;
 use state::*;
-use common::*;
 
 #[program]
 pub mod svm_spoke {
@@ -32,7 +32,7 @@ pub mod svm_spoke {
         remote_domain: u32,
         cross_domain_admin: Pubkey,
         deposit_quote_time_buffer: u32,
-        fill_deadline_buffer: u32
+        fill_deadline_buffer: u32,
     ) -> Result<()> {
         instructions::initialize(
             ctx,
@@ -42,7 +42,7 @@ pub mod svm_spoke {
             remote_domain,
             cross_domain_admin,
             deposit_quote_time_buffer,
-            fill_deadline_buffer
+            fill_deadline_buffer,
         )
     }
 
@@ -57,22 +57,23 @@ pub mod svm_spoke {
     pub fn relay_root_bundle(
         ctx: Context<RelayRootBundle>,
         relayer_refund_root: [u8; 32],
-        slow_relay_root: [u8; 32]
+        slow_relay_root: [u8; 32],
     ) -> Result<()> {
         instructions::relay_root_bundle(ctx, relayer_refund_root, slow_relay_root)
     }
 
     pub fn emergency_delete_root_bundle(
         ctx: Context<EmergencyDeleteRootBundleState>,
-        root_bundle_id: u32
+        root_bundle_id: u32,
     ) -> Result<()> {
         instructions::emergency_delete_root_bundle(ctx, root_bundle_id)
     }
 
     pub fn execute_relayer_refund_leaf<'c, 'info>(
-        ctx: Context<'_, '_, 'c, 'info, ExecuteRelayerRefundLeaf<'info>>
+        ctx: Context<'_, '_, 'c, 'info, ExecuteRelayerRefundLeaf<'info>>,
     ) -> Result<()>
-        where 'c: 'info
+    where
+        'c: 'info,
     {
         instructions::execute_relayer_refund_leaf(ctx)
     }
@@ -89,7 +90,7 @@ pub mod svm_spoke {
         ctx: Context<SetEnableRoute>,
         origin_token: Pubkey,
         destination_chain_id: u64,
-        enabled: bool
+        enabled: bool,
     ) -> Result<()> {
         instructions::set_enable_route(ctx, origin_token, destination_chain_id, enabled)
     }
@@ -112,7 +113,7 @@ pub mod svm_spoke {
         quote_timestamp: u32,
         fill_deadline: u32,
         exclusivity_deadline: u32,
-        message: Vec<u8>
+        message: Vec<u8>,
     ) -> Result<()> {
         instructions::deposit_v3(
             ctx,
@@ -127,7 +128,7 @@ pub mod svm_spoke {
             quote_timestamp,
             fill_deadline,
             exclusivity_deadline,
-            message
+            message,
         )
     }
 
@@ -137,7 +138,7 @@ pub mod svm_spoke {
         _relay_hash: [u8; 32],
         relay_data: V3RelayData,
         repayment_chain_id: u64,
-        repayment_address: Pubkey
+        repayment_address: Pubkey,
     ) -> Result<()> {
         instructions::fill_v3_relay(ctx, relay_data, repayment_chain_id, repayment_address)
     }
@@ -149,7 +150,7 @@ pub mod svm_spoke {
     // CCTP methods.
     pub fn handle_receive_message<'info>(
         ctx: Context<'_, '_, '_, 'info, HandleReceiveMessage<'info>>,
-        params: HandleReceiveMessageParams
+        params: HandleReceiveMessageParams,
     ) -> Result<()> {
         let self_ix_data = ctx.accounts.handle_receive_message(&params)?;
 
@@ -162,7 +163,7 @@ pub mod svm_spoke {
     pub fn request_v3_slow_fill(
         ctx: Context<SlowFillV3Relay>,
         _relay_hash: [u8; 32],
-        relay_data: V3RelayData
+        relay_data: V3RelayData,
     ) -> Result<()> {
         instructions::request_v3_slow_fill(ctx, relay_data)
     }
@@ -172,7 +173,7 @@ pub mod svm_spoke {
         _relay_hash: [u8; 32],
         slow_fill_leaf: V3SlowFill,
         _root_bundle_id: u32,
-        proof: Vec<[u8; 32]>
+        proof: Vec<[u8; 32]>,
     ) -> Result<()> {
         instructions::execute_v3_slow_relay_leaf(ctx, slow_fill_leaf, proof)
     }
@@ -189,7 +190,7 @@ pub mod svm_spoke {
     pub fn write_instruction_params_fragment<'info>(
         ctx: Context<WriteInstructionParamsFragment<'info>>,
         offset: u32,
-        fragment: Vec<u8>
+        fragment: Vec<u8>,
     ) -> Result<()> {
         instructions::write_instruction_params_fragment(ctx, offset, fragment)
     }
@@ -201,7 +202,7 @@ pub mod svm_spoke {
     pub fn initialize_claim_account(
         ctx: Context<InitializeClaimAccount>,
         _mint: Pubkey,
-        _token_account: Pubkey
+        _token_account: Pubkey,
     ) -> Result<()> {
         instructions::initialize_claim_account(ctx)
     }
@@ -212,8 +213,8 @@ pub mod svm_spoke {
 
     pub fn close_claim_account(
         ctx: Context<CloseClaimAccount>,
-        _mint: Pubkey, // Only used in account constraints.
-        _token_account: Pubkey // Only used in account constraints.
+        _mint: Pubkey,          // Only used in account constraints.
+        _token_account: Pubkey, // Only used in account constraints.
     ) -> Result<()> {
         instructions::close_claim_account(ctx)
     }

--- a/programs/svm-spoke/src/state/refund_account.rs
+++ b/programs/svm-spoke/src/state/refund_account.rs
@@ -18,7 +18,10 @@ pub enum RefundAccount<'info> {
 }
 // TODO: consider if we can avoid this dual account and pass both ATA and claim account arrays.
 
-impl<'c, 'info> RefundAccount<'info> where 'c: 'info {
+impl<'c, 'info> RefundAccount<'info>
+where
+    'c: 'info,
+{
     // This function is used to parse a refund account from the remaining accounts list. It first tries to parse it as
     // a token account and if that fails, it tries to parse it as a claim account.
     pub fn try_from_remaining_account(
@@ -26,7 +29,7 @@ impl<'c, 'info> RefundAccount<'info> where 'c: 'info {
         index: usize,
         expected_token_account: &Pubkey,
         expected_mint: &Pubkey,
-        token_program: &Pubkey
+        token_program: &Pubkey,
     ) -> Result<Self> {
         let refund_account_info = remaining_accounts.get(index).ok_or(ErrorCode::AccountNotEnoughKeys)?;
 
@@ -34,19 +37,16 @@ impl<'c, 'info> RefundAccount<'info> where 'c: 'info {
             refund_account_info,
             expected_token_account,
             expected_mint,
-            token_program
+            token_program,
         )
-            .map(Self::TokenAccount)
-            .or_else(|| {
-                Self::try_claim_account_from_account_info(
-                    refund_account_info,
-                    expected_mint,
-                    expected_token_account
-                ).map(Self::ClaimAccount)
-            })
-            .ok_or_else(|| {
-                error::Error::from(SvmError::InvalidRefund).with_account_name(&format!("remaining_accounts[{}]", index))
-            })
+        .map(Self::TokenAccount)
+        .or_else(|| {
+            Self::try_claim_account_from_account_info(refund_account_info, expected_mint, expected_token_account)
+                .map(Self::ClaimAccount)
+        })
+        .ok_or_else(|| {
+            error::Error::from(SvmError::InvalidRefund).with_account_name(&format!("remaining_accounts[{}]", index))
+        })
     }
 
     // This implements the following Anchor account constraints when parsing remaining account as a token account:
@@ -62,7 +62,7 @@ impl<'c, 'info> RefundAccount<'info> where 'c: 'info {
         account_info: &'info AccountInfo<'info>,
         expected_token_account: &Pubkey,
         expected_mint: &Pubkey,
-        token_program: &Pubkey
+        token_program: &Pubkey,
     ) -> Option<InterfaceAccount<'info, TokenAccount>> {
         // Checks ownership on deserialization for the TokenAccount interface.
         let token_account: InterfaceAccount<'info, TokenAccount> = InterfaceAccount::try_from(account_info).ok()?;
@@ -101,16 +101,14 @@ impl<'c, 'info> RefundAccount<'info> where 'c: 'info {
     fn try_claim_account_from_account_info(
         account_info: &'info AccountInfo<'info>,
         mint: &Pubkey,
-        token_account: &Pubkey
+        token_account: &Pubkey,
     ) -> Option<Account<'info, ClaimAccount>> {
         // Checks ownership on deserialization for the ClaimAccount.
         let claim_account: Account<'info, ClaimAccount> = Account::try_from(account_info).ok()?;
 
         // Checks the PDA is derived from mint and token account keys.
-        let (pda_address, _bump) = Pubkey::find_program_address(
-            &[b"claim_account", mint.as_ref(), token_account.as_ref()],
-            &crate::ID
-        );
+        let (pda_address, _bump) =
+            Pubkey::find_program_address(&[b"claim_account", mint.as_ref(), token_account.as_ref()], &crate::ID);
         if account_info.key != &pda_address {
             return None;
         }

--- a/programs/svm-spoke/src/state/state.rs
+++ b/programs/svm-spoke/src/state/state.rs
@@ -8,11 +8,11 @@ pub struct State {
     pub owner: Pubkey,
     pub seed: u64, // Add a seed to the state to enable multiple deployments.
     pub number_of_deposits: u32,
-    pub chain_id: u64, // Across definition of chainId for Solana.
-    pub current_time: u32, // Only used in testable mode, else set to 0 on mainnet.
-    pub remote_domain: u32, // CCTP domain for Mainnet Ethereum.
-    pub cross_domain_admin: Pubkey, // HubPool on Mainnet Ethereum.
-    pub root_bundle_id: u32, // TODO rename to next_root_bundle_id
+    pub chain_id: u64,                  // Across definition of chainId for Solana.
+    pub current_time: u32,              // Only used in testable mode, else set to 0 on mainnet.
+    pub remote_domain: u32,             // CCTP domain for Mainnet Ethereum.
+    pub cross_domain_admin: Pubkey,     // HubPool on Mainnet Ethereum.
+    pub root_bundle_id: u32,            // TODO rename to next_root_bundle_id
     pub deposit_quote_time_buffer: u32, // Deposit quote times can't be set more than this amount into the past/future.
-    pub fill_deadline_buffer: u32, // Fill deadlines can't be set more than this amount into the future.
+    pub fill_deadline_buffer: u32,      // Fill deadlines can't be set more than this amount into the future.
 }

--- a/programs/svm-spoke/src/utils/cctp_utils.rs
+++ b/programs/svm-spoke/src/utils/cctp_utils.rs
@@ -2,7 +2,7 @@ use std::mem::size_of_val;
 
 use anchor_lang::prelude::*;
 
-use crate::{ constants::DISCRIMINATOR_SIZE, error::CallDataError, program::SvmSpoke };
+use crate::{constants::DISCRIMINATOR_SIZE, error::CallDataError, program::SvmSpoke};
 
 pub trait EncodeInstructionData {
     fn encode_instruction_data(&self, discriminator_str: &str) -> Result<Vec<u8>>;
@@ -12,7 +12,7 @@ impl<T: AnchorSerialize> EncodeInstructionData for T {
     fn encode_instruction_data(&self, discriminator_str: &str) -> Result<Vec<u8>> {
         let mut data = Vec::with_capacity(DISCRIMINATOR_SIZE + size_of_val(self));
         data.extend_from_slice(
-            &anchor_lang::solana_program::hash::hash(discriminator_str.as_bytes()).to_bytes()[..DISCRIMINATOR_SIZE]
+            &anchor_lang::solana_program::hash::hash(discriminator_str.as_bytes()).to_bytes()[..DISCRIMINATOR_SIZE],
         );
         data.extend_from_slice(&self.try_to_vec()?);
 
@@ -44,14 +44,13 @@ pub fn decode_solidity_bool(data: &[u8; 32]) -> Result<bool> {
     let h_value = u128::from_be_bytes(data[..16].try_into().unwrap());
     let l_value = u128::from_be_bytes(data[16..].try_into().unwrap());
     match h_value {
-        0 =>
-            match l_value {
-                0 => Ok(false),
-                1 => Ok(true),
-                _ => {
-                    return err!(CallDataError::InvalidBool);
-                }
+        0 => match l_value {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => {
+                return err!(CallDataError::InvalidBool);
             }
+        },
         _ => {
             return err!(CallDataError::InvalidBool);
         }

--- a/programs/svm-spoke/src/utils/merkle_proof_utils.rs
+++ b/programs/svm-spoke/src/utils/merkle_proof_utils.rs
@@ -1,6 +1,6 @@
-use anchor_lang::{ prelude::*, solana_program::keccak };
+use anchor_lang::{prelude::*, solana_program::keccak};
 
-use crate::{ error::CommonError, common::V3RelayData };
+use crate::{common::V3RelayData, error::CommonError};
 
 pub fn get_v3_relay_hash(relay_data: &V3RelayData, chain_id: u64) -> [u8; 32] {
     let mut input = relay_data.try_to_vec().unwrap();
@@ -29,7 +29,11 @@ pub fn process_proof(proof: &[[u8; 32]], leaf: &[u8; 32]) -> [u8; 32] {
 
 // See https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/Hashes.sol
 fn commutative_keccak256(a: &[u8; 32], b: &[u8; 32]) -> [u8; 32] {
-    if a < b { efficient_keccak256(a, b) } else { efficient_keccak256(b, a) }
+    if a < b {
+        efficient_keccak256(a, b)
+    } else {
+        efficient_keccak256(b, a)
+    }
 }
 
 fn efficient_keccak256(a: &[u8; 32], b: &[u8; 32]) -> [u8; 32] {

--- a/programs/test/src/lib.rs
+++ b/programs/test/src/lib.rs
@@ -1,5 +1,9 @@
 use anchor_lang::prelude::*;
-use svm_spoke::{ constants::DISCRIMINATOR_SIZE, error::CommonError, utils::{ is_claimed, process_proof, set_claimed } };
+use svm_spoke::{
+    constants::DISCRIMINATOR_SIZE,
+    error::CommonError,
+    utils::{is_claimed, process_proof, set_claimed},
+};
 
 declare_id!("84j1xFuoz2xynhesB8hxC5N1zaWPr4MW1DD2gVm9PUs4");
 

--- a/scripts/preCommitHook.sh
+++ b/scripts/preCommitHook.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# This script runs pretty-quick and rustfmt on staged files before committing. It is intended to be used as a pre-commit
+# hook. We want to run pretty-quick first, so that it handles formatting of macro lines in rust code, but we use rustfmt
+# on top of it to use standard rust formatting for the rest of the rust code.
+
+# Store staged rust files for later use in rustfmt as pretty-quick might revert some changes
+STAGED_RUST_FILES=$(git diff --cached --name-only --diff-filter=d | grep '\.rs$')
+
+echo "Running pretty-quick on staged files ..."
+
+yarn pretty-quick --staged
+PRETTY_QUICK_EXIT=$?
+if [ $PRETTY_QUICK_EXIT -ne 0 ]; then
+    echo "pretty-quick encountered an error. Aborting the hook."
+    exit $PRETTY_QUICK_EXIT
+fi
+
+echo "Running rustfmt on staged files ..."
+
+if [ -n "$STAGED_RUST_FILES" ]; then
+    echo "$STAGED_RUST_FILES" | xargs -I {} rustfmt --edition 2021 {}
+    RUSTFMT_EXIT=$?
+    if [ $RUSTFMT_EXIT -ne 0 ]; then
+        echo "rustfmt encountered an error. Aborting the hook."
+        exit $RUSTFMT_EXIT
+    fi
+
+    # Restage any formatted rust files
+    echo "$STAGED_RUST_FILES" | xargs git add
+fi

--- a/scripts/preCommitHook.sh
+++ b/scripts/preCommitHook.sh
@@ -19,7 +19,7 @@ fi
 echo "Running rustfmt on staged files ..."
 
 if [ -n "$STAGED_RUST_FILES" ]; then
-    echo "$STAGED_RUST_FILES" | xargs -I {} rustfmt --edition 2021 {}
+    echo "$STAGED_RUST_FILES" | xargs -I {} rustfmt {}
     RUSTFMT_EXIT=$?
     if [ $RUSTFMT_EXIT -ne 0 ]; then
         echo "rustfmt encountered an error. Aborting the hook."


### PR DESCRIPTION
We introduced prettier plugin to lint rust code, mostly to format Anchor attribute macros that rustfmt does not handle well. This though, brought in quite a lot of opinionated formatting for the rest of the rust code from prettier. In order to be more aligned with default rust formatting, this PR introduces wrapper pre-commit hook that first runs prettier-quick and then applies rustfmt on top for any staged rust files.

The only deviation from default rust formatting this PR adds is extending maximum line with to 120 characters to be consistent with other parts of this repo.