### PR TITLE
improve(OP): More generic OP chain adapter deployment

### DIFF
--- a/deploy/002_deploy_optimism_adapter.ts
+++ b/deploy/002_deploy_optimism_adapter.ts
@@ -1,6 +1,7 @@
-import { L1_ADDRESS_MAP, USDC, WETH } from "./consts";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { CHAIN_IDs } from "../utils";
+import { L1_ADDRESS_MAP, OP_STACK_ADDRESS_MAP, USDC, WETH } from "./consts";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
@@ -8,8 +9,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const args = [
     WETH[chainId],
-    L1_ADDRESS_MAP[chainId].optimismCrossDomainMessenger,
-    L1_ADDRESS_MAP[chainId].optimismStandardBridge,
+    OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.OPTIMISM].L1CrossDomainMessenger,
+    OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.OPTIMISM].L1StandardBridge,
     USDC[chainId],
     L1_ADDRESS_MAP[chainId].cctpTokenMessenger,
   ];

--- a/deploy/002_deploy_optimism_adapter.ts
+++ b/deploy/002_deploy_optimism_adapter.ts
@@ -3,14 +3,17 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { CHAIN_IDs } from "../utils";
 import { L1_ADDRESS_MAP, OP_STACK_ADDRESS_MAP, USDC, WETH } from "./consts";
 
+const SPOKE_CHAIN_ID = CHAIN_IDs.OPTIMISM;
+
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const chainId = parseInt(await hre.getChainId());
+  const opStack = OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID];
 
   const args = [
     WETH[chainId],
-    OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.OPTIMISM].L1CrossDomainMessenger,
-    OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.OPTIMISM].L1StandardBridge,
+    opStack.L1CrossDomainMessenger,
+    opStack.L1StandardBridge,
     USDC[chainId],
     L1_ADDRESS_MAP[chainId].cctpTokenMessenger,
   ];

--- a/deploy/012_deploy_boba_adapter.ts
+++ b/deploy/012_deploy_boba_adapter.ts
@@ -1,6 +1,7 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { L1_ADDRESS_MAP, WETH } from "./consts";
 import { DeployFunction } from "hardhat-deploy/types";
+import { CHAIN_IDs } from "../utils";
+import { OP_STACK_ADDRESS_MAP, WETH } from "./consts";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
@@ -10,7 +11,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     from: deployer,
     log: true,
     skipIfAlreadyDeployed: true,
-    args: [WETH[chainId], L1_ADDRESS_MAP[chainId].bobaCrossDomainMessenger, L1_ADDRESS_MAP[chainId].bobaStandardBridge],
+    args: [
+      WETH[chainId],
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BOBA].L1CrossDomainMessenger,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BOBA].L1StandardBridge,
+    ],
   });
 };
 

--- a/deploy/012_deploy_boba_adapter.ts
+++ b/deploy/012_deploy_boba_adapter.ts
@@ -3,19 +3,18 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { CHAIN_IDs } from "../utils";
 import { OP_STACK_ADDRESS_MAP, WETH } from "./consts";
 
+const SPOKE_CHAIN_ID = CHAIN_IDs.BOBA;
+
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const chainId = parseInt(await hre.getChainId());
+  const opStack = OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID];
 
   await hre.deployments.deploy("Boba_Adapter", {
     from: deployer,
     log: true,
     skipIfAlreadyDeployed: true,
-    args: [
-      WETH[chainId],
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BOBA].L1CrossDomainMessenger,
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BOBA].L1StandardBridge,
-    ],
+    args: [WETH[chainId], opStack.L1CrossDomainMessenger, opStack.L1StandardBridge],
   });
 };
 

--- a/deploy/024_deploy_base_adapter.ts
+++ b/deploy/024_deploy_base_adapter.ts
@@ -3,14 +3,18 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { CHAIN_IDs } from "../utils";
 import { L1_ADDRESS_MAP, OP_STACK_ADDRESS_MAP, USDC, WETH } from "./consts";
 
+const SPOKE_CHAIN_ID = CHAIN_IDs.BASE;
+
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const chainId = parseInt(await hre.getChainId());
 
+  const addresses = OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID];
+
   const args = [
     WETH[chainId],
-    OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BASE].L1CrossDomainMessenger,
-    OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BASE].L1StandardBridge,
+    addresses.L1CrossDomainMessenger,
+    addresses.L1StandardBridge,
     USDC[chainId],
     L1_ADDRESS_MAP[chainId].cctpTokenMessenger,
   ];

--- a/deploy/024_deploy_base_adapter.ts
+++ b/deploy/024_deploy_base_adapter.ts
@@ -1,6 +1,7 @@
-import { L1_ADDRESS_MAP, USDC, WETH } from "./consts";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { CHAIN_IDs } from "../utils";
+import { L1_ADDRESS_MAP, OP_STACK_ADDRESS_MAP, USDC, WETH } from "./consts";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
@@ -8,11 +9,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const args = [
     WETH[chainId],
-    L1_ADDRESS_MAP[chainId].baseCrossDomainMessenger,
-    L1_ADDRESS_MAP[chainId].baseStandardBridge,
+    OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BASE].L1CrossDomainMessenger,
+    OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BASE].L1StandardBridge,
     USDC[chainId],
     L1_ADDRESS_MAP[chainId].cctpTokenMessenger,
   ];
+
   const instance = await hre.deployments.deploy("Base_Adapter", {
     from: deployer,
     log: true,

--- a/deploy/024_deploy_base_adapter.ts
+++ b/deploy/024_deploy_base_adapter.ts
@@ -8,13 +8,12 @@ const SPOKE_CHAIN_ID = CHAIN_IDs.BASE;
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const chainId = parseInt(await hre.getChainId());
-
-  const addresses = OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID];
+  const opStack = OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID];
 
   const args = [
     WETH[chainId],
-    addresses.L1CrossDomainMessenger,
-    addresses.L1StandardBridge,
+    opStack.L1CrossDomainMessenger,
+    opStack.L1StandardBridge,
     USDC[chainId],
     L1_ADDRESS_MAP[chainId].cctpTokenMessenger,
   ];

--- a/deploy/037_deploy_blast_adapter.ts
+++ b/deploy/037_deploy_blast_adapter.ts
@@ -1,7 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { TOKEN_SYMBOLS_MAP } from "../utils";
-import { L1_ADDRESS_MAP, USDC, WETH } from "./consts";
+import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../utils";
+import { OP_STACK_ADDRESS_MAP, USDC, WETH } from "./consts";
 
 const USDB = TOKEN_SYMBOLS_MAP.USDB.addresses;
 
@@ -15,10 +15,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     skipIfAlreadyDeployed: true,
     args: [
       WETH[chainId],
-      L1_ADDRESS_MAP[chainId].blastCrossDomainMessenger,
-      L1_ADDRESS_MAP[chainId].blastStandardBridge,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BLAST].L1CrossDomainMessenger,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BLAST].L1StandardBridge,
       USDC[chainId],
-      L1_ADDRESS_MAP[chainId].l1BlastBridge,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BLAST].L1BlastBridge,
       USDB[chainId],
       "200_000",
     ],

--- a/deploy/037_deploy_blast_adapter.ts
+++ b/deploy/037_deploy_blast_adapter.ts
@@ -4,10 +4,12 @@ import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../utils";
 import { OP_STACK_ADDRESS_MAP, USDC, WETH } from "./consts";
 
 const USDB = TOKEN_SYMBOLS_MAP.USDB.addresses;
+const SPOKE_CHAIN_ID = CHAIN_IDs.BLAST;
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const chainId = parseInt(await hre.getChainId());
+  const opStack = OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID];
 
   await hre.deployments.deploy("Blast_Adapter", {
     from: deployer,
@@ -15,10 +17,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     skipIfAlreadyDeployed: true,
     args: [
       WETH[chainId],
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BLAST].L1CrossDomainMessenger,
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BLAST].L1StandardBridge,
+      opStack.L1CrossDomainMessenger,
+      opStack.L1StandardBridge,
       USDC[chainId],
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.BLAST].L1BlastBridge,
+      opStack.L1BlastBridge,
       USDB[chainId],
       "200_000",
     ],

--- a/deploy/038_deploy_mode_adapter.ts
+++ b/deploy/038_deploy_mode_adapter.ts
@@ -3,20 +3,18 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { CHAIN_IDs } from "../utils";
 import { OP_STACK_ADDRESS_MAP, USDC, WETH } from "./consts";
 
+const SPOKE_CHAIN_ID = CHAIN_IDs.BOBA;
+
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const chainId = parseInt(await hre.getChainId());
+  const opStack = OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID];
 
   await hre.deployments.deploy("Mode_Adapter", {
     from: deployer,
     log: true,
     skipIfAlreadyDeployed: true,
-    args: [
-      WETH[chainId],
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.MODE].L1CrossDomainMessenger,
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.MODE].LStandardBridge,
-      USDC[chainId],
-    ],
+    args: [WETH[chainId], opStack.L1CrossDomainMessenger, opStack.L1StandardBridge, USDC[chainId]],
   });
 };
 

--- a/deploy/038_deploy_mode_adapter.ts
+++ b/deploy/038_deploy_mode_adapter.ts
@@ -1,6 +1,7 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
-import { L1_ADDRESS_MAP, USDC, WETH } from "./consts";
+import { CHAIN_IDs } from "../utils";
+import { OP_STACK_ADDRESS_MAP, USDC, WETH } from "./consts";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
@@ -12,8 +13,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     skipIfAlreadyDeployed: true,
     args: [
       WETH[chainId],
-      L1_ADDRESS_MAP[chainId].modeCrossDomainMessenger,
-      L1_ADDRESS_MAP[chainId].modeStandardBridge,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.MODE].L1CrossDomainMessenger,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.MODE].LStandardBridge,
       USDC[chainId],
     ],
   });

--- a/deploy/042_deploy_lisk_adapter.ts
+++ b/deploy/042_deploy_lisk_adapter.ts
@@ -3,20 +3,18 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { CHAIN_IDs } from "../utils";
 import { OP_STACK_ADDRESS_MAP, USDC, WETH } from "./consts";
 
+const SPOKE_CHAIN_ID = CHAIN_IDs.LISK;
+
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const chainId = parseInt(await hre.getChainId());
+  const opStack = OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID];
 
   await hre.deployments.deploy("Lisk_Adapter", {
     from: deployer,
     log: true,
     skipIfAlreadyDeployed: true,
-    args: [
-      WETH[chainId],
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.LISK].L1CrossDomainMessenger,
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.LISK].L1StandardBridge,
-      USDC[chainId],
-    ],
+    args: [WETH[chainId], opStack.L1CrossDomainMessenger, opStack.L1StandardBridge, USDC[chainId]],
   });
 };
 

--- a/deploy/042_deploy_lisk_adapter.ts
+++ b/deploy/042_deploy_lisk_adapter.ts
@@ -1,6 +1,7 @@
-import { L1_ADDRESS_MAP, USDC, WETH } from "./consts";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { CHAIN_IDs } from "../utils";
+import { OP_STACK_ADDRESS_MAP, USDC, WETH } from "./consts";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
@@ -12,8 +13,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     skipIfAlreadyDeployed: true,
     args: [
       WETH[chainId],
-      L1_ADDRESS_MAP[chainId].liskCrossDomainMessenger,
-      L1_ADDRESS_MAP[chainId].liskStandardBridge,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.LISK].L1CrossDomainMessenger,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.LISK].L1StandardBridge,
       USDC[chainId],
     ],
   });

--- a/deploy/046_deploy_redstone_adapter.ts
+++ b/deploy/046_deploy_redstone_adapter.ts
@@ -1,6 +1,7 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
-import { L1_ADDRESS_MAP, WETH, ZERO_ADDRESS } from "./consts";
+import { CHAIN_IDs } from "../utils";
+import { OP_STACK_ADDRESS_MAP, WETH, ZERO_ADDRESS } from "./consts";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
@@ -12,8 +13,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     skipIfAlreadyDeployed: true,
     args: [
       WETH[chainId],
-      L1_ADDRESS_MAP[chainId].redstoneCrossDomainMessenger,
-      L1_ADDRESS_MAP[chainId].redstoneStandardBridge,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.REDSTONE].L1CrossDomainMessenger,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.REDSTONE].L1StandardBridge,
       ZERO_ADDRESS,
     ],
   });

--- a/deploy/046_deploy_redstone_adapter.ts
+++ b/deploy/046_deploy_redstone_adapter.ts
@@ -3,20 +3,18 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { CHAIN_IDs } from "../utils";
 import { OP_STACK_ADDRESS_MAP, WETH, ZERO_ADDRESS } from "./consts";
 
+const SPOKE_CHAIN_ID = CHAIN_IDs.REDSTONE;
+
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const chainId = parseInt(await hre.getChainId());
+  const opStack = OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID];
 
   await hre.deployments.deploy("Redstone_Adapter", {
     from: deployer,
     log: true,
     skipIfAlreadyDeployed: true,
-    args: [
-      WETH[chainId],
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.REDSTONE].L1CrossDomainMessenger,
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.REDSTONE].L1StandardBridge,
-      ZERO_ADDRESS,
-    ],
+    args: [WETH[chainId], opStack.L1CrossDomainMessenger, opStack.L1StandardBridge, ZERO_ADDRESS],
   });
 };
 

--- a/deploy/048_deploy_zora_adapter.ts
+++ b/deploy/048_deploy_zora_adapter.ts
@@ -3,20 +3,18 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { CHAIN_IDs } from "../utils";
 import { OP_STACK_ADDRESS_MAP, WETH, ZERO_ADDRESS } from "./consts";
 
+const SPOKE_CHAIN_ID = CHAIN_IDs.ZORA;
+
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const chainId = parseInt(await hre.getChainId());
+  const opStack = OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID];
 
   await hre.deployments.deploy("Zora_Adapter", {
     from: deployer,
     log: true,
     skipIfAlreadyDeployed: true,
-    args: [
-      WETH[chainId],
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.ZORA].L1CrossDomainMessenger,
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.ZORA].L1StandardBridge,
-      ZERO_ADDRESS,
-    ],
+    args: [WETH[chainId], opStack.L1CrossDomainMessenger, opStack.L1StandardBridge, ZERO_ADDRESS],
   });
 };
 

--- a/deploy/048_deploy_zora_adapter.ts
+++ b/deploy/048_deploy_zora_adapter.ts
@@ -1,6 +1,7 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
-import { L1_ADDRESS_MAP, WETH, ZERO_ADDRESS } from "./consts";
+import { CHAIN_IDs } from "../utils";
+import { OP_STACK_ADDRESS_MAP, WETH, ZERO_ADDRESS } from "./consts";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
@@ -12,8 +13,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     skipIfAlreadyDeployed: true,
     args: [
       WETH[chainId],
-      L1_ADDRESS_MAP[chainId].zoraCrossDomainMessenger,
-      L1_ADDRESS_MAP[chainId].zoraStandardBridge,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.ZORA].L1CrossDomainMessenger,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.ZORA].L1StandardBridge,
       ZERO_ADDRESS,
     ],
   });

--- a/deploy/050_deploy_worldchain_adapter.ts
+++ b/deploy/050_deploy_worldchain_adapter.ts
@@ -1,6 +1,7 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
-import { L1_ADDRESS_MAP, USDC, WETH } from "./consts";
+import { CHAIN_IDs } from "../utils";
+import { OP_STACK_ADDRESS_MAP, WETH, ZERO_ADDRESS } from "./consts";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
@@ -13,9 +14,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     args: [
       WETH[chainId],
       USDC[chainId],
-      L1_ADDRESS_MAP[chainId].worldChainCrossDomainMessenger,
-      L1_ADDRESS_MAP[chainId].worldChainStandardBridge,
-      L1_ADDRESS_MAP[chainId].worldChainOpUSDCBridge,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.WORLD_CHAIN].L1CrossDomainMessenger,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.WORLD_CHAIN].L1StandardBridge,
+      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.WORLD_CHAIN].L1OpUSDCBridge,
+      ZERO_ADDRESS,
     ],
   });
 };

--- a/deploy/050_deploy_worldchain_adapter.ts
+++ b/deploy/050_deploy_worldchain_adapter.ts
@@ -1,7 +1,7 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
 import { CHAIN_IDs } from "../utils";
-import { OP_STACK_ADDRESS_MAP, WETH, ZERO_ADDRESS } from "./consts";
+import { OP_STACK_ADDRESS_MAP, USDC, WETH } from "./consts";
 
 const SPOKE_CHAIN_ID = CHAIN_IDs.WORLD_CHAIN;
 
@@ -20,7 +20,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       opStack.L1CrossDomainMessenger,
       opStack.L1StandardBridge,
       opStack.L1OpUSDCBridge,
-      ZERO_ADDRESS,
     ],
   });
 };

--- a/deploy/050_deploy_worldchain_adapter.ts
+++ b/deploy/050_deploy_worldchain_adapter.ts
@@ -3,9 +3,12 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { CHAIN_IDs } from "../utils";
 import { OP_STACK_ADDRESS_MAP, WETH, ZERO_ADDRESS } from "./consts";
 
+const SPOKE_CHAIN_ID = CHAIN_IDs.WORLD_CHAIN;
+
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const chainId = parseInt(await hre.getChainId());
+  const opStack = OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID];
 
   await hre.deployments.deploy("OP_Adapter", {
     from: deployer,
@@ -14,9 +17,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     args: [
       WETH[chainId],
       USDC[chainId],
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.WORLD_CHAIN].L1CrossDomainMessenger,
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.WORLD_CHAIN].L1StandardBridge,
-      OP_STACK_ADDRESS_MAP[chainId][CHAIN_IDs.WORLD_CHAIN].L1OpUSDCBridge,
+      opStack.L1CrossDomainMessenger,
+      opStack.L1StandardBridge,
+      opStack.L1OpUSDCBridge,
       ZERO_ADDRESS,
     ],
   });

--- a/deploy/054_deploy_op_adapter.ts
+++ b/deploy/054_deploy_op_adapter.ts
@@ -24,18 +24,22 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const chainId = parseInt(await hre.getChainId());
 
-  await hre.deployments.deploy("OP_Adapter", {
+  const constructorArguments = [
+    WETH[chainId],
+    USDC[chainId],
+    OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID].L1CrossDomainMessenger,
+    OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID].L1StandardBridge,
+    OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID].L1OpUSDCBridgeAdapter,
+  ];
+
+  const { address: deployment } = await hre.deployments.deploy("OP_Adapter", {
     from: deployer,
     log: true,
     skipIfAlreadyDeployed: true,
-    args: [
-      WETH[chainId],
-      USDC[chainId],
-      OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID].L1CrossDomainMessenger,
-      OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID].L1StandardBridge,
-      OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID].L1OpUSDCBridgeAdapter,
-    ],
+    constructorArguments,
   });
+
+  await hre.run("verify:verify", { address: deployment, constructorArguments });
 };
 
 module.exports = func;

--- a/deploy/054_deploy_op_adapter.ts
+++ b/deploy/054_deploy_op_adapter.ts
@@ -1,0 +1,42 @@
+import assert from "assert";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { OP_STACK_ADDRESS_MAP, USDC, WETH } from "./consts";
+
+/**
+ * Note:
+ * This adapter supports OP stack L2s with Circle Bridged USDC.
+ * Do not deploy this adapter if the OP L2 uses OP bridged USDC.
+ * It is _not_ currently suitable for CCTP deployments because the CCTP messenger address is set to 0x0.
+ *
+ * Usage:
+ * $ SPOKE_CHAIN_ID=10 yarn hardhat deploy --network mainnet --tags OpAdapter
+ */
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { SPOKE_CHAIN_ID } = process.env;
+  assert(SPOKE_CHAIN_ID !== undefined, "SPOKE_CHAIN_ID not defined in environment");
+  assert(
+    parseInt(SPOKE_CHAIN_ID).toString() === SPOKE_CHAIN_ID,
+    "SPOKE_CHAIN_ID (${SPOKE_CHAIN_ID}) must be an integer"
+  );
+
+  const { deployer } = await hre.getNamedAccounts();
+  const chainId = parseInt(await hre.getChainId());
+
+  await hre.deployments.deploy("OP_Adapter", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+    args: [
+      WETH[chainId],
+      USDC[chainId],
+      OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID].L1CrossDomainMessenger,
+      OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID].L1StandardBridge,
+      OP_STACK_ADDRESS_MAP[chainId][SPOKE_CHAIN_ID].L1OpUSDCBridgeAdapter,
+    ],
+  });
+};
+
+module.exports = func;
+func.tags = ["OpAdapter", "mainnet"];

--- a/deploy/consts.ts
+++ b/deploy/consts.ts
@@ -24,7 +24,6 @@ export const L1_ADDRESS_MAP: { [key: number]: { [contractName: string]: string }
     polygonERC20Predicate: "0x40ec5B33f54e0E8A33A975908C5BA1c14e5BbbDf",
     polygonRegistry: "0x33a02E6cC863D393d6Bf231B697b82F6e499cA71",
     polygonDepositManager: "0x401F6c983eA34274ec46f84D70b31C151321188b",
-    l1BlastBridge: "0xc644cc19d2A9388b71dd1dEde07cFFC73237Dca8",
     cctpTokenMessenger: "0xBd3fa81B58Ba92a82136038B25aDec7066af3155",
     cctpMessageTransmitter: "0x0a992d191deec32afe36203ad87d7d289a738f81",
     lineaMessageService: "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
@@ -113,6 +112,7 @@ export const OP_STACK_ADDRESS_MAP: {
       L1StandardBridge: "0xfd0Bf71F60660E2f608ed56e1659C450eB113120",
     },
     [CHAIN_IDs.BLAST_SEPOLIA]: {
+      L1BlastBridge: "0xc644cc19d2A9388b71dd1dEde07cFFC73237Dca8",
       L1CrossDomainMessenger: "0x9338F298F29D3918D5D1Feb209aeB9915CC96333",
       L1StandardBridge: "0xDeDa8D3CCf044fE2A16217846B6e1f1cfD8e122f",
     },

--- a/deploy/consts.ts
+++ b/deploy/consts.ts
@@ -16,10 +16,6 @@ export const AZERO_GAS_PRICE = "240000000000";
 
 export const L1_ADDRESS_MAP: { [key: number]: { [contractName: string]: string } } = {
   [CHAIN_IDs.MAINNET]: {
-    optimismCrossDomainMessenger: "0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1", // Source: https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts/deployments
-    optimismStandardBridge: "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
-    bobaCrossDomainMessenger: "0x6D4528d192dB72E282265D6092F4B872f9Dff69e",
-    bobaStandardBridge: "0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00",
     finder: "0x40f941E48A552bF496B154Af6bf55725f18D77c3",
     l1ArbitrumInbox: "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f",
     l1ERC20GatewayRouter: "0x72Ce9c846789fdB6fC1f34aC4AD25Dd9ef7031ef",
@@ -28,11 +24,7 @@ export const L1_ADDRESS_MAP: { [key: number]: { [contractName: string]: string }
     polygonERC20Predicate: "0x40ec5B33f54e0E8A33A975908C5BA1c14e5BbbDf",
     polygonRegistry: "0x33a02E6cC863D393d6Bf231B697b82F6e499cA71",
     polygonDepositManager: "0x401F6c983eA34274ec46f84D70b31C151321188b",
-    baseCrossDomainMessenger: "0x866E82a600A1414e583f7F13623F1aC5d58b0Afa",
-    baseStandardBridge: "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
-    l1BlastBridge: "0x3a05E5d33d7Ab3864D53aaEc93c8301C1Fa49115",
-    blastCrossDomainMessenger: "0x5D4472f31Bd9385709ec61305AFc749F0fA8e9d0",
-    blastStandardBridge: "0x697402166Fbf2F22E970df8a6486Ef171dbfc524",
+    l1BlastBridge: "0xc644cc19d2A9388b71dd1dEde07cFFC73237Dca8",
     cctpTokenMessenger: "0xBd3fa81B58Ba92a82136038B25aDec7066af3155",
     cctpMessageTransmitter: "0x0a992d191deec32afe36203ad87d7d289a738f81",
     lineaMessageService: "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
@@ -41,33 +33,16 @@ export const L1_ADDRESS_MAP: { [key: number]: { [contractName: string]: string }
     scrollERC20GatewayRouter: "0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6",
     scrollMessengerRelay: "0x6774Bcbd5ceCeF1336b5300fb5186a12DDD8b367",
     scrollGasPriceOracle: "0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B",
-    modeCrossDomainMessenger: "0x95bDCA6c8EdEB69C98Bd5bd17660BaCef1298A6f",
-    modeStandardBridge: "0x735aDBbE72226BD52e818E7181953f42E3b0FF21",
-    liskCrossDomainMessenger: "0x31B72D76FB666844C41EdF08dF0254875Dbb7edB",
-    liskStandardBridge: "0x2658723Bf70c7667De6B25F99fcce13A16D25d08",
     blastYieldManager: "0xa230285d5683C74935aD14c446e137c8c8828438",
     blastDaiRetriever: "0x98Dd57048d7d5337e92D9102743528ea4Fea64aB",
-    redstoneCrossDomainMessenger: "0x592C1299e0F8331D81A28C0FC7352Da24eDB444a",
-    redstoneStandardBridge: "0xc473ca7E02af24c129c2eEf51F2aDf0411c1Df69",
-    zoraCrossDomainMessenger: "0xdC40a14d9abd6F410226f1E6de71aE03441ca506",
-    zoraStandardBridge: "0x3e2Ea9B92B7E48A52296fD261dc26fd995284631",
-    worldChainCrossDomainMessenger: "0xf931a81D18B1766d15695ffc7c1920a62b7e710a",
-    worldChainStandardBridge: "0x470458C91978D2d929704489Ad730DC3E3001113",
-    worldChainOpUSDCBridge: "0x153A69e4bb6fEDBbAaF463CB982416316c84B2dB",
     l1AlephZeroInbox: "0x56D8EC76a421063e1907503aDd3794c395256AEb",
     l1AlephZeroERC20GatewayRouter: "0xeBb17f398ed30d02F2e8733e7c1e5cf566e17812",
     donationBox: "0x0d57392895Db5aF3280e9223323e20F3951E81B1",
   },
   [CHAIN_IDs.SEPOLIA]: {
-    optimismCrossDomainMessenger: "0x58Cc85b8D04EA49cC6DBd3CbFFd00B4B8D6cb3ef",
-    optimismStandardBridge: "0xFBb0621E0B23b5478B630BD55a5f21f67730B0F1",
-    bobaCrossDomainMessenger: "0x6D4528d192dB72E282265D6092F4B872f9Dff69e", // No sepolia deploy address
-    bobaStandardBridge: "0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00", // No sepolia deploy address
     finder: "0xeF684C38F94F48775959ECf2012D7E864ffb9dd4",
     l1ArbitrumInbox: "0xaAe29B0366299461418F5324a79Afc425BE5ae21",
     l1ERC20GatewayRouter: "0xcE18836b233C83325Cc8848CA4487e94C6288264",
-    baseCrossDomainMessenger: "0xC34855F4De64F1840e5686e64278da901e261f20",
-    baseStandardBridge: "0xfd0Bf71F60660E2f608ed56e1659C450eB113120",
     cctpTokenMessenger: "0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5",
     cctpMessageTransmitter: "0x7865fAfC2db2093669d92c0F33AeEF291086BEFD",
     usdc: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
@@ -77,8 +52,6 @@ export const L1_ADDRESS_MAP: { [key: number]: { [contractName: string]: string }
     scrollERC20GatewayRouter: "0x13FBE0D0e5552b8c9c4AE9e2435F38f37355998a",
     scrollMessengerRelay: "0x50c7d3e7f7c656493D1D76aaa1a836CedfCBB16A",
     scrollGasPriceOracle: "0x247969F4fad93a33d4826046bc3eAE0D36BdE548",
-    modeCrossDomainMessenger: "0xc19a60d9E8C27B9A43527c3283B4dd8eDC8bE15C",
-    modeStandardBridge: "0xbC5C679879B2965296756CD959C3C739769995E2",
 
     // https://github.com/maticnetwork/static/blob/master/network/testnet/amoy/index.json
     polygonRootChainManager: "0x34F5A25B627f50Bb3f5cAb72807c4D4F405a9232",
@@ -86,15 +59,75 @@ export const L1_ADDRESS_MAP: { [key: number]: { [contractName: string]: string }
     polygonERC20Predicate: "0x4258C75b752c812B7Fa586bdeb259f2d4bd17f4F",
     polygonRegistry: "0xfE92F7c3a701e43d8479738c8844bCc555b9e5CD",
     polygonDepositManager: "0x44Ad17990F9128C6d823Ee10dB7F0A5d40a731A4",
+  },
+};
 
-    // https://docs.lisk.com/contracts
-    liskCrossDomainMessenger: "0x857824E6234f7733ecA4e9A76804fd1afa1A3A2C",
-    liskStandardBridge: "0x1Fb30e446eA791cd1f011675E5F3f5311b70faF5",
-
-    // https://docs.blast.io/building/contracts
-    l1BlastBridge: "0xc644cc19d2A9388b71dd1dEde07cFFC73237Dca8",
-    blastCrossDomainMessenger: "0x9338F298F29D3918D5D1Feb209aeB9915CC96333",
-    blastStandardBridge: "0xDeDa8D3CCf044fE2A16217846B6e1f1cfD8e122f",
+export const OP_STACK_ADDRESS_MAP: {
+  [hubChainId: number]: {
+    [spokeChainId: number]: { [contract: string]: string };
+  };
+} = {
+  [CHAIN_IDs.MAINNET]: {
+    [CHAIN_IDs.BASE]: {
+      L1CrossDomainMessenger: "0x866E82a600A1414e583f7F13623F1aC5d58b0Afa",
+      L1StandardBridge: "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+    },
+    [CHAIN_IDs.BOBA]: {
+      L1CrossDomainMessenger: "0x6D4528d192dB72E282265D6092F4B872f9Dff69e",
+      L1StandardBridge: "0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00",
+    },
+    [CHAIN_IDs.BLAST]: {
+      L1BlastBridge: "0x3a05E5d33d7Ab3864D53aaEc93c8301C1Fa49115",
+      L1CrossDomainMessenger: "0x5D4472f31Bd9385709ec61305AFc749F0fA8e9d0",
+      L1StandardBridge: "0x697402166Fbf2F22E970df8a6486Ef171dbfc524",
+    },
+    [CHAIN_IDs.LISK]: {
+      L1CrossDomainMessenger: "0x31B72D76FB666844C41EdF08dF0254875Dbb7edB",
+      L1StandardBridge: "0x2658723Bf70c7667De6B25F99fcce13A16D25d08",
+    },
+    [CHAIN_IDs.MODE]: {
+      L1CrossDomainMessenger: "0x95bDCA6c8EdEB69C98Bd5bd17660BaCef1298A6f",
+      L1StandardBridge: "0x735aDBbE72226BD52e818E7181953f42E3b0FF21",
+    },
+    [CHAIN_IDs.OPTIMISM]: {
+      L1CrossDomainMessenger: "0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1", // Source: https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts/deployments
+      L1StandardBridge: "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
+    },
+    [CHAIN_IDs.REDSTONE]: {
+      L1CrossDomainMessenger: "0x592C1299e0F8331D81A28C0FC7352Da24eDB444a",
+      L1StandardBridge: "0xc473ca7E02af24c129c2eEf51F2aDf0411c1Df69",
+    },
+    [CHAIN_IDs.WORLD_CHAIN]: {
+      L1CrossDomainMessenger: "0xf931a81D18B1766d15695ffc7c1920a62b7e710a",
+      L1StandardBridge: "0x470458C91978D2d929704489Ad730DC3E3001113",
+      L1OpUSDCBridgeAdapter: "0x153A69e4bb6fEDBbAaF463CB982416316c84B2dB",
+    },
+    [CHAIN_IDs.ZORA]: {
+      L1CrossDomainMessenger: "0xdC40a14d9abd6F410226f1E6de71aE03441ca506",
+      L1StandardBridge: "0x3e2Ea9B92B7E48A52296fD261dc26fd995284631",
+    },
+  },
+  [CHAIN_IDs.SEPOLIA]: {
+    [CHAIN_IDs.BASE_SEPOLIA]: {
+      L1CrossDomainMessenger: "0xC34855F4De64F1840e5686e64278da901e261f20",
+      L1StandardBridge: "0xfd0Bf71F60660E2f608ed56e1659C450eB113120",
+    },
+    [CHAIN_IDs.BLAST_SEPOLIA]: {
+      L1CrossDomainMessenger: "0x9338F298F29D3918D5D1Feb209aeB9915CC96333",
+      L1StandardBridge: "0xDeDa8D3CCf044fE2A16217846B6e1f1cfD8e122f",
+    },
+    [CHAIN_IDs.LISK_SEPOLIA]: {
+      L1CrossDomainMessenger: "0x857824E6234f7733ecA4e9A76804fd1afa1A3A2C",
+      L1StandardBridge: "0x1Fb30e446eA791cd1f011675E5F3f5311b70faF5",
+    },
+    [CHAIN_IDs.MODE_SEPOLIA]: {
+      L1CrossDomainMessenger: "0xc19a60d9E8C27B9A43527c3283B4dd8eDC8bE15C",
+      L1StandardBridge: "0xbC5C679879B2965296756CD959C3C739769995E2",
+    },
+    [CHAIN_IDs.OPTIMISM_SEPOLIA]: {
+      L1CrossDomainMessenger: "0x58Cc85b8D04EA49cC6DBd3CbFFd00B4B8D6cb3ef",
+      L1StandardBridge: "0xFBb0621E0B23b5478B630BD55a5f21f67730B0F1",
+    },
   },
 };
 


### PR DESCRIPTION
This change permits an incremental step towards a totally generic chain adapter deployment for OP stack chains. It does this be restructuring the address mappings for OP stack chains, such that the L1 contract addresses can be resolved solely with the combination of HubPool and SpokPool chain IDs. It also updates the new OP_Adapter deployment script to support a runtime-defined SpokePool chain ID. This is clunkily supplied via the environment because hardhat deploy doesn't seem to permit arbitrary runtime arguments being supplied, but that aside, this should ease subsequent deployments.