### PR TITLE
fix: M-08 Transfers of The Target Chain's Gas Token Will Fail

### DIFF
--- a/contracts/chain-adapters/ZkStack_Adapter.sol
+++ b/contracts/chain-adapters/ZkStack_Adapter.sol
@@ -132,9 +132,9 @@ contract ZkStack_Adapter is AdapterInterface {
             txHash = BRIDGE_HUB.requestL2TransactionDirect{ value: amount + txBaseCost }(
                 BridgeHubInterface.L2TransactionRequestDirect({
                     chainId: CHAIN_ID,
-                    mintValue: txBaseCost,
+                    mintValue: txBaseCost + txBaseCost,
                     l2Contract: to,
-                    l2Value: 0,
+                    l2Value: amount,
                     l2Calldata: "",
                     l2GasLimit: L2_GAS_LIMIT,
                     l2GasPerPubdataByteLimit: L1_GAS_TO_L2_GAS_PER_PUB_DATA_LIMIT,

--- a/contracts/chain-adapters/ZkStack_Adapter.sol
+++ b/contracts/chain-adapters/ZkStack_Adapter.sol
@@ -132,7 +132,7 @@ contract ZkStack_Adapter is AdapterInterface {
             txHash = BRIDGE_HUB.requestL2TransactionDirect{ value: amount + txBaseCost }(
                 BridgeHubInterface.L2TransactionRequestDirect({
                     chainId: CHAIN_ID,
-                    mintValue: txBaseCost + txBaseCost,
+                    mintValue: txBaseCost + amount,
                     l2Contract: to,
                     l2Value: amount,
                     l2Calldata: "",

--- a/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol
+++ b/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol
@@ -173,9 +173,9 @@ contract ZkStack_CustomGasToken_Adapter is AdapterInterface {
             txHash = BRIDGE_HUB.requestL2TransactionDirect(
                 BridgeHubInterface.L2TransactionRequestDirect({
                     chainId: CHAIN_ID,
-                    mintValue: txBaseCost,
+                    mintValue: txBaseCost + amount,
                     l2Contract: to,
-                    l2Value: 0,
+                    l2Value: amount,
                     l2Calldata: "",
                     l2GasLimit: L2_GAS_LIMIT,
                     l2GasPerPubdataByteLimit: L1_GAS_TO_L2_GAS_PER_PUB_DATA_LIMIT,

--- a/test/evm/foundry/local/ZkStack_Adapter.t.sol
+++ b/test/evm/foundry/local/ZkStack_Adapter.t.sol
@@ -173,9 +173,9 @@ contract ZkStackAdapterTest is Test {
             abi.encode(
                 BridgeHubInterface.L2TransactionRequestDirect({
                     chainId: ZK_CHAIN_ID,
-                    mintValue: baseCost,
+                    mintValue: baseCost + amountToSend,
                     l2Contract: random,
-                    l2Value: 0,
+                    l2Value: amountToSend,
                     l2Calldata: "",
                     l2GasLimit: L2_GAS_LIMIT,
                     l2GasPerPubdataByteLimit: L2_GAS_PER_PUBDATA_LIMIT,
@@ -311,9 +311,9 @@ contract ZkStackAdapterTest is Test {
             abi.encode(
                 BridgeHubInterface.L2TransactionRequestDirect({
                     chainId: ZK_ALT_CHAIN_ID,
-                    mintValue: baseCost,
+                    mintValue: baseCost + amountToSend,
                     l2Contract: random,
-                    l2Value: 0,
+                    l2Value: amountToSend,
                     l2Calldata: "",
                     l2GasLimit: L2_GAS_LIMIT,
                     l2GasPerPubdataByteLimit: L2_GAS_PER_PUBDATA_LIMIT,


### PR DESCRIPTION
> The relayTokens [function](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/ZkStack_Adapter.sol#L109-L122) of the ZkStack_Adapter is intended to facilitate transfers from the HubPool on the Ethereum Mainnet to ZkStack chains, having ETH as the gas token, via the BridgeHub. The relayTokens [function](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol#L141) of the ZkStack_CustomGasToken_Adapter contract enables this functionality for chains with a custom gas token.

> For ZkStack_Adapter, when transferring WETH, the relayTokens function [unwraps](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/ZkStack_Adapter.sol#L128-L144) the WETH into ETH and sends this amount to the BridgeHub as part of the requestL2TransactionDirect call to the BridgeHub contract. For ETH transfers, the requestL2TransactionDirect function checks that the value sent along with the call is equal to the mintValue of the request. However, in the relayTokens function, the value that is sent is the [amount + txBaseCost](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/ZkStack_Adapter.sol#L132) while mintValue [is only](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/ZkStack_Adapter.sol#L135) the txBaseCost.

> The requestL2TransactionDirect function [requires](https://etherscan.io/address/0x509da1be24432f8804c4a9ff4a3c3f80284cdd13#code#F1#L222) the mintValue field to be equal to the msg.value of the call, but the mintValue will always only be set as the txBaseCost, meaning that the check will always fail. In addition, the l2Value for the requestL2TransactionDirect is [fixed at 0](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/ZkStack_Adapter.sol#L137) inside the contract, meaning that the l2Contract will never receive any ETH. Consequently, transfers of WETH to ZkStack chains that use ETH as a base token cannot succeed.

> There is a similar issue present in the relayTokens function for ZkStack chains with custom gas tokens. In cases where the token to be bridged is the gas token, only the [amount needed to cover the transaction cost will be transferred](https://github.com/across-protocol/contracts/blob/5a0c67c984d19a3bb843a4cec9bb081734583dd1/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol#L176) as the amount argument of the relayTokens function is ignored.

> Consider amending the implementation in accordance with the guidelines for [L1 to L2 bridging](https://docs.zksync.io/build/developer-reference/era-contracts/l1-ecosystem-contracts#l1l2-communication) on ZkStack chains. For the ZkStack_Adapter and ZkStack_CustomGasToken_Adapter contracts, this will require setting the mintValue as the total value that is transferred with the call to requestL2TransactionDirect, which is txBaseCost + amount. The l2Value should also be amended to reflect the value to be transferred to the l2Contract.

This looked similar to the changes made to `Arbitrum_CustomGasToken_Adapter` [here](https://github.com/across-protocol/contracts/commit/e8921d7a61028df058dc79f3eb9e07409856e4e5). We now make sure that the mint value is equal to the `msg.value`/ amount we approve (if a custom gas token), and that the call value on L2 is not necessarily 0.