### PR TITLE
fix: update node version for publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: "18.x"
           always-auth: true
           registry-url: "https://registry.npmjs.org"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
Some packages are no longer compatible with the node version we were using: https://github.com/across-protocol/contracts/actions/runs/11746427003