### PR TITLE
fix: M-03 Types Incompatible With ERC-7683

### DIFF
--- a/contracts/erc7683/ERC7683Across.sol
+++ b/contracts/erc7683/ERC7683Across.sol
@@ -31,8 +31,8 @@ bytes constant ACROSS_ORDER_DATA_TYPE = abi.encodePacked(
     "uint256 inputAmount,",
     "address outputToken,",
     "uint256 outputAmount,",
-    "uint32 destinationChainId,",
-    "address recipient,",
+    "uint256 destinationChainId,",
+    "bytes32 recipient,",
     "address exclusiveRelayer,"
     "uint32 exclusivityPeriod,",
     "bytes message)"

--- a/contracts/erc7683/ERC7683Across.sol
+++ b/contracts/erc7683/ERC7683Across.sol
@@ -10,8 +10,8 @@ struct AcrossOrderData {
     uint256 inputAmount;
     address outputToken;
     uint256 outputAmount;
-    uint32 destinationChainId;
-    address recipient;
+    uint256 destinationChainId;
+    bytes32 recipient;
     address exclusiveRelayer;
     uint32 exclusivityPeriod;
     bytes message;

--- a/contracts/erc7683/ERC7683OrderDepositor.sol
+++ b/contracts/erc7683/ERC7683OrderDepositor.sol
@@ -342,7 +342,7 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
     }
 
     function _toAddress(bytes32 _bytes32) internal pure returns (address) {
-        require(uint256(_bytes32) >> 192 == 0, "Invalid bytes32: highest 12 bytes must be 0");
+        require(uint256(_bytes32) >> 160 == 0, "Invalid bytes32: highest 12 bytes must be 0");
         return address(uint160(uint256(_bytes32)));
     }
 

--- a/contracts/erc7683/ERC7683OrderDepositor.sol
+++ b/contracts/erc7683/ERC7683OrderDepositor.sol
@@ -64,7 +64,7 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
 
         _callDeposit(
             order.user,
-            acrossOrderData.recipient,
+            _toAddress(acrossOrderData.recipient),
             acrossOrderData.inputToken,
             acrossOrderData.outputToken,
             acrossOrderData.inputAmount,
@@ -94,7 +94,7 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
 
         _callDeposit(
             msg.sender,
-            acrossOrderData.recipient,
+            _toAddress(acrossOrderData.recipient),
             acrossOrderData.inputToken,
             acrossOrderData.outputToken,
             acrossOrderData.inputAmount,
@@ -195,7 +195,7 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
         maxSpent[0] = Output({
             token: _toBytes32(acrossOrderData.outputToken),
             amount: acrossOrderData.outputAmount,
-            recipient: _toBytes32(acrossOrderData.recipient),
+            recipient: acrossOrderData.recipient,
             chainId: acrossOrderData.destinationChainId
         });
 
@@ -208,13 +208,13 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
             token: _toBytes32(acrossOrderData.inputToken),
             amount: acrossOrderData.inputAmount,
             recipient: _toBytes32(acrossOriginFillerData.exclusiveRelayer),
-            chainId: SafeCast.toUint32(block.chainid)
+            chainId: block.chainid
         });
 
         FillInstruction[] memory fillInstructions = new FillInstruction[](1);
         V3SpokePoolInterface.V3RelayData memory relayData;
         relayData.depositor = order.user;
-        relayData.recipient = acrossOrderData.recipient;
+        relayData.recipient = _toAddress(acrossOrderData.recipient);
         relayData.exclusiveRelayer = acrossOriginFillerData.exclusiveRelayer;
         relayData.inputToken = acrossOrderData.inputToken;
         relayData.outputToken = acrossOrderData.outputToken;
@@ -226,7 +226,7 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
         relayData.exclusivityDeadline = acrossOrderData.exclusivityPeriod;
         relayData.message = acrossOrderData.message;
         fillInstructions[0] = FillInstruction({
-            destinationChainId: acrossOrderData.destinationChainId,
+            destinationChainId: SafeCast.toUint64(acrossOrderData.destinationChainId),
             destinationSettler: _toBytes32(_destinationSettler(acrossOrderData.destinationChainId)),
             originData: abi.encode(relayData)
         });
@@ -259,7 +259,7 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
         maxSpent[0] = Output({
             token: _toBytes32(acrossOrderData.outputToken),
             amount: acrossOrderData.outputAmount,
-            recipient: _toBytes32(acrossOrderData.recipient),
+            recipient: acrossOrderData.recipient,
             chainId: acrossOrderData.destinationChainId
         });
 
@@ -272,13 +272,13 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
             token: _toBytes32(acrossOrderData.inputToken),
             amount: acrossOrderData.inputAmount,
             recipient: _toBytes32(acrossOrderData.exclusiveRelayer),
-            chainId: SafeCast.toUint32(block.chainid)
+            chainId: block.chainid
         });
 
         FillInstruction[] memory fillInstructions = new FillInstruction[](1);
         V3SpokePoolInterface.V3RelayData memory relayData;
         relayData.depositor = msg.sender;
-        relayData.recipient = acrossOrderData.recipient;
+        relayData.recipient = _toAddress(acrossOrderData.recipient);
         relayData.exclusiveRelayer = acrossOrderData.exclusiveRelayer;
         relayData.inputToken = acrossOrderData.inputToken;
         relayData.outputToken = acrossOrderData.outputToken;
@@ -290,14 +290,14 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
         relayData.exclusivityDeadline = acrossOrderData.exclusivityPeriod;
         relayData.message = acrossOrderData.message;
         fillInstructions[0] = FillInstruction({
-            destinationChainId: acrossOrderData.destinationChainId,
+            destinationChainId: SafeCast.toUint64(acrossOrderData.destinationChainId),
             destinationSettler: _toBytes32(_destinationSettler(acrossOrderData.destinationChainId)),
             originData: abi.encode(relayData)
         });
 
         resolvedOrder = ResolvedCrossChainOrder({
             user: msg.sender,
-            originChainId: SafeCast.toUint64(block.chainid),
+            originChainId: block.chainid,
             openDeadline: type(uint32).max, // no deadline since the user is sending it
             fillDeadline: order.fillDeadline,
             minReceived: minReceived,
@@ -339,6 +339,11 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
 
     function _toBytes32(address input) internal pure returns (bytes32) {
         return bytes32(uint256(uint160(input)));
+    }
+
+    function _toAddress(bytes32 _bytes32) internal pure returns (address) {
+        require(uint256(_bytes32) >> 192 == 0, "Invalid bytes32: highest 12 bytes must be 0");
+        return address(uint160(uint256(_bytes32)));
     }
 
     function _callDeposit(


### PR DESCRIPTION
> The [newest changes](https://github.com/across-protocol/ERCs/blob/d975d7b4b58fa3d1aa6db1763935cfa2ab1444b1/ERCS/erc-7683.md) to the ERC-7683 standard redefined the types of some variables. Particularly, the variables storing the chain ID now have the uint64 type instead of uint32, and some addresses are now stored in the bytes32 type. However, the variables declared inside the [AcrossOrderData struct](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683Across.sol#L8-L18) still have the old types. In particular, the [destinationChainId member](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683Across.sol#L13) is of type uint32 and the [recipient member](https://github.com/across-protocol/contracts/blob/108be77c29a3861c64bdf66209ac6735a6a87090/contracts/erc7683/ERC7683Across.sol#L14) is of the address type.

> Consider changing the types of all affected variables so that they are in compliance with the latest version of the ERC-7683 standard.

The updated changes to ERC7683 should now be matched in `AcrossOrderData`. Namely, `recipient` is now represented as a `bytes32`, and `destinationChainId` is now represented as a `uint256`. In order to keep compatibility with the spoke pool, a new function, `_toAddress(bytes32)`, was created, which converts `recipient` to an evm `address`. 