### PR TITLE
improve: L-01: Comment on `setCrossDomainAdmin` Edge Case

### DIFF
--- a/contracts/chain-adapters/ForwarderBase.sol
+++ b/contracts/chain-adapters/ForwarderBase.sol
@@ -65,6 +65,9 @@ abstract contract ForwarderBase is UUPSUpgradeable, ForwarderInterface {
     /**
      * @notice Sets a new cross domain admin for this contract.
      * @param _newCrossDomainAdmin L1 address of the new cross domain admin.
+     * @dev Before calling this function, you must ensure that there are no message or token relays currently being sent over the L1-L2
+     * bridge. This is to prevent these messages from getting permanently stuck, since otherwise receipt of these messages will always revert,
+     * as the L1 sender is the old cross domain admin.
      */
     function setCrossDomainAdmin(address _newCrossDomainAdmin) external onlyAdmin {
         if (_newCrossDomainAdmin == address(0)) revert InvalidCrossDomainAdmin();

--- a/contracts/chain-adapters/ForwarderBase.sol
+++ b/contracts/chain-adapters/ForwarderBase.sol
@@ -67,7 +67,7 @@ abstract contract ForwarderBase is UUPSUpgradeable, ForwarderInterface {
      * @param _newCrossDomainAdmin L1 address of the new cross domain admin.
      * @dev Before calling this function, you must ensure that there are no message or token relays currently being sent over the L1-L2
      * bridge. This is to prevent these messages from getting permanently stuck, since otherwise receipt of these messages will always revert,
-     * as the L1 sender is the old cross domain admin.
+     * as the L1 sender is the old cross-domain admin.
      */
     function setCrossDomainAdmin(address _newCrossDomainAdmin) external onlyAdmin {
         if (_newCrossDomainAdmin == address(0)) revert InvalidCrossDomainAdmin();


### PR DESCRIPTION
> The ForwarderBase contract has the setCrossDomainAdmin [function](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/ForwarderBase.sol#L69) which changes the crossDomainAdmin state [variable](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/ForwarderBase.sol#L20). This variable is used to give access control to almost all functions within the contract, including those that are meant to be used to complete L1->L3 message passing and asset transfers. When calling setCrossDomainAdmin, it is assumed that there are no outstanding operations that need to be passed to another chain. This is because when operations arrive at L2, the original sender of those is the old crossDomainAdmin and will be blocked from continuing further. In order to raise awareness about such behavior, consider documenting this edge case in the setCrossDomainAdmin function.

This PR adds a comment outlining this effect.