### PR TITLE
feat: handle EIP-2612 and EIP-3009 in `SwapAndBridge.sol`

### DIFF
--- a/contracts/SwapAndBridge.sol
+++ b/contracts/SwapAndBridge.sol
@@ -13,6 +13,7 @@ import "@uma/core/contracts/common/implementation/MultiCaller.sol";
 /**
  * @title SwapAndBridgeBase
  * @notice Base contract for both variants of SwapAndBridge.
+ * @dev Variables which may be immutable are not marked as immutable so that this contract may be deployed deterministically.
  * @custom:security-contact bugs@across.to
  */
 abstract contract SwapAndBridgeBase is Lockable, MultiCaller {
@@ -23,13 +24,13 @@ abstract contract SwapAndBridgeBase is Lockable, MultiCaller {
     mapping(bytes4 => bool) public allowedSelectors;
 
     // Across SpokePool we'll submit deposits to with acrossInputToken as the input token.
-    V3SpokePoolInterface public immutable SPOKE_POOL;
+    V3SpokePoolInterface public spokePool;
 
     // Exchange address or router where the swapping will happen.
-    address public immutable EXCHANGE;
+    address public exchange;
 
     // Wrapped native token contract address.
-    WETH9Interface internal immutable WRAPPED_NATIVE_TOKEN;
+    WETH9Interface internal wrappedNativeToken;
 
     // Params we'll need caller to pass in to specify an Across Deposit. The input token will be swapped into first
     // before submitting a bridge deposit, which is why we don't include the input token amount as it is not known
@@ -89,9 +90,9 @@ abstract contract SwapAndBridgeBase is Lockable, MultiCaller {
         address _exchange,
         bytes4[] memory _allowedSelectors
     ) {
-        SPOKE_POOL = _spokePool;
-        EXCHANGE = _exchange;
-        WRAPPED_NATIVE_TOKEN = _wrappedNativeToken;
+        spokePool = _spokePool;
+        exchange = _exchange;
+        wrappedNativeToken = _wrappedNativeToken;
         for (uint256 i = 0; i < _allowedSelectors.length; i++) {
             allowedSelectors[_allowedSelectors[i]] = true;
         }
@@ -115,9 +116,9 @@ abstract contract SwapAndBridgeBase is Lockable, MultiCaller {
         uint256 srcBalanceBefore = _swapToken.balanceOf(address(this));
         uint256 dstBalanceBefore = _acrossInputToken.balanceOf(address(this));
 
-        _swapToken.safeIncreaseAllowance(EXCHANGE, swapTokenAmount);
+        _swapToken.safeIncreaseAllowance(exchange, swapTokenAmount);
         // solhint-disable-next-line avoid-low-level-calls
-        (bool success, bytes memory result) = EXCHANGE.call(routerCalldata);
+        (bool success, bytes memory result) = exchange.call(routerCalldata);
         require(success, string(result));
 
         _checkSwapOutputAndDeposit(
@@ -156,7 +157,7 @@ abstract contract SwapAndBridgeBase is Lockable, MultiCaller {
         if (swapTokenBalanceBefore - _swapToken.balanceOf(address(this)) != swapTokenAmount) revert LeftoverSrcTokens();
 
         emit SwapBeforeBridge(
-            EXCHANGE,
+            exchange,
             address(_swapToken),
             address(_acrossInputToken),
             swapTokenAmount,
@@ -179,8 +180,8 @@ abstract contract SwapAndBridgeBase is Lockable, MultiCaller {
         uint256 _acrossInputAmount,
         DepositData calldata depositData
     ) internal {
-        _acrossInputToken.safeIncreaseAllowance(address(SPOKE_POOL), _acrossInputAmount);
-        SPOKE_POOL.depositV3(
+        _acrossInputToken.safeIncreaseAllowance(address(spokePool), _acrossInputAmount);
+        spokePool.depositV3(
             depositData.depositor,
             depositData.recipient,
             address(_acrossInputToken), // input token
@@ -313,8 +314,8 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
         // as though the user deposited a wrapped native token.
         if (msg.value != 0) {
             if (msg.value != swapTokenAmount) revert InsufficientSwapValue();
-            if (address(swapToken) != address(WRAPPED_NATIVE_TOKEN)) revert InvalidSwapToken();
-            WRAPPED_NATIVE_TOKEN.deposit{ value: msg.value }();
+            if (address(swapToken) != address(wrappedNativeToken)) revert InvalidSwapToken();
+            wrappedNativeToken.deposit{ value: msg.value }();
         } else {
             swapToken.safeTransferFrom(msg.sender, address(this), swapTokenAmount);
         }

--- a/contracts/SwapAndBridge.sol
+++ b/contracts/SwapAndBridge.sol
@@ -357,8 +357,9 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
         bytes32 r,
         bytes32 s
     ) external nonReentrant {
-        swapToken.permit(msg.sender, address(this), swapTokenAmount, deadline, v, r, s);
-        IERC20 _swapToken = IERC20(address(swapToken)); // Cast IERC20Permit to IERC20
+        IERC20 _swapToken = IERC20(address(swapToken)); // Cast IERC20Permit to IERC20.
+        if (_swapToken.allowance(msg.sender, address(this)) < swapTokenAmount)
+            swapToken.permit(msg.sender, address(this), swapTokenAmount, deadline, v, r, s);
 
         _swapToken.safeTransferFrom(msg.sender, address(this), swapTokenAmount);
         _swapAndBridge(
@@ -418,7 +419,7 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
             r,
             s
         );
-        IERC20 _swapToken = IERC20(address(swapToken)); // Cast IERC20Auth to IERC20
+        IERC20 _swapToken = IERC20(address(swapToken)); // Cast IERC20Auth to IERC20.
 
         _swapAndBridge(
             routerCalldata,
@@ -450,8 +451,9 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
         bytes32 r,
         bytes32 s
     ) external nonReentrant {
-        acrossInputToken.permit(msg.sender, address(this), acrossInputAmount, deadline, v, r, s);
         IERC20 _acrossInputToken = IERC20(address(acrossInputToken)); // Cast IERC20Permit to an IERC20 type.
+        if (_acrossInputToken.allowance(msg.sender, address(this)) < acrossInputAmount)
+            acrossInputToken.permit(msg.sender, address(this), acrossInputAmount, deadline, v, r, s);
 
         _acrossInputToken.safeTransferFrom(msg.sender, address(this), acrossInputAmount);
         _depositV3(_acrossInputToken, acrossInputAmount, depositData);

--- a/contracts/SwapAndBridge.sol
+++ b/contracts/SwapAndBridge.sol
@@ -264,7 +264,7 @@ contract SwapAndBridge is SwapAndBridgeBase {
 contract UniversalSwapAndBridge is SwapAndBridgeBase {
     using SafeERC20 for IERC20;
 
-    error InsufficientTokenBalance(address token, uint256 balance, uint256 balanceRequired);
+    error InsufficientTokenBalance(address token, uint256 balanceRequired, uint256 balanceOwned);
 
     /**
      * @notice Construct a new SwapAndBridgeBase contract.

--- a/contracts/SwapAndBridge.sol
+++ b/contracts/SwapAndBridge.sol
@@ -264,8 +264,6 @@ contract SwapAndBridge is SwapAndBridgeBase {
 contract UniversalSwapAndBridge is SwapAndBridgeBase {
     using SafeERC20 for IERC20;
 
-    error InsufficientTokenBalance(address token, uint256 balanceRequired, uint256 balanceOwned);
-
     /**
      * @notice Construct a new SwapAndBridgeBase contract.
      * @param _spokePool Address of the SpokePool contract that we'll submit deposits to.
@@ -402,9 +400,6 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
         );
         IERC20 _swapToken = IERC20(address(swapToken)); // Cast IERC20Auth to IERC20
 
-        uint256 tokenBalance = _swapToken.balanceOf(address(this));
-        if (tokenBalance < swapTokenAmount)
-            revert InsufficientTokenBalance(address(swapToken), swapTokenAmount, tokenBalance);
         _swapAndBridge(
             routerCalldata,
             swapTokenAmount,
@@ -478,10 +473,6 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
             s
         );
         IERC20 _acrossInputToken = IERC20(address(acrossInputToken)); // Cast the input token to an IERC20.
-
-        uint256 tokenBalance = _acrossInputToken.balanceOf(address(this));
-        if (tokenBalance < acrossInputAmount)
-            revert InsufficientTokenBalance(address(acrossInputToken), acrossInputAmount, tokenBalance);
         _depositV3(_acrossInputToken, acrossInputAmount, depositData);
     }
 }

--- a/contracts/SwapAndBridge.sol
+++ b/contracts/SwapAndBridge.sol
@@ -359,8 +359,7 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
         bytes32 s
     ) external nonReentrant {
         IERC20 _swapToken = IERC20(address(swapToken)); // Cast IERC20Permit to IERC20.
-        if (_swapToken.allowance(msg.sender, address(this)) < swapTokenAmount)
-            swapToken.permit(msg.sender, address(this), swapTokenAmount, deadline, v, r, s);
+        try swapToken.permit(msg.sender, address(this), swapTokenAmount, deadline, v, r, s) {} catch {}
 
         _swapToken.safeTransferFrom(msg.sender, address(this), swapTokenAmount);
         _swapAndBridge(
@@ -453,8 +452,7 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
         bytes32 s
     ) external nonReentrant {
         IERC20 _acrossInputToken = IERC20(address(acrossInputToken)); // Cast IERC20Permit to an IERC20 type.
-        if (_acrossInputToken.allowance(msg.sender, address(this)) < acrossInputAmount)
-            acrossInputToken.permit(msg.sender, address(this), acrossInputAmount, deadline, v, r, s);
+        try acrossInputToken.permit(msg.sender, address(this), acrossInputAmount, deadline, v, r, s) {} catch {}
 
         _acrossInputToken.safeTransferFrom(msg.sender, address(this), acrossInputAmount);
         _depositV3(_acrossInputToken, acrossInputAmount, depositData);

--- a/contracts/SwapAndBridge.sol
+++ b/contracts/SwapAndBridge.sol
@@ -360,7 +360,8 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
     ) external nonReentrant {
         IERC20 _swapToken = IERC20(address(swapToken)); // Cast IERC20Permit to IERC20.
         // For permit transactions, we wrap the call in a try/catch block so that the transaction will continue even if the call to
-        // permit fails. For example, this may be useful if the permit signature is front-run.
+        // permit fails. For example, this may be useful if the permit signature, which can be redeemed by anyone, is executed by somebody
+        // other than this contract.
         try swapToken.permit(msg.sender, address(this), swapTokenAmount, deadline, v, r, s) {} catch {}
 
         _swapToken.safeTransferFrom(msg.sender, address(this), swapTokenAmount);
@@ -455,7 +456,8 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
     ) external nonReentrant {
         IERC20 _acrossInputToken = IERC20(address(acrossInputToken)); // Cast IERC20Permit to an IERC20 type.
         // For permit transactions, we wrap the call in a try/catch block so that the transaction will continue even if the call to
-        // permit fails. For example, this may be useful if the permit signature is front-run.
+        // permit fails. For example, this may be useful if the permit signature, which can be redeemed by anyone, is executed by somebody
+        // other than this contract.
         try acrossInputToken.permit(msg.sender, address(this), acrossInputAmount, deadline, v, r, s) {} catch {}
 
         _acrossInputToken.safeTransferFrom(msg.sender, address(this), acrossInputAmount);

--- a/contracts/SwapAndBridge.sol
+++ b/contracts/SwapAndBridge.sol
@@ -405,7 +405,8 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
         bytes32 s
     ) external nonReentrant {
         // While any contract can vacuously implement `transferWithAuthorization` (or just have a fallback),
-        // If tokens were not sent to this contract, the call to `transferFrom` in _swapAndBridge will revert.
+        // if tokens were not sent to this contract, by this call to the swapToken, the call to `transferFrom`
+        // in _swapAndBridge will revert.
         swapToken.receiveWithAuthorization(
             msg.sender,
             address(this),

--- a/contracts/SwapAndBridge.sol
+++ b/contracts/SwapAndBridge.sol
@@ -359,6 +359,8 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
         bytes32 s
     ) external nonReentrant {
         IERC20 _swapToken = IERC20(address(swapToken)); // Cast IERC20Permit to IERC20.
+        // For permit transactions, we wrap the call in a try/catch block so that the transaction will continue even if the call to
+        // permit fails. For example, this may be useful if the permit signature is front-run.
         try swapToken.permit(msg.sender, address(this), swapTokenAmount, deadline, v, r, s) {} catch {}
 
         _swapToken.safeTransferFrom(msg.sender, address(this), swapTokenAmount);
@@ -452,6 +454,8 @@ contract UniversalSwapAndBridge is SwapAndBridgeBase {
         bytes32 s
     ) external nonReentrant {
         IERC20 _acrossInputToken = IERC20(address(acrossInputToken)); // Cast IERC20Permit to an IERC20 type.
+        // For permit transactions, we wrap the call in a try/catch block so that the transaction will continue even if the call to
+        // permit fails. For example, this may be useful if the permit signature is front-run.
         try acrossInputToken.permit(msg.sender, address(this), acrossInputAmount, deadline, v, r, s) {} catch {}
 
         _acrossInputToken.safeTransferFrom(msg.sender, address(this), acrossInputAmount);

--- a/contracts/external/interfaces/IERC20Auth.sol
+++ b/contracts/external/interfaces/IERC20Auth.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+/*
+ * @notice Minimal interface for an EIP-3009 compliant token.
+ * https://eips.ethereum.org/EIPS/eip-3009
+ */
+interface IERC20Auth {
+    /**
+     * @notice Receive a transfer with a signed authorization from the payer
+     * @dev This has an additional check to ensure that the payee's address matches
+     * the caller of this function to prevent front-running attacks. (See security
+     * considerations)
+     * @param from          Payer's address (Authorizer)
+     * @param to            Payee's address
+     * @param value         Amount to be transferred
+     * @param validAfter    The time after which this is valid (unix time)
+     * @param validBefore   The time before which this is valid (unix time)
+     * @param nonce         Unique nonce
+     * @param v             v of the signature
+     * @param r             r of the signature
+     * @param s             s of the signature
+     */
+    function receiveWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+}


### PR DESCRIPTION
# Summary
We need to have a way to deposit into the spoke pool **and** perform a `swapAndBridge` using [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) and [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009). 

This functionality is added with four new functions in the `UniversalSwapAndBridge` contract: `swapAndBridgeWithPermit`, `depositWithPermit`, `swapAndBridgeWithAuthorization`, and `depositWithAuthorization`, where `*WithPermit` indicates usage of an EIP-2612 compliant token, and `*WithAuthorization` indicates usage of an EIP-3009 compliant token.

# Details
EIP-2616 is used solely to give an approval to an address without calling `approve` first. This allows us to still use `transferFrom` when using any EIP-2612 token. 
On the other hand, EIP-3009 will simply transfer tokens to the designated receiver contract and not raise the contract's allowance, so all usage of these types of functions check whether a sufficient token amount was transferred to the contract before proceeding with the rest of the swap/deposit.