### PR TITLE
fix: support native token bridging in the forwarder/withdrawal helper

### DIFF
--- a/contracts/chain-adapters/Arbitrum_Forwarder.sol
+++ b/contracts/chain-adapters/Arbitrum_Forwarder.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import { ForwarderBase } from "./ForwarderBase.sol";
 import { CrossDomainAddressUtils } from "../libraries/CrossDomainAddressUtils.sol";
+import { WETH9Interface } from "../external/interfaces/WETH9Interface.sol";
 
 /**
  * @title Arbitrum_Forwarder
@@ -19,10 +20,9 @@ contract Arbitrum_Forwarder is ForwarderBase {
 
     /**
      * @notice Constructs an Arbitrum-specific forwarder contract.
-     * @dev Since this is a proxy contract, we only set immutable variables in the constructor, and leave everything else to be initialized.
-     * This includes variables like the cross domain admin.
+     * @param _wrappedNativeToken Address of the wrapped native token contract on the L2.
      */
-    constructor() ForwarderBase() {}
+    constructor(WETH9Interface _wrappedNativeToken) ForwarderBase(_wrappedNativeToken) {}
 
     /**
      * @notice Initializes the forwarder contract.

--- a/contracts/chain-adapters/ForwarderBase.sol
+++ b/contracts/chain-adapters/ForwarderBase.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { ForwarderInterface } from "./interfaces/ForwarderInterface.sol";
 import { AdapterInterface } from "./interfaces/AdapterInterface.sol";
+import { WETH9Interface } from "../external/interfaces/WETH9Interface.sol";
 
 /**
  * @title ForwarderBase
@@ -16,6 +17,8 @@ import { AdapterInterface } from "./interfaces/AdapterInterface.sol";
  * @custom:security-contact bugs@across.to
  */
 abstract contract ForwarderBase is UUPSUpgradeable, ForwarderInterface {
+    // Address of the wrapped native token contract on this L2.
+    WETH9Interface public immutable WRAPPED_NATIVE_TOKEN;
     // Address that can relay messages using this contract and also upgrade this contract.
     address public crossDomainAdmin;
 
@@ -46,12 +49,20 @@ abstract contract ForwarderBase is UUPSUpgradeable, ForwarderInterface {
 
     /**
      * @notice Constructs the Forwarder contract.
+     * @param _wrappedNativeToken Address of the wrapped native token contract on the L2.
      * @dev _disableInitializers() restricts anybody from initializing the implementation contract, which if not done,
      * may disrupt the proxy if another EOA were to initialize it.
      */
-    constructor() {
+    constructor(WETH9Interface _wrappedNativeToken) {
+        WRAPPED_NATIVE_TOKEN = _wrappedNativeToken;
         _disableInitializers();
     }
+
+    /**
+     * @notice Receives the native token from external sources.
+     * @dev Forwarders need a receive function so that it may accept the native token incoming from L1-L2 bridges.
+     */
+    receive() external payable {}
 
     /**
      * @notice Initializes the forwarder contract.
@@ -125,6 +136,7 @@ abstract contract ForwarderBase is UUPSUpgradeable, ForwarderInterface {
     ) external payable override onlyAdmin {
         address adapter = chainAdapters[destinationChainId];
         if (adapter == address(0)) revert UninitializedChainAdapter();
+        if (baseToken == address(WRAPPED_NATIVE_TOKEN)) _wrapNativeToken();
 
         (bool success, ) = adapter.delegatecall(
             abi.encodeCall(AdapterInterface.relayTokens, (baseToken, destinationChainToken, amount, target))
@@ -145,6 +157,13 @@ abstract contract ForwarderBase is UUPSUpgradeable, ForwarderInterface {
         if (_newCrossDomainAdmin == address(0)) revert InvalidCrossDomainAdmin();
         crossDomainAdmin = _newCrossDomainAdmin;
         emit SetXDomainAdmin(_newCrossDomainAdmin);
+    }
+
+    /*
+     * @notice Wraps the contract's entire balance of the native token.
+     */
+    function _wrapNativeToken() internal {
+        if (address(this).balance > 0) WRAPPED_NATIVE_TOKEN.deposit{ value: address(this).balance }();
     }
 
     // Reserve storage slots for future versions of this base contract to add state variables without

--- a/contracts/chain-adapters/Ovm_Forwarder.sol
+++ b/contracts/chain-adapters/Ovm_Forwarder.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import { ForwarderBase } from "./ForwarderBase.sol";
 import { LibOptimismUpgradeable } from "@openzeppelin/contracts-upgradeable/crosschain/optimism/LibOptimismUpgradeable.sol";
 import { Lib_PredeployAddresses } from "@eth-optimism/contracts/libraries/constants/Lib_PredeployAddresses.sol";
+import { WETH9Interface } from "../external/interfaces/WETH9Interface.sol";
 
 /**
  * @title Ovm_Forwarder
@@ -22,8 +23,9 @@ contract Ovm_Forwarder is ForwarderBase {
 
     /**
      * @notice Constructs an Ovm specific forwarder contract.
+     * @param _wrappedNativeToken Address of the wrapped native token contract on the L2.
      */
-    constructor() ForwarderBase() {}
+    constructor(WETH9Interface _wrappedNativeToken) ForwarderBase(_wrappedNativeToken) {}
 
     /**
      * @notice Initializes the forwarder contract.

--- a/contracts/chain-adapters/l2/Arbitrum_WithdrawalHelper.sol
+++ b/contracts/chain-adapters/l2/Arbitrum_WithdrawalHelper.sol
@@ -9,6 +9,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ArbitrumL2ERC20GatewayLike } from "../../interfaces/ArbitrumBridge.sol";
 import { WithdrawalHelperBase } from "./WithdrawalHelperBase.sol";
 import { ITokenMessenger } from "../../external/interfaces/CCTPInterfaces.sol";
+import { WETH9Interface } from "../../external/interfaces/WETH9Interface.sol";
 import { CrossDomainAddressUtils } from "../../libraries/CrossDomainAddressUtils.sol";
 
 /**
@@ -27,6 +28,7 @@ contract Arbitrum_WithdrawalHelper is WithdrawalHelperBase {
      * @notice Constructs the Arbitrum_WithdrawalHelper.
      * @param _l2Usdc Address of native USDC on the L2.
      * @param _cctpTokenMessenger Address of the CCTP token messenger contract on L2.
+     * @param _wrappedNativeToken Address of the wrapped native token contract on L2.
      * @param _destinationCircleDomainId Circle's assigned CCTP domain ID for the destination network. For Ethereum, this is 0.
      * @param _l2GatewayRouter Address of the Arbitrum l2 gateway router contract.
      * @param _tokenRecipient L1 Address which will unconditionally receive tokens withdrawn from this contract.
@@ -34,6 +36,7 @@ contract Arbitrum_WithdrawalHelper is WithdrawalHelperBase {
     constructor(
         IERC20 _l2Usdc,
         ITokenMessenger _cctpTokenMessenger,
+        WETH9Interface _wrappedNativeToken,
         uint32 _destinationCircleDomainId,
         address _l2GatewayRouter,
         address _tokenRecipient
@@ -41,6 +44,7 @@ contract Arbitrum_WithdrawalHelper is WithdrawalHelperBase {
         WithdrawalHelperBase(
             _l2Usdc,
             _cctpTokenMessenger,
+            _wrappedNativeToken,
             _destinationCircleDomainId,
             _l2GatewayRouter,
             _tokenRecipient
@@ -70,6 +74,7 @@ contract Arbitrum_WithdrawalHelper is WithdrawalHelperBase {
         if (l2Token == address(usdcToken) && _isCCTPEnabled()) {
             _transferUsdc(TOKEN_RECIPIENT, amountToReturn);
         } else {
+            if (l2Token == address(WRAPPED_NATIVE_TOKEN)) _depositNativeToken();
             // Otherwise, we use the Arbitrum ERC20 Gateway router.
             ArbitrumL2ERC20GatewayLike tokenBridge = ArbitrumL2ERC20GatewayLike(L2_TOKEN_GATEWAY);
             // If the gateway router's expected L2 token address does not match then revert. This check does not actually

--- a/contracts/chain-adapters/l2/Ovm_WithdrawalHelper.sol
+++ b/contracts/chain-adapters/l2/Ovm_WithdrawalHelper.sol
@@ -25,9 +25,6 @@ interface IOvm_SpokePool {
     // Returns the address for the representation of ETH on the l2.
     function l2Eth() external view returns (address);
 
-    // Returns the address of the wrapped native token for the L2.
-    function wrappedNativeToken() external view returns (WETH9Interface);
-
     // Returns the amount of gas the contract allocates for a token withdrawal.
     function l1Gas() external view returns (uint32);
 }
@@ -43,10 +40,6 @@ interface IOvm_SpokePool {
 contract Ovm_WithdrawalHelper is WithdrawalHelperBase {
     using SafeERC20 for IERC20;
 
-    // Address for the wrapped native token on this chain. For Ovm standard bridges, we need to unwrap
-    // this token before initiating the withdrawal. Normally, it is 0x42..006, but there are instances
-    // where this address is different.
-    WETH9Interface public immutable wrappedNativeToken;
     // Address of the corresponding spoke pool on L2. This is to piggyback off of the spoke pool's supported
     // token routes/defined token bridges.
     IOvm_SpokePool public immutable spokePool;
@@ -60,6 +53,7 @@ contract Ovm_WithdrawalHelper is WithdrawalHelperBase {
      * @notice Constructs the Ovm_WithdrawalAdapter.
      * @param _l2Usdc Address of native USDC on the L2.
      * @param _cctpTokenMessenger Address of the CCTP token messenger contract on L2.
+     * @param _wrappedNativeToken Address of the wrapped native token contract on L2.
      * @param _destinationCircleDomainId Circle's assigned CCTP domain ID for the destination network. For Ethereum, this
      * is 0.
      * @param _l2Gateway Address of the Optimism ERC20 L2 standard bridge contract.
@@ -71,15 +65,24 @@ contract Ovm_WithdrawalHelper is WithdrawalHelperBase {
     constructor(
         IERC20 _l2Usdc,
         ITokenMessenger _cctpTokenMessenger,
+        WETH9Interface _wrappedNativeToken,
         uint32 _destinationCircleDomainId,
         address _l2Gateway,
         address _tokenRecipient,
         IOvm_SpokePool _spokePool
-    ) WithdrawalHelperBase(_l2Usdc, _cctpTokenMessenger, _destinationCircleDomainId, _l2Gateway, _tokenRecipient) {
+    )
+        WithdrawalHelperBase(
+            _l2Usdc,
+            _cctpTokenMessenger,
+            _wrappedNativeToken,
+            _destinationCircleDomainId,
+            _l2Gateway,
+            _tokenRecipient
+        )
+    {
         spokePool = _spokePool;
 
-        // These addresses should only change network-by-network, or after a bridge upgrade, so we define them once in the constructor.
-        wrappedNativeToken = spokePool.wrappedNativeToken();
+        // This address is immutable in the spoke pool so we query once and save its value locally.
         l2Eth = spokePool.l2Eth();
     }
 
@@ -111,7 +114,11 @@ contract Ovm_WithdrawalHelper is WithdrawalHelperBase {
         uint32 l1Gas = spokePool.l1Gas();
         // If the token being bridged is WETH then we need to first unwrap it to ETH and then send ETH over the
         // canonical bridge. On Optimism, this is address 0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000.
-        if (l2Token == address(wrappedNativeToken)) {
+        if (l2Token == address(WRAPPED_NATIVE_TOKEN)) {
+            // Wrap the contract's balance of the native token if we are withdrawing the L2's native token. We need wrap the contract's balance
+            // and then unwrap the amount to send to account for cases where `amountToReturn` is greater than the contract's native token balance
+            // and wrapped native token balance, but less than their sum.
+            _depositNativeToken();
             WETH9Interface(l2Token).withdraw(amountToReturn); // Unwrap into ETH.
             l2Token = l2Eth; // Set the l2Token to ETH.
             IL2ERC20Bridge(Lib_PredeployAddresses.L2_STANDARD_BRIDGE).withdrawTo{ value: amountToReturn }(

--- a/contracts/chain-adapters/l2/WithdrawalHelperBase.sol
+++ b/contracts/chain-adapters/l2/WithdrawalHelperBase.sol
@@ -5,6 +5,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { MultiCaller } from "@uma/core/contracts/common/implementation/MultiCaller.sol";
 import { CircleCCTPAdapter, ITokenMessenger, CircleDomainIds } from "../../libraries/CircleCCTPAdapter.sol";
+import { WETH9Interface } from "../../external/interfaces/WETH9Interface.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 /**
@@ -18,6 +19,8 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 abstract contract WithdrawalHelperBase is CircleCCTPAdapter, MultiCaller, UUPSUpgradeable {
     using SafeERC20 for IERC20;
 
+    // The L2 address of the wrapped native token for this L2.
+    WETH9Interface public immutable WRAPPED_NATIVE_TOKEN;
     // The L1 address which will unconditionally receive all withdrawals from this contract.
     address public immutable TOKEN_RECIPIENT;
     // The address of the primary or default token gateway/canonical bridge contract on L2.
@@ -43,6 +46,7 @@ abstract contract WithdrawalHelperBase is CircleCCTPAdapter, MultiCaller, UUPSUp
      * @notice Constructs a new withdrawal helper.
      * @param _l2Usdc Address of native USDC on the L2.
      * @param _cctpTokenMessenger Address of the CCTP token messenger contract on L2.
+     * @param _wrappedNativeToken Address of the wrapped native token contract on L2.
      * @param _destinationCircleDomainId Circle's assigned CCTP domain ID for the destination network.
      * @param _l2TokenGateway Address of the network's l2 token gateway/bridge contract.
      * @param _tokenRecipient L1 address which will unconditionally receive all withdrawals originating from this contract.
@@ -54,14 +58,23 @@ abstract contract WithdrawalHelperBase is CircleCCTPAdapter, MultiCaller, UUPSUp
     constructor(
         IERC20 _l2Usdc,
         ITokenMessenger _cctpTokenMessenger,
+        WETH9Interface _wrappedNativeToken,
         uint32 _destinationCircleDomainId,
         address _l2TokenGateway,
         address _tokenRecipient
     ) CircleCCTPAdapter(_l2Usdc, _cctpTokenMessenger, _destinationCircleDomainId) {
         L2_TOKEN_GATEWAY = _l2TokenGateway;
         TOKEN_RECIPIENT = _tokenRecipient;
+        WRAPPED_NATIVE_TOKEN = _wrappedNativeToken;
         _disableInitializers();
     }
+
+    /**
+     * @notice Receives the native token from bridge contracts.
+     * @dev When bridging from L3 to the L2's native token, OpStack bridges will send the "unwrapped"/native token to the recipient on L2
+     * during withdrawals. This means that this contract must be able to accept value transfers.
+     */
+    receive() external payable {}
 
     /**
      * @notice Initializes the withdrawal helper contract.
@@ -99,6 +112,13 @@ abstract contract WithdrawalHelperBase is CircleCCTPAdapter, MultiCaller, UUPSUp
         address l2Token,
         uint256 amountToReturn
     ) public virtual;
+
+    /*
+     * @notice Wraps the contract's entire balance of the native token.
+     */
+    function _depositNativeToken() internal virtual {
+        if (address(this).balance > 0) WRAPPED_NATIVE_TOKEN.deposit{ value: address(this).balance }();
+    }
 
     /*
      * @notice Checks that the L1 msg.sender is the `crossDomainAdmin` address.

--- a/test/evm/foundry/local/Forwarder.t.sol
+++ b/test/evm/foundry/local/Forwarder.t.sol
@@ -64,7 +64,7 @@ contract ForwarderTest is Test {
             ITokenMessenger(address(0))
         );
 
-        arbitrumForwarder = new Arbitrum_Forwarder();
+        arbitrumForwarder = new Arbitrum_Forwarder(WETH9Interface(address(l2Weth)));
         address proxy = address(
             new ERC1967Proxy(address(arbitrumForwarder), abi.encodeCall(Arbitrum_Forwarder.initialize, (owner)))
         );
@@ -121,7 +121,7 @@ contract ForwarderTest is Test {
     // Test access control on proxy upgrades.
     function testUpgrade(address random) public {
         vm.assume(random != aliasedOwner);
-        address newImplementation = address(new Arbitrum_Forwarder());
+        address newImplementation = address(new Arbitrum_Forwarder(WETH9Interface(address(l2Weth))));
         vm.startPrank(random);
         vm.expectRevert();
         arbitrumForwarder.upgradeTo(newImplementation);

--- a/test/evm/foundry/local/WithdrawalHelper.t.sol
+++ b/test/evm/foundry/local/WithdrawalHelper.t.sol
@@ -18,28 +18,6 @@ import { WithdrawalHelperBase } from "../../../../contracts/chain-adapters/l2/Wi
 import { WETH9 } from "../../../../contracts/external/WETH9.sol";
 import { WETH9Interface } from "../../../../contracts/external/interfaces/WETH9Interface.sol";
 
-contract Mock_Ovm_WithdrawalHelper is Ovm_WithdrawalHelper {
-    constructor(
-        IERC20 _l2Usdc,
-        ITokenMessenger _cctpTokenMessenger,
-        uint32 _destinationCircleDomainId,
-        address _l2Gateway,
-        address _tokenRecipient,
-        IOvm_SpokePool _spokePool
-    )
-        Ovm_WithdrawalHelper(
-            _l2Usdc,
-            _cctpTokenMessenger,
-            _destinationCircleDomainId,
-            _l2Gateway,
-            _tokenRecipient,
-            _spokePool
-        )
-    {}
-
-    receive() external payable {}
-}
-
 contract Token_ERC20 is ERC20 {
     constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
 
@@ -55,7 +33,7 @@ contract Token_ERC20 is ERC20 {
 contract WithdrawalAdapterTest is Test {
     uint32 constant fillDeadlineBuffer = type(uint32).max;
     Arbitrum_WithdrawalHelper arbitrumWithdrawalHelper;
-    Mock_Ovm_WithdrawalHelper ovmWithdrawalHelper;
+    Ovm_WithdrawalHelper ovmWithdrawalHelper;
     Base_SpokePool ovmSpokePool;
 
     L2GatewayRouter arbBridge;
@@ -138,6 +116,7 @@ contract WithdrawalAdapterTest is Test {
         arbitrumWithdrawalHelper = new Arbitrum_WithdrawalHelper(
             l2Usdc,
             tokenMessenger,
+            WETH9Interface(address(l2Weth)),
             CircleDomainIds.Ethereum,
             address(arbBridge),
             hubPool
@@ -150,9 +129,10 @@ contract WithdrawalAdapterTest is Test {
         );
         arbitrumWithdrawalHelper = Arbitrum_WithdrawalHelper(payable(proxy));
 
-        ovmWithdrawalHelper = new Mock_Ovm_WithdrawalHelper(
+        ovmWithdrawalHelper = new Ovm_WithdrawalHelper(
             l2Usdc,
             tokenMessenger,
+            WETH9Interface(address(l2Weth)),
             CircleDomainIds.Ethereum,
             address(ovmBridge),
             hubPool,
@@ -161,7 +141,7 @@ contract WithdrawalAdapterTest is Test {
         proxy = address(
             new ERC1967Proxy(address(ovmWithdrawalHelper), abi.encodeCall(Ovm_WithdrawalHelper.initialize, (hubPool)))
         );
-        ovmWithdrawalHelper = Mock_Ovm_WithdrawalHelper(payable(proxy));
+        ovmWithdrawalHelper = Ovm_WithdrawalHelper(payable(proxy));
     }
 
     // This test should call the gateway router contract.
@@ -184,10 +164,11 @@ contract WithdrawalAdapterTest is Test {
 
     // This test should call the OpStack standard bridge with l2Eth as the input token.
     function testWithdrawEthOvm(uint256 amountToReturn, address random) public {
-        // Give the withdrawal adapter some WETH.
-        vm.startPrank(address(ovmWithdrawalHelper));
-        vm.deal(address(ovmWithdrawalHelper), amountToReturn);
-        l2Weth.deposit{ value: amountToReturn }();
+        // Give the withdrawal adapter some ETH. The contract should automatically swap it into WETH.
+        vm.startPrank(random);
+        vm.deal(random, amountToReturn);
+        (bool success, ) = address(ovmWithdrawalHelper).call{ value: amountToReturn }("");
+        require(success, "Withdrawal Helper failed to receive ETH");
         vm.stopPrank();
 
         vm.expectEmit(address(ovmBridge));
@@ -228,7 +209,14 @@ contract WithdrawalAdapterTest is Test {
         l2CustomToken.mint(address(ovmWithdrawalHelper), amountToReturn);
 
         address newImplementation = address(
-            new Arbitrum_WithdrawalHelper(l2Usdc, tokenMessenger, CircleDomainIds.Ethereum, address(arbBridge), hubPool)
+            new Arbitrum_WithdrawalHelper(
+                l2Usdc,
+                tokenMessenger,
+                WETH9Interface(address(l2Weth)),
+                CircleDomainIds.Ethereum,
+                address(arbBridge),
+                hubPool
+            )
         );
 
         // Should revert if we are an unauthorized user.


### PR DESCRIPTION
> The [WithdrawalHelperBase](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/l2/WithdrawalHelperBase.sol#L18) and [ForwarderBase](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/ForwarderBase.sol#L18) contracts are designed to be deployed on L2s and assist in moving tokens and messages to and from L3 chains. These contracts are inherited by the chain-specific contracts, currently designed for Arbitrum and OVM-based blockchains. However, none of these contracts handle ETH transfers correctly. This is because they do not contain the receive function, which causes any attempt to transfer ETH to these contracts to fail.

> In the case of forwarder contracts, the lack of the receive function means that WETH transfers, which rely on unwrapping before bridging such as [the transfers made through the Optimism_Adapter](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/Optimism_Adapter.sol#L101-L105), will fail, leaving the ETH in the bridge until the contract can be upgraded. In the case of withdrawal helper contracts, the lack of the receive function implies that they will not be capable of unwrapping WETH [in an attempt to transfer it to Ethereum](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/l2/Ovm_WithdrawalHelper.sol#L114-L124). Additionally, they will not be capable of receiving ETH bridged from L3s. Moreover, while the withdrawal helper contracts contain [token-bridging logic](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/l2/WithdrawalHelperBase.sol#L87-L101), they do not support bridging ETH. This means that even if they were capable of receiving ETH and ETH was bridged to them from L3s, it could not be routed to L1.

> Consider adding a receive function to the ForwarderBase and WithdrawalHelperBase contracts to facilitate incoming ETH transfers and the unwrapping of WETH tokens during bridging. As the contracts do not support bridging ETH directly, the receive function should include logic to ensure that incoming ETH is handled correctly and can be sent on to the target chain.

This PR adds `receive` to both `ForwarderBase` and `WithdrawalHelperBase` so that it can receive native token transfers from L1 or L3 bridges. Both the `ForwarderBase` and `WithdrawalHelperBase` now contain a hook named `_wrapNativeToken` which is called whenever a L2-L3 bridge or withdrawal which includes the L2's native token is initiated on the respective contracts. Both the `ForwarderBase` and `WithdrawalHelperBase` now take an additional argument `_wrappedNativeToken` in their constructor, which is used to deposit the native token in the `_wrapNativeToken` hook.