### PR TITLE
fix: C-01 Missing Access Control for `setDestinationSettler`

### DIFF
--- a/contracts/erc7683/ERC7683OrderDepositorExternal.sol
+++ b/contracts/erc7683/ERC7683OrderDepositorExternal.sol
@@ -35,7 +35,7 @@ contract ERC7683OrderDepositorExternal is ERC7683OrderDepositor, Ownable, MultiC
         SPOKE_POOL = _spokePool;
     }
 
-    function setDestinationSettler(uint256 chainId, address destinationSettler) external {
+    function setDestinationSettler(uint256 chainId, address destinationSettler) external onlyOwner {
         address prevDestinationSettler = destinationSettlers[chainId];
         destinationSettlers[chainId] = destinationSettler;
         emit SetDestinationSettler(chainId, prevDestinationSettler, destinationSettler);


### PR DESCRIPTION
> The ERC7683OrderDepositorExternal contract contains the setDestinationSettler [function](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683OrderDepositorExternal.sol#L38-L42) which provides a mapping of chain ID to that chain's settler contract address. This value is accessed through the [_destinationSettler](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683OrderDepositorExternal.sol#L80-L82) function of the same contract and is used by the inherited ERC7683OrderDepositor contract when constructing the [fill instructions](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683OrderDepositor.sol#L216) inside the [_resolveFor](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683OrderDepositor.sol#L161) function.

> The issue is that the setDestinationSettler function has [no access control](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683OrderDepositorExternal.sol#L38-L42) and can be changed to any arbitrary address by any account. Consequently, a malicious user could set the destinationSettler address to a malicious address which is used in constructing the fill instructions. The filler on the destinationChain would need to give token approvals to the destinationSettler to execute the fill call. A malicious destinationSettler would be thus able to steal funds from the filler.

> Since the ERC7683OrderDepositorExternal contract already [inherits](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683OrderDepositorExternal.sol#L16) the Ownable contract, consider adding the onlyOwner modifier to its setDestinationSettler function.

This applies the suggestion and adds `onlyOwner` to `setDestinationSettler`.