### PR TITLE
H-01 SpokePool's fill Function Performs Malformed Call

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -913,9 +913,13 @@ abstract contract SpokePool is
             revert WrongERC7683OrderId();
         }
 
+        // Ensure that the call is not malformed. If the call is malformed, abi.decode will fail.
+        V3SpokePoolInterface.V3RelayData memory relayData = abi.decode(originData, (V3SpokePoolInterface.V3RelayData));
+        uint256 repaymentChainId = abi.decode(fillerData, (uint256));
+
         // Must do a delegatecall because the function requires the inputs to be calldata.
         (bool success, bytes memory data) = address(this).delegatecall(
-            abi.encodeWithSelector(this.fillV3Relay.selector, abi.encodePacked(originData, fillerData))
+            abi.encodeCall(V3SpokePoolInterface.fillV3Relay, (relayData, repaymentChainId))
         );
         if (!success) {
             revert LowLevelCallFailed(data);

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "./MerkleLib.sol";
 import "./erc7683/ERC7683.sol";
+import "./erc7683/ERC7683Across.sol";
 import "./external/interfaces/WETH9Interface.sol";
 import "./interfaces/SpokePoolMessageHandler.sol";
 import "./interfaces/SpokePoolInterface.sol";
@@ -915,11 +916,14 @@ abstract contract SpokePool is
 
         // Ensure that the call is not malformed. If the call is malformed, abi.decode will fail.
         V3SpokePoolInterface.V3RelayData memory relayData = abi.decode(originData, (V3SpokePoolInterface.V3RelayData));
-        uint256 repaymentChainId = abi.decode(fillerData, (uint256));
+        AcrossDestinationFillerData memory destinationFillerData = abi.decode(
+            fillerData,
+            (AcrossDestinationFillerData)
+        );
 
         // Must do a delegatecall because the function requires the inputs to be calldata.
         (bool success, bytes memory data) = address(this).delegatecall(
-            abi.encodeCall(V3SpokePoolInterface.fillV3Relay, (relayData, repaymentChainId))
+            abi.encodeCall(V3SpokePoolInterface.fillV3Relay, (relayData, destinationFillerData.repaymentChainId))
         );
         if (!success) {
             revert LowLevelCallFailed(data);

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -910,7 +910,7 @@ abstract contract SpokePool is
         bytes calldata originData,
         bytes calldata fillerData
     ) external {
-        if (keccak256(originData) != orderId) {
+        if (keccak256(abi.encode(originData, chainId())) != orderId) {
             revert WrongERC7683OrderId();
         }
 


### PR DESCRIPTION
> The fill [function](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/SpokePool.sol#L988) of the SpokePool contract is meant to adhere to the IDestinationSettler interface, as dictated by the latest update to the ERC-7683 [specifications](https://github.com/across-protocol/ERCs/blob/d975d7b4b58fa3d1aa6db1763935cfa2ab1444b1/ERCS/erc-7683.md). The fill function is meant to internally call the fillV3Relay [function](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/SpokePool.sol#L864) in order to process the order data, and it does so by [making a delegatecall to its own fillV3Relay function](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/SpokePool.sol#L998-L999), passing abi.encodePacked(originData, fillerData) as the parameter.

> However, the fillV3Relay function accepts two parameters, having the repaymentChainId as the second parameter. Since the call is constructed using encodeWithSelector, which is not type-safe, the compiler does not complain about the missing parameter. As an incorrect number of parameters is passed, the call to fillV3Relay will always revert when trying to decode the input parameters, breaking the entire execution flow. Moreover, the input data is encoded with abi.encodePacked the use of which is discouraged, especially when dealing with structs and dynamic types like arrays.

> Consider using encodeCall instead of encodeWithSelector to ensure type safety, and providing the parameters required by the fillV3Relay function separately. In addition, consider explicitly making the SpokePool contract inherit from the IDestinationSettler interface as required by the ERC-7683 standard.

This PR performs the suggested change and decodes the input data to fields of `fillV3Relay`, so that `abi.encodeCall` can be used.