### PR TITLE
fix(svm): instruction to create multiple token accounts

### DIFF
--- a/programs/svm-spoke/src/error.rs
+++ b/programs/svm-spoke/src/error.rs
@@ -71,6 +71,8 @@ pub enum SvmError {
     InvalidClaimInitializer,
     #[msg("Seed must be 0 in production!")]
     InvalidProductionSeed,
+    #[msg("Invalid remaining accounts for ATA creation!")]
+    InvalidATACreationAccounts,
 }
 
 // Errors to handle the CCTP interactions.

--- a/programs/svm-spoke/src/instructions/create_token_accounts.rs
+++ b/programs/svm-spoke/src/instructions/create_token_accounts.rs
@@ -1,0 +1,46 @@
+use anchor_lang::prelude::*;
+use anchor_spl::{ associated_token::{ self, AssociatedToken }, token_interface::{ Mint, TokenInterface } };
+
+use crate::error::SvmError;
+
+#[derive(Accounts)]
+pub struct CreateTokenAccounts<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+
+    #[account(mint::token_program = token_program)]
+    pub mint: InterfaceAccount<'info, Mint>,
+
+    pub token_program: Interface<'info, TokenInterface>,
+
+    pub associated_token_program: Program<'info, AssociatedToken>,
+
+    pub system_program: Program<'info, System>,
+}
+
+pub fn create_token_accounts<'info>(ctx: Context<'_, '_, '_, 'info, CreateTokenAccounts<'info>>) -> Result<()> {
+    // Remaining accounts must be passed in pairs of owner and ATA accounts.
+    if ctx.remaining_accounts.len() % 2 != 0 {
+        return err!(SvmError::InvalidATACreationAccounts);
+    }
+
+    for accounts in ctx.remaining_accounts.chunks(2) {
+        // We don't need to perform any additional checks as they will be done within ATA creation CPI.
+        let authority = &accounts[0];
+        let associated_token = &accounts[1];
+
+        let cpi_program = ctx.accounts.associated_token_program.to_account_info();
+        let cpi_accounts = associated_token::Create {
+            payer: ctx.accounts.signer.to_account_info(),
+            associated_token: associated_token.to_account_info(),
+            authority: authority.to_account_info(),
+            mint: ctx.accounts.mint.to_account_info(),
+            system_program: ctx.accounts.system_program.to_account_info(),
+            token_program: ctx.accounts.token_program.to_account_info(),
+        };
+        let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+        associated_token::create_idempotent(cpi_ctx)?;
+    }
+
+    Ok(())
+}

--- a/programs/svm-spoke/src/instructions/mod.rs
+++ b/programs/svm-spoke/src/instructions/mod.rs
@@ -1,4 +1,5 @@
 mod admin;
+mod create_token_accounts;
 mod bundle;
 mod deposit;
 mod fill;
@@ -10,6 +11,7 @@ mod testable;
 mod token_bridge;
 
 pub use admin::*;
+pub use create_token_accounts::*;
 pub use bundle::*;
 pub use deposit::*;
 pub use fill::*;

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -217,4 +217,8 @@ pub mod svm_spoke {
     ) -> Result<()> {
         instructions::close_claim_account(ctx)
     }
+
+    pub fn create_token_accounts<'info>(ctx: Context<'_, '_, '_, 'info, CreateTokenAccounts<'info>>) -> Result<()> {
+        instructions::create_token_accounts(ctx)
+    }
 }

--- a/test/svm/SvmSpoke.CreateTokenAccounts.ts
+++ b/test/svm/SvmSpoke.CreateTokenAccounts.ts
@@ -1,0 +1,150 @@
+import * as anchor from "@coral-xyz/anchor";
+import { AnchorError, AnchorProvider, Wallet } from "@coral-xyz/anchor";
+import { Keypair, PublicKey } from "@solana/web3.js";
+import {
+  createMint,
+  getOrCreateAssociatedTokenAccount,
+  TOKEN_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  getAccount,
+} from "@solana/spl-token";
+import { common } from "./SvmSpoke.common";
+
+const { provider, program, connection, assertSE, assert, owner } = common;
+
+describe("svm_spoke.create_token_accounts", () => {
+  anchor.setProvider(provider);
+
+  const payer = (AnchorProvider.env().wallet as Wallet).payer;
+
+  let mint: PublicKey;
+
+  beforeEach(async () => {
+    mint = await createMint(connection, payer, owner, owner, 6);
+  });
+
+  it("Creates single associated token account", async () => {
+    const authority = Keypair.generate().publicKey;
+    const associatedToken = getAssociatedTokenAddressSync(mint, authority);
+
+    const remainingAccounts = [
+      { pubkey: authority, isWritable: false, isSigner: false },
+      { pubkey: associatedToken, isWritable: true, isSigner: false },
+    ];
+
+    await program.methods
+      .createTokenAccounts()
+      .accounts({ mint, tokenProgram: TOKEN_PROGRAM_ID })
+      .remainingAccounts(remainingAccounts)
+      .rpc();
+
+    const associatedTokenAccount = await getAccount(connection, associatedToken);
+    assertSE(associatedTokenAccount.address, associatedToken, "Wrong address");
+    assertSE(associatedTokenAccount.mint, mint, "Wrong mint");
+    assertSE(associatedTokenAccount.owner, authority, "Wrong owner");
+    assert.isTrue(associatedTokenAccount.isInitialized, "Account not initialized");
+  });
+
+  it("Handles already created token account", async () => {
+    const authority = Keypair.generate().publicKey;
+    const associatedTokenAccount = await getOrCreateAssociatedTokenAccount(connection, payer, mint, authority);
+    assertSE(associatedTokenAccount.mint, mint, "Wrong mint");
+    assertSE(associatedTokenAccount.owner, authority, "Wrong owner");
+    assert.isTrue(associatedTokenAccount.isInitialized, "Account not initialized");
+
+    const remainingAccounts = [
+      { pubkey: authority, isWritable: false, isSigner: false },
+      { pubkey: associatedTokenAccount.address, isWritable: true, isSigner: false },
+    ];
+
+    // Should not fail when running against already created account
+    await program.methods
+      .createTokenAccounts()
+      .accounts({ mint, tokenProgram: TOKEN_PROGRAM_ID })
+      .remainingAccounts(remainingAccounts)
+      .rpc();
+  });
+
+  it("Wrong token program", async () => {
+    const authority = Keypair.generate().publicKey;
+    // By default mint and ATA uses the old token program
+    const associatedToken = getAssociatedTokenAddressSync(mint, authority);
+
+    const remainingAccounts = [
+      { pubkey: authority, isWritable: false, isSigner: false },
+      { pubkey: associatedToken, isWritable: true, isSigner: false },
+    ];
+
+    // Should fail when passing the new token program
+    try {
+      await program.methods
+        .createTokenAccounts()
+        .accounts({ mint, tokenProgram: TOKEN_2022_PROGRAM_ID })
+        .remainingAccounts(remainingAccounts)
+        .rpc();
+      assert.fail("Should have failed with wrong token program");
+    } catch (error: any) {
+      assert.instanceOf(error, AnchorError);
+      assertSE(
+        error.error.errorCode.code,
+        "ConstraintMintTokenProgram",
+        "Expected error code ConstraintMintTokenProgram"
+      );
+    }
+  });
+
+  it("Invalid remaining accounts for ATA creation", async () => {
+    const authority = Keypair.generate().publicKey;
+    const associatedToken = getAssociatedTokenAddressSync(mint, authority);
+
+    // Omit ATA for the second pair
+    const remainingAccounts = [
+      { pubkey: authority, isWritable: false, isSigner: false },
+      { pubkey: associatedToken, isWritable: true, isSigner: false },
+      { pubkey: authority, isWritable: false, isSigner: false },
+    ];
+
+    // Should fail when passing odd number of remaining accounts
+    try {
+      await program.methods
+        .createTokenAccounts()
+        .accounts({ mint, tokenProgram: TOKEN_PROGRAM_ID })
+        .remainingAccounts(remainingAccounts)
+        .rpc();
+      assert.fail("Should have failed with odd number of remaining accounts");
+    } catch (error: any) {
+      assert.instanceOf(error, AnchorError);
+      assertSE(
+        error.error.errorCode.code,
+        "InvalidATACreationAccounts",
+        "Expected error code InvalidATACreationAccounts"
+      );
+    }
+  });
+
+  it("Duplicate accounts", async () => {
+    const authority = Keypair.generate().publicKey;
+    const associatedToken = getAssociatedTokenAddressSync(mint, authority);
+
+    // Pass duplicate account pairs
+    const remainingAccounts = [
+      { pubkey: authority, isWritable: false, isSigner: false },
+      { pubkey: associatedToken, isWritable: true, isSigner: false },
+      { pubkey: authority, isWritable: false, isSigner: false },
+      { pubkey: associatedToken, isWritable: true, isSigner: false },
+    ];
+
+    await program.methods
+      .createTokenAccounts()
+      .accounts({ mint, tokenProgram: TOKEN_PROGRAM_ID })
+      .remainingAccounts(remainingAccounts)
+      .rpc();
+
+    const associatedTokenAccount = await getAccount(connection, associatedToken);
+    assertSE(associatedTokenAccount.address, associatedToken, "Wrong address");
+    assertSE(associatedTokenAccount.mint, mint, "Wrong mint");
+    assertSE(associatedTokenAccount.owner, authority, "Wrong owner");
+    assert.isTrue(associatedTokenAccount.isInitialized, "Account not initialized");
+  });
+});

--- a/test/svm/SvmSpoke.Fill.ts
+++ b/test/svm/SvmSpoke.Fill.ts
@@ -1,5 +1,5 @@
 import * as anchor from "@coral-xyz/anchor";
-import { BN } from "@coral-xyz/anchor";
+import { BN, web3 } from "@coral-xyz/anchor";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
@@ -8,8 +8,16 @@ import {
   getOrCreateAssociatedTokenAccount,
   mintTo,
   getAccount,
+  getAssociatedTokenAddressSync,
 } from "@solana/spl-token";
-import { PublicKey, Keypair } from "@solana/web3.js";
+import {
+  PublicKey,
+  Keypair,
+  TransactionInstruction,
+  AddressLookupTableProgram,
+  VersionedTransaction,
+  TransactionMessage,
+} from "@solana/web3.js";
 import { readProgramEvents, calculateRelayHashUint8Array } from "../../src/SvmUtils";
 import { common } from "./SvmSpoke.common";
 const { provider, connection, program, owner, chainId, seedBalance } = common;
@@ -424,5 +432,105 @@ describe("svm_spoke.fill", () => {
       iRecipientBal + BigInt(relayAmount),
       "Recipient's balance should be increased by the relay amount"
     );
+  });
+
+  it("Max fills in one transaction with account creation", async () => {
+    // Save relayer balance before the the fills
+    const iRelayerBal = (await getAccount(connection, relayerTA)).amount;
+
+    // Larger number of fills would exceed the transaction size limit.
+    const numberOfFills = 2;
+
+    // Build instruction for all recipient ATA creation
+    const recipientAuthorities = Array.from({ length: numberOfFills }, () => Keypair.generate().publicKey);
+    const recipientAssociatedTokens = recipientAuthorities.map((authority) =>
+      getAssociatedTokenAddressSync(mint, authority)
+    );
+    const remainingAccounts = recipientAuthorities.flatMap((authority, index) => [
+      { pubkey: authority, isWritable: false, isSigner: false },
+      { pubkey: recipientAssociatedTokens[index], isWritable: true, isSigner: false },
+    ]);
+    const createTokenAccountsInstruction = await program.methods
+      .createTokenAccounts()
+      .accounts({ signer: relayer.publicKey, mint, tokenProgram: TOKEN_PROGRAM_ID })
+      .remainingAccounts(remainingAccounts)
+      .instruction();
+
+    // Build instructions for all fills
+    const fillInstructions: TransactionInstruction[] = [];
+    for (let i = 0; i < numberOfFills; i++) {
+      const newRelayData = {
+        ...relayData,
+        recipient: recipientAuthorities[i],
+        depositId: new BN(Math.floor(Math.random() * 1000000)),
+      };
+      updateRelayData(newRelayData);
+      accounts.recipientTokenAccount = recipientAssociatedTokens[i];
+      const relayHash = Array.from(calculateRelayHashUint8Array(newRelayData, chainId));
+      const fillInstruction = await program.methods
+        .fillV3Relay(relayHash, newRelayData, new BN(1), relayer.publicKey)
+        .accounts(accounts)
+        .instruction();
+      fillInstructions.push(fillInstruction);
+    }
+
+    // Consolidate all above addresses into a single array for the  Address Lookup Table (ALT).
+    const lookupAddresses = [...Object.values(accounts), ...recipientAuthorities, ...recipientAssociatedTokens];
+
+    // Create instructions for creating and extending the ALT.
+    const [lookupTableInstruction, lookupTableAddress] = await AddressLookupTableProgram.createLookupTable({
+      authority: relayer.publicKey,
+      payer: relayer.publicKey,
+      recentSlot: await connection.getSlot(),
+    });
+
+    // Submit the ALT creation transaction
+    await web3.sendAndConfirmTransaction(connection, new web3.Transaction().add(lookupTableInstruction), [relayer], {
+      skipPreflight: true, // Avoids recent slot mismatch in simulation.
+    });
+
+    // Extend the ALT with all accounts
+    const extendInstruction = AddressLookupTableProgram.extendLookupTable({
+      lookupTable: lookupTableAddress,
+      authority: relayer.publicKey,
+      payer: relayer.publicKey,
+      addresses: lookupAddresses as PublicKey[],
+    });
+    await web3.sendAndConfirmTransaction(connection, new web3.Transaction().add(extendInstruction), [relayer], {
+      skipPreflight: true, // Avoids recent slot mismatch in simulation.
+    });
+
+    // Avoids invalid ALT index as ALT might not be active yet on the following tx.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // Fetch the AddressLookupTableAccount
+    const lookupTableAccount = (await connection.getAddressLookupTable(lookupTableAddress)).value;
+    if (lookupTableAccount === null) throw new Error("AddressLookupTableAccount not fetched");
+
+    // Create the versioned transaction
+    const versionedTx = new VersionedTransaction(
+      new TransactionMessage({
+        payerKey: relayer.publicKey,
+        recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+        instructions: [createTokenAccountsInstruction, ...fillInstructions],
+      }).compileToV0Message([lookupTableAccount])
+    );
+
+    // Sign and submit the versioned transaction.
+    versionedTx.sign([relayer]);
+    await connection.sendTransaction(versionedTx);
+
+    // Verify balances after the fill
+    await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for tx processing
+    const fRelayerBal = (await getAccount(connection, relayerTA)).amount;
+    assertSE(
+      fRelayerBal,
+      iRelayerBal - BigInt(relayAmount * numberOfFills),
+      "Relayer's balance should be reduced by total relay amount"
+    );
+    recipientAssociatedTokens.forEach(async (recipientAssociatedToken) => {
+      const recipientBal = (await getAccount(connection, recipientAssociatedToken)).amount;
+      assertSE(recipientBal, BigInt(relayAmount), "Recipient's balance should be increased by the relay amount");
+    });
   });
 });


### PR DESCRIPTION
Adds method to create multiple associated token accounts. This instruction can be prepended to other instructions that expect ATAs being initialized.