### PR TITLE
fix(svm): fork cctp from mainnet

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -35,7 +35,7 @@ remotePauseDeposits = "NODE_NO_WARNINGS=1 yarn run ts-node ./scripts/svm/remoteP
 generateExternalTypes = "NODE_NO_WARNINGS=1 yarn run ts-node ./scripts/svm/generateExternalTypes.ts"
 
 [test.validator]
-url = "https://api.devnet.solana.com"
+url = "https://api.mainnet-beta.solana.com"
 
 ### Forked Circle Message Transmitter Program
 [[test.validator.clone]]


### PR DESCRIPTION
CCTP upgraded their messanger program on devnet that broke our forking tests. This switches to mainnet forking that still has the original CCTP instance.