### PR TITLE
fix: M-06 Incorrect Parameters Passed to permitWitnessTransferFrom

### DIFF
--- a/contracts/erc7683/ERC7683Across.sol
+++ b/contracts/erc7683/ERC7683Across.sol
@@ -67,7 +67,7 @@ library ERC7683Permit2Lib {
     string internal constant PERMIT2_ORDER_TYPE =
         string(
             abi.encodePacked(
-                "CrossChainOrder witness)",
+                "GaslessCrossChainOrder witness)",
                 ACROSS_ORDER_DATA_TYPE,
                 CROSS_CHAIN_ORDER_TYPE,
                 TOKEN_PERMISSIONS_TYPE
@@ -86,6 +86,7 @@ library ERC7683Permit2Lib {
                     order.originChainId,
                     order.openDeadline,
                     order.fillDeadline,
+                    order.orderDataType,
                     orderDataHash
                 )
             );
@@ -102,6 +103,7 @@ library ERC7683Permit2Lib {
                     orderData.outputAmount,
                     orderData.destinationChainId,
                     orderData.recipient,
+                    orderData.exclusiveRelayer,
                     orderData.exclusivityPeriod,
                     keccak256(orderData.message)
                 )


### PR DESCRIPTION
> The [PERMIT2_ORDER_TYPE variable](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683Across.sol#L67) stores the witness data type string, which is supposed to be passed as the witnessTypeString parameter to the permitWitnessTransferFrom function of the Permit2 contract. As such, this variable is supposed to define the typed data that the witness parameter passed to that function was hashed from. However, it instead [specifies](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683Across.sol#L70) that the witness parameter has been hashed from the CrossChainOrder type, whereas in reality, [it was hashed from the GaslessCrossChainOrder type](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683OrderDepositor.sol#L331).

> Moreover, the witness parameter specified is incorrect as the [orderDataType](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683.sol#L22) member of the GaslessCrossChainOrder struct is not taken into account when [calculating it](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683Across.sol#L80-L91). The same is true for the [exclusiveRelayer](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683Across.sol#L15) and [depositNonce](https://github.com/across-protocol/contracts/blob/7641fbf38b661e02fc00f3b33d7e587c6dc5f06f/contracts/erc7683/ERC7683Across.sol#L16) members of the AcrossOrderData struct, which are [not included](https://github.com/across-protocol/contracts/blob/7641fbf38b661e02fc00f3b33d7e587c6dc5f06f/contracts/erc7683/ERC7683Across.sol#L106-L107) in the calculation of its hash. Furthermore, the CROSS_CHAIN_ORDER_TYPE variable used to create the witness contains an incorrect encoding of the [GaslessCrossChainOrder struct](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683.sol#L6) as the [originChainId member](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683Across.sol#L55) is specified to be of type uint32 instead of uint64.

> Consider correcting the errors described above in order to maintain compliance with EIP-712 and Permit2.

The issues with `originChainId` being a uint32 was fixed in [this PR](https://github.com/across-protocol/contracts/commit/98c761ee9ca3a496b4a368bdf12743d727644138), so this proposal just modifies the `PERMIT2_ORDER_TYPE` and adds the necessary fields to the order hash.