### PR TITLE
fix: L-02 Incorrect Casts

### DIFF
--- a/contracts/erc7683/ERC7683OrderDepositor.sol
+++ b/contracts/erc7683/ERC7683OrderDepositor.sol
@@ -208,7 +208,7 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
             token: _toBytes32(acrossOrderData.inputToken),
             amount: acrossOrderData.inputAmount,
             recipient: _toBytes32(acrossOriginFillerData.exclusiveRelayer),
-            chainId: SafeCast.toUint32(block.chainid)
+            chainId: block.chainid
         });
 
         FillInstruction[] memory fillInstructions = new FillInstruction[](1);
@@ -272,7 +272,7 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
             token: _toBytes32(acrossOrderData.inputToken),
             amount: acrossOrderData.inputAmount,
             recipient: _toBytes32(acrossOrderData.exclusiveRelayer),
-            chainId: SafeCast.toUint32(block.chainid)
+            chainId: block.chainid
         });
 
         FillInstruction[] memory fillInstructions = new FillInstruction[](1);


### PR DESCRIPTION
> Orders inside the ERC7683OrderDepositor contract may be resolved either by the [_resolve function](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683OrderDepositor.sol#L244) or by the [_resolveFor function](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683OrderDepositor.sol#L161). Both functions receive an order and convert it to the [ResolvedCrossChainOrder struct](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683.sol#L46-L65), which contains the minReceived member of the Output[] type. However, inside both _resolve and _resolveFor functions, the minReceived member is [initialized](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683OrderDepositor.sol#L210) using the block.chainId cast to uint32, although the [Output.chainId member](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683.sol#L77) is of type uint64. This means that the code will revert for blockchains with chainID not fitting into uint32, although it should work for all blockchains with chain IDs lower than type(uint64).max.

> Consider casting block.chainId to uint64 instead of uint32 when initializing ResolvedCrossChainOrder.minReceived.

[This commit](https://github.com/across-protocol/contracts/commit/98c761ee9ca3a496b4a368bdf12743d727644138) changed the `chainId` field from a u64 to a u256, so the cast is now removed entirely. 