### PR TITLE
fix(svm): use free function in handling cctp

### DIFF
--- a/programs/svm-spoke/src/instructions/handle_receive_message.rs
+++ b/programs/svm-spoke/src/instructions/handle_receive_message.rs
@@ -47,13 +47,15 @@ pub struct HandleReceiveMessageParams {
     pub authority_bump: u8,
 }
 
-// TODO: consider refactoring this to be consistent with using free functions.
-impl<'info> HandleReceiveMessage<'info> {
-    pub fn handle_receive_message(&self, params: &HandleReceiveMessageParams) -> Result<Vec<u8>> {
-        // Return instruction data for the self invoked CPI based on the received message body.
-        translate_message(&params.message_body)
-    }
+pub fn handle_receive_message<'info>(
+    ctx: Context<'_, '_, '_, 'info, HandleReceiveMessage<'info>>,
+    params: HandleReceiveMessageParams,
+) -> Result<()> {
+    let self_ix_data = translate_message(&params.message_body)?;
+
+    invoke_self(&ctx, &self_ix_data)
 }
+
 // TODO: ensure that CCTP blocks re-played messages sent over the bridge. i.e one pauseDeposit Call cant be replayed.
 fn translate_message(data: &Vec<u8>) -> Result<Vec<u8>> {
     match utils::get_solidity_selector(data)? {
@@ -99,7 +101,7 @@ fn translate_message(data: &Vec<u8>) -> Result<Vec<u8>> {
 // Invokes self CPI for remote domain invoked message calls. We use low level invoke_signed with seeds corresponding to
 // the self_authority account and passing all remaining accounts from the context. Instruction data is obtained within
 // handle_receive_message by translating the received message body into a valid instruction data for the invoked CPI.
-pub fn invoke_self<'info>(ctx: &Context<'_, '_, '_, 'info, HandleReceiveMessage<'info>>, data: &Vec<u8>) -> Result<()> {
+fn invoke_self<'info>(ctx: &Context<'_, '_, '_, 'info, HandleReceiveMessage<'info>>, data: &Vec<u8>) -> Result<()> {
     let self_authority_seeds: &[&[&[u8]]] = &[&[b"self_authority", &[ctx.bumps.self_authority]]];
 
     let mut accounts = Vec::with_capacity(1 + ctx.remaining_accounts.len());

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -148,16 +148,11 @@ pub mod svm_spoke {
     }
 
     // CCTP methods.
-    // TODO: consider refactoring this to be consistent with using free functions.
     pub fn handle_receive_message<'info>(
         ctx: Context<'_, '_, '_, 'info, HandleReceiveMessage<'info>>,
         params: HandleReceiveMessageParams,
     ) -> Result<()> {
-        let self_ix_data = ctx.accounts.handle_receive_message(&params)?;
-
-        invoke_self(&ctx, &self_ix_data)?;
-
-        Ok(())
+        instructions::handle_receive_message(ctx, params)
     }
 
     // Slow fill methods.


### PR DESCRIPTION
For the sake of consistency use free function in internal handle_receive_message call. This also simplifies the external function.

Fixes: https://linear.app/uma/issue/ACX-3102/librs-refactor-handle-receive-message-to-be-consistent-with-using-free