### PR TITLE
fix: delegated transfers in deposits

### DIFF
--- a/programs/svm-spoke/src/utils/mod.rs
+++ b/programs/svm-spoke/src/utils/mod.rs
@@ -1,7 +1,9 @@
 pub mod bitmap_utils;
 pub mod cctp_utils;
 pub mod merkle_proof_utils;
+pub mod transfer_utils;
 
 pub use bitmap_utils::*;
 pub use cctp_utils::*;
 pub use merkle_proof_utils::*;
+pub use transfer_utils::*;

--- a/programs/svm-spoke/src/utils/transfer_utils.rs
+++ b/programs/svm-spoke/src/utils/transfer_utils.rs
@@ -1,0 +1,29 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked};
+
+use crate::State;
+
+pub fn transfer_from<'info>(
+    from: &InterfaceAccount<'info, TokenAccount>,
+    to: &InterfaceAccount<'info, TokenAccount>,
+    amount: u64,
+    state: &Account<'info, State>,
+    state_bump: u8,
+    mint: &InterfaceAccount<'info, Mint>,
+    token_program: &Interface<'info, TokenInterface>,
+) -> Result<()> {
+    let transfer_accounts = TransferChecked {
+        from: from.to_account_info(),
+        mint: mint.to_account_info(),
+        to: to.to_account_info(),
+        authority: state.to_account_info(),
+    };
+
+    let state_seed_bytes = state.seed.to_le_bytes();
+    let seeds = &[b"state", state_seed_bytes.as_ref(), &[state_bump]];
+    let signer_seeds = &[&seeds[..]];
+
+    let cpi_context = CpiContext::new_with_signer(token_program.to_account_info(), transfer_accounts, signer_seeds);
+
+    transfer_checked(cpi_context, amount, mint.decimals)
+}

--- a/scripts/svm/simpleFill.ts
+++ b/scripts/svm/simpleFill.ts
@@ -3,8 +3,15 @@
 
 import * as anchor from "@coral-xyz/anchor";
 import { BN, Program, AnchorProvider } from "@coral-xyz/anchor";
-import { PublicKey, SystemProgram } from "@solana/web3.js";
-import { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID, getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { PublicKey, SystemProgram, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  createApproveCheckedInstruction,
+  getAssociatedTokenAddressSync,
+  getMint,
+  getOrCreateAssociatedTokenAccount,
+} from "@solana/spl-token";
 import { SvmSpoke } from "../../target/types/svm_spoke";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -65,7 +72,7 @@ async function fillV3Relay(): Promise<void> {
   };
 
   // Define the signer (replace with your actual signer)
-  const signer = provider.wallet.publicKey;
+  const signer = (provider.wallet as anchor.Wallet).payer;
 
   console.log("Filling V3 Relay...");
 
@@ -87,19 +94,25 @@ async function fillV3Relay(): Promise<void> {
   // Create ATA for the relayer and recipient token accounts
   const relayerTokenAccount = getAssociatedTokenAddressSync(
     outputToken,
-    signer,
+    signer.publicKey,
     true,
     TOKEN_PROGRAM_ID,
     ASSOCIATED_TOKEN_PROGRAM_ID
   );
 
-  const recipientTokenAccount = getAssociatedTokenAddressSync(
-    outputToken,
-    recipient,
-    true,
-    TOKEN_PROGRAM_ID,
-    ASSOCIATED_TOKEN_PROGRAM_ID
-  );
+  const recipientTokenAccount = (
+    await getOrCreateAssociatedTokenAccount(
+      provider.connection,
+      signer,
+      outputToken,
+      recipient,
+      true,
+      undefined,
+      undefined,
+      TOKEN_PROGRAM_ID,
+      ASSOCIATED_TOKEN_PROGRAM_ID
+    )
+  ).address;
 
   console.table([
     { property: "relayHash", value: Buffer.from(relayHashUint8Array).toString("hex") },
@@ -121,10 +134,26 @@ async function fillV3Relay(): Promise<void> {
     }))
   );
 
-  const tx = await (program.methods.fillV3Relay(Array.from(relayHashUint8Array), relayData, chainId, signer) as any)
+  const tokenDecimals = (await getMint(provider.connection, outputToken, undefined, TOKEN_PROGRAM_ID)).decimals;
+
+  // Delegate state PDA to pull relayer tokens.
+  const approveIx = await createApproveCheckedInstruction(
+    relayerTokenAccount,
+    outputToken,
+    statePda,
+    signer.publicKey,
+    BigInt(relayData.outputAmount.toString()),
+    tokenDecimals,
+    undefined,
+    TOKEN_PROGRAM_ID
+  );
+
+  const fillIx = await (
+    program.methods.fillV3Relay(Array.from(relayHashUint8Array), relayData, chainId, signer.publicKey) as any
+  )
     .accounts({
       state: statePda,
-      signer: signer,
+      signer: signer.publicKey,
       mintAccount: outputToken,
       relayerTokenAccount: relayerTokenAccount,
       recipientTokenAccount: recipientTokenAccount,
@@ -134,7 +163,9 @@ async function fillV3Relay(): Promise<void> {
       systemProgram: SystemProgram.programId,
       programId: programId,
     })
-    .rpc();
+    .instruction();
+  const fillTx = new Transaction().add(approveIx, fillIx);
+  const tx = await sendAndConfirmTransaction(provider.connection, fillTx, [signer]);
 
   console.log("Transaction signature:", tx);
 }

--- a/test/svm/SvmSpoke.Deposit.ts
+++ b/test/svm/SvmSpoke.Deposit.ts
@@ -515,4 +515,19 @@ describe("svm_spoke.deposit", () => {
     vaultAccount = await getAccount(connection, vault, undefined, tokenProgram);
     assertSE(vaultAccount.amount, depositData.inputAmount, "Vault balance should be increased by the deposited amount");
   });
+
+  it("Deposit without approval fails", async () => {
+    const depositDataValues = Object.values(depositData) as DepositDataValues;
+
+    try {
+      await program.methods
+        .depositV3(...depositDataValues)
+        .accounts(depositAccounts)
+        .signers([depositor])
+        .rpc();
+      assert.fail("Deposit should have failed due to missing approval");
+    } catch (err: any) {
+      assert.include(err.toString(), "owner does not match");
+    }
+  });
 });

--- a/test/svm/SvmSpoke.Deposit.ts
+++ b/test/svm/SvmSpoke.Deposit.ts
@@ -3,12 +3,17 @@ import { BN } from "@coral-xyz/anchor";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
   createMint,
   getOrCreateAssociatedTokenAccount,
   mintTo,
   getAccount,
+  createApproveCheckedInstruction,
+  createEnableCpiGuardInstruction,
+  createReallocateInstruction,
+  ExtensionType,
 } from "@solana/spl-token";
-import { PublicKey, Keypair } from "@solana/web3.js";
+import { PublicKey, Keypair, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
 import { common, DepositDataValues } from "./SvmSpoke.common";
 import { readProgramEvents } from "./utils";
 const { provider, connection, program, owner, seedBalance, initializeState, depositData } = common;
@@ -20,21 +25,47 @@ describe("svm_spoke.deposit", () => {
 
   const depositor = Keypair.generate();
   const payer = (anchor.AnchorProvider.env().wallet as anchor.Wallet).payer;
-  let state: PublicKey, inputToken: PublicKey, depositorTA: PublicKey, vault: PublicKey;
-  let depositAccounts: any; // Re-used between tests to simplify props.
+  const tokenDecimals = 6;
+
+  let state: PublicKey, inputToken: PublicKey, depositorTA: PublicKey, vault: PublicKey, tokenProgram: PublicKey;
+
+  // Re-used between tests to simplify props.
+  type DepositAccounts = {
+    state: PublicKey;
+    route: PublicKey;
+    signer: PublicKey;
+    depositorTokenAccount: PublicKey;
+    vault: PublicKey;
+    mint: PublicKey;
+    tokenProgram: PublicKey;
+    program: PublicKey;
+  };
+  let depositAccounts: DepositAccounts;
+
   let setEnableRouteAccounts: any; // Common variable for setEnableRoute accounts
 
   const setupInputToken = async () => {
-    inputToken = await createMint(connection, payer, owner, owner, 6);
+    inputToken = await createMint(connection, payer, owner, owner, tokenDecimals, undefined, undefined, tokenProgram);
 
-    depositorTA = (await getOrCreateAssociatedTokenAccount(connection, payer, inputToken, depositor.publicKey)).address;
-    await mintTo(connection, payer, inputToken, depositorTA, owner, seedBalance);
+    depositorTA = (
+      await getOrCreateAssociatedTokenAccount(
+        connection,
+        payer,
+        inputToken,
+        depositor.publicKey,
+        undefined,
+        undefined,
+        undefined,
+        tokenProgram
+      )
+    ).address;
+    await mintTo(connection, payer, inputToken, depositorTA, owner, seedBalance, undefined, undefined, tokenProgram);
   };
 
   const enableRoute = async () => {
     const routeChainId = new BN(1);
     const route = createRoutePda(inputToken, state, routeChainId);
-    vault = getVaultAta(inputToken, state);
+    vault = await getVaultAta(inputToken, state);
 
     setEnableRouteAccounts = {
       signer: owner,
@@ -43,7 +74,7 @@ describe("svm_spoke.deposit", () => {
       route,
       vault,
       originTokenMint: inputToken, // Note the Sol expects this to be named originTokenMint.
-      tokenProgram: TOKEN_PROGRAM_ID,
+      tokenProgram: tokenProgram ?? TOKEN_PROGRAM_ID,
       associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
       systemProgram: anchor.web3.SystemProgram.programId,
     };
@@ -61,16 +92,39 @@ describe("svm_spoke.deposit", () => {
       depositorTokenAccount: depositorTA,
       vault,
       mint: inputToken,
-      tokenProgram: TOKEN_PROGRAM_ID,
+      tokenProgram: tokenProgram ?? TOKEN_PROGRAM_ID,
+      program: program.programId,
     };
   };
 
-  before("Creates token mint and associated token accounts", async () => {
-    await setupInputToken();
-  });
+  const approvedDepositV3 = async (
+    depositDataValues: DepositDataValues,
+    calledDepositAccounts: DepositAccounts = depositAccounts
+  ) => {
+    // Delegate state PDA to pull depositor tokens.
+    const approveIx = await createApproveCheckedInstruction(
+      calledDepositAccounts.depositorTokenAccount,
+      calledDepositAccounts.mint,
+      calledDepositAccounts.state,
+      depositor.publicKey,
+      BigInt(depositData.inputAmount.toString()),
+      tokenDecimals,
+      undefined,
+      tokenProgram
+    );
+    const depositIx = await program.methods
+      .depositV3(...depositDataValues)
+      .accounts(calledDepositAccounts)
+      .instruction();
+    const depositTx = new Transaction().add(approveIx, depositIx);
+    await sendAndConfirmTransaction(connection, depositTx, [payer, depositor]);
+  };
 
   beforeEach(async () => {
     state = await initializeState();
+
+    tokenProgram = TOKEN_PROGRAM_ID; // Some tests might override this.
+    await setupInputToken();
 
     await enableRoute();
   });
@@ -81,11 +135,7 @@ describe("svm_spoke.deposit", () => {
 
     // Execute the deposit_v3 call
     let depositDataValues = Object.values(depositData) as DepositDataValues;
-    await program.methods
-      .depositV3(...depositDataValues)
-      .accounts(depositAccounts)
-      .signers([depositor])
-      .rpc();
+    await approvedDepositV3(depositDataValues);
 
     // Verify tokens leave the depositor's account
     let depositorAccount = await getAccount(connection, depositorTA);
@@ -105,11 +155,7 @@ describe("svm_spoke.deposit", () => {
     // Execute the second deposit_v3 call
 
     depositDataValues = Object.values({ ...depositData, inputAmount: secondInputAmount }) as DepositDataValues;
-    await program.methods
-      .depositV3(...depositDataValues)
-      .accounts(depositAccounts)
-      .signers([depositor])
-      .rpc();
+    await approvedDepositV3(depositDataValues);
 
     // Verify tokens leave the depositor's account again
     depositorAccount = await getAccount(connection, depositorTA);
@@ -133,11 +179,7 @@ describe("svm_spoke.deposit", () => {
 
     // Execute the first deposit_v3 call
     let depositDataValues = Object.values(depositData) as DepositDataValues;
-    await program.methods
-      .depositV3(...depositDataValues)
-      .accounts(depositAccounts)
-      .signers([depositor])
-      .rpc();
+    await approvedDepositV3(depositDataValues);
     await new Promise((resolve) => setTimeout(resolve, 500));
 
     // Fetch and verify the depositEvent
@@ -155,11 +197,7 @@ describe("svm_spoke.deposit", () => {
     }
 
     // Execute the second deposit_v3 call
-    await program.methods
-      .depositV3(...depositDataValues)
-      .accounts(depositAccounts)
-      .signers([depositor])
-      .rpc();
+    await approvedDepositV3(depositDataValues);
     await new Promise((resolve) => setTimeout(resolve, 500));
 
     // Fetch and verify the depositEvent for the second deposit
@@ -185,11 +223,7 @@ describe("svm_spoke.deposit", () => {
         ...depositData,
         destinationChainId: differentChainId,
       }) as DepositDataValues;
-      await program.methods
-        .depositV3(...depositDataValues)
-        .accounts(depositAccounts)
-        .signers([depositor])
-        .rpc();
+      await approvedDepositV3(depositDataValues);
       assert.fail("Deposit should have failed for a route that is not initialized");
     } catch (err: any) {
       assert.include(err.toString(), "AccountNotInitialized", "Expected AccountNotInitialized error");
@@ -205,11 +239,7 @@ describe("svm_spoke.deposit", () => {
 
     try {
       const depositDataValues = Object.values(depositData) as DepositDataValues;
-      await program.methods
-        .depositV3(...depositDataValues)
-        .accounts(depositAccounts)
-        .signers([depositor])
-        .rpc();
+      await approvedDepositV3(depositDataValues);
       assert.fail("Deposit should have failed for a route that is explicitly disabled");
     } catch (err: any) {
       assert.include(err.toString(), "DisabledRoute", "Expected DisabledRoute error");
@@ -226,15 +256,10 @@ describe("svm_spoke.deposit", () => {
     // Try to deposit. This should fail because deposits are paused.
     try {
       const depositDataValues = Object.values(depositData) as DepositDataValues;
-      await program.methods
-        .depositV3(...depositDataValues)
-        .accounts(depositAccounts)
-        .signers([depositor])
-        .rpc();
+      await approvedDepositV3(depositDataValues);
       assert.fail("Should not be able to process deposit when deposits are paused");
     } catch (err: any) {
-      assert.instanceOf(err, anchor.AnchorError);
-      assert.strictEqual(err.error.errorCode.code, "DepositsArePaused", "Expected error code DepositsArePaused");
+      assert.include(err.toString(), "Error Code: DepositsArePaused", "Expected DepositsArePaused error");
     }
   });
 
@@ -246,11 +271,7 @@ describe("svm_spoke.deposit", () => {
 
     try {
       const depositDataValues = Object.values(depositData) as DepositDataValues;
-      await program.methods
-        .depositV3(...depositDataValues)
-        .accounts(depositAccounts)
-        .signers([depositor])
-        .rpc();
+      await approvedDepositV3(depositDataValues);
       assert.fail("Deposit should have failed due to InvalidQuoteTimestamp");
     } catch (err: any) {
       assert.include(err.toString(), "Error Code: InvalidQuoteTimestamp", "Expected InvalidQuoteTimestamp error");
@@ -265,11 +286,7 @@ describe("svm_spoke.deposit", () => {
 
     try {
       const depositDataValues = Object.values(depositData) as DepositDataValues;
-      await program.methods
-        .depositV3(...depositDataValues)
-        .accounts(depositAccounts)
-        .signers([depositor])
-        .rpc();
+      await approvedDepositV3(depositDataValues);
       assert.fail("Deposit should have failed due to InvalidQuoteTimestamp");
     } catch (err: any) {
       assert.include(err.toString(), "Error Code: InvalidQuoteTimestamp", "Expected InvalidQuoteTimestamp error");
@@ -286,11 +303,7 @@ describe("svm_spoke.deposit", () => {
 
     try {
       const depositDataValues = Object.values(depositData) as DepositDataValues;
-      await program.methods
-        .depositV3(...depositDataValues)
-        .accounts(depositAccounts)
-        .signers([depositor])
-        .rpc();
+      await approvedDepositV3(depositDataValues);
       assert.fail("Deposit should have failed due to InvalidFillDeadline (past deadline)");
     } catch (err: any) {
       assert.include(err.toString(), "InvalidFillDeadline", "Expected InvalidFillDeadline error for past deadline");
@@ -302,11 +315,7 @@ describe("svm_spoke.deposit", () => {
 
     try {
       const depositDataValues = Object.values(depositData) as DepositDataValues;
-      await program.methods
-        .depositV3(...depositDataValues)
-        .accounts(depositAccounts)
-        .signers([depositor])
-        .rpc();
+      await approvedDepositV3(depositDataValues);
       assert.fail("Deposit should have failed due to InvalidFillDeadline (future deadline)");
     } catch (err: any) {
       assert.include(err.toString(), "InvalidFillDeadline", "Expected InvalidFillDeadline error for future deadline");
@@ -327,22 +336,17 @@ describe("svm_spoke.deposit", () => {
     const malformedDepositAccounts = { ...depositAccounts, route: firstDepositAccounts.route };
     try {
       const depositDataValues = Object.values(malformedDepositData) as DepositDataValues;
-      await program.methods
-        .depositV3(...depositDataValues)
-        .accounts(malformedDepositAccounts)
-        .signers([depositor])
-        .rpc();
+      await approvedDepositV3(depositDataValues, malformedDepositAccounts);
       assert.fail("Should not be able to process deposit for inconsistent mint");
     } catch (err: any) {
-      assert.instanceOf(err, anchor.AnchorError);
-      assert.strictEqual(err.error.errorCode.code, "InvalidMint", "Expected error code InvalidMint");
+      assert.include(err.toString(), "Error Code: InvalidMint", "Expected InvalidMint error");
     }
   });
 
   it("Tests deposit with a fake route PDA", async () => {
     // Create fake program state
     const fakeState = await initializeState();
-    const fakeVault = getVaultAta(inputToken, fakeState);
+    const fakeVault = await getVaultAta(inputToken, fakeState);
 
     const fakeRouteChainId = new BN(3);
     const fakeRoutePda = createRoutePda(inputToken, fakeState, fakeRouteChainId);
@@ -381,11 +385,7 @@ describe("svm_spoke.deposit", () => {
       ...depositData,
       destinationChainId: fakeRouteChainId,
     }) as DepositDataValues;
-    await program.methods
-      .depositV3(...depositDataValues)
-      .accounts(fakeDepositAccounts)
-      .signers([depositor])
-      .rpc();
+    await approvedDepositV3(depositDataValues, fakeDepositAccounts);
 
     await new Promise((resolve) => setTimeout(resolve, 500));
 
@@ -411,11 +411,7 @@ describe("svm_spoke.deposit", () => {
       const depositDataValues = Object.values({
         ...{ ...depositData, destinationChainId: fakeRouteChainId },
       }) as DepositDataValues;
-      await program.methods
-        .depositV3(...depositDataValues)
-        .accounts({ ...depositAccounts, route: fakeRoutePda })
-        .signers([depositor])
-        .rpc();
+      await approvedDepositV3(depositDataValues, { ...depositAccounts, route: fakeRoutePda });
       assert.fail("Deposit should have failed for a fake route PDA");
     } catch (err: any) {
       assert.include(err.toString(), "A seeds constraint was violated");
@@ -432,9 +428,20 @@ describe("svm_spoke.deposit", () => {
     // Equally, depositV3Now does not have `quoteTimestamp`. this is set to the current time from the program.
     const fillDeadlineOffset = 60; // 60 seconds offset
 
-    // Execute the deposit_v3_now call. Remove the quoteTimestamp from the depositData as not needed for this method.
+    // Delegate state PDA to pull depositor tokens.
+    const approveIx = await createApproveCheckedInstruction(
+      depositAccounts.depositorTokenAccount,
+      depositAccounts.mint,
+      depositAccounts.state,
+      depositor.publicKey,
+      BigInt(depositData.inputAmount.toString()),
+      tokenDecimals,
+      undefined,
+      tokenProgram
+    );
 
-    await program.methods
+    // Execute the deposit_v3_now call. Remove the quoteTimestamp from the depositData as not needed for this method.
+    const depositIx = await program.methods
       .depositV3Now(
         depositData.depositor!,
         depositData.recipient!,
@@ -449,8 +456,9 @@ describe("svm_spoke.deposit", () => {
         depositData.message
       )
       .accounts(depositAccounts)
-      .signers([depositor])
-      .rpc();
+      .instruction();
+    const depositTx = new Transaction().add(approveIx, depositIx);
+    await sendAndConfirmTransaction(connection, depositTx, [payer, depositor]);
 
     await new Promise((resolve) => setTimeout(resolve, 500));
 
@@ -472,5 +480,39 @@ describe("svm_spoke.deposit", () => {
     for (const [key, value] of Object.entries(expectedValues)) {
       assertSE(event[key], value, `${key} should match`);
     }
+  });
+
+  it("Deposit with enabled CPI-guard", async () => {
+    // CPI-guard is available only for the 2022 token program.
+    tokenProgram = TOKEN_2022_PROGRAM_ID;
+    await setupInputToken();
+    await enableRoute();
+
+    // Enable CPI-guard for the depositor (requires TA reallocation).
+    const enableCpiGuardTx = new Transaction().add(
+      createReallocateInstruction(depositorTA, payer.publicKey, [ExtensionType.CpiGuard], depositor.publicKey),
+      createEnableCpiGuardInstruction(depositorTA, depositor.publicKey)
+    );
+    await sendAndConfirmTransaction(connection, enableCpiGuardTx, [payer, depositor]);
+
+    // Verify vault balance is zero before the deposit
+    let vaultAccount = await getAccount(connection, vault, undefined, tokenProgram);
+    assertSE(vaultAccount.amount, "0", "Vault balance should be zero before the deposit");
+
+    // Execute the deposit_v3 call
+    const depositDataValues = Object.values(depositData) as DepositDataValues;
+    await approvedDepositV3(depositDataValues);
+
+    // Verify tokens leave the depositor's account
+    const depositorAccount = await getAccount(connection, depositorTA, undefined, tokenProgram);
+    assertSE(
+      depositorAccount.amount,
+      seedBalance - depositData.inputAmount.toNumber(),
+      "Depositor's balance should be reduced by the deposited amount"
+    );
+
+    // Verify tokens are credited into the vault
+    vaultAccount = await getAccount(connection, vault, undefined, tokenProgram);
+    assertSE(vaultAccount.amount, depositData.inputAmount, "Vault balance should be increased by the deposited amount");
   });
 });

--- a/test/svm/SvmSpoke.HandleReceiveMessage.ts
+++ b/test/svm/SvmSpoke.HandleReceiveMessage.ts
@@ -314,7 +314,7 @@ describe("svm_spoke.handle_receive_message", () => {
 
     // Remaining accounts specific to SetEnableRoute.
     const routePda = createRoutePda(originToken, state, new BN(routeChainId));
-    const vault = getVaultAta(originToken, state);
+    const vault = await getVaultAta(originToken, state);
     // Same 3 remaining accounts passed for HandleReceiveMessage context.
     const enableRouteRemainingAccounts = remainingAccounts.slice(0, 3);
     // payer in self-invoked SetEnableRoute.

--- a/test/svm/SvmSpoke.Routes.ts
+++ b/test/svm/SvmSpoke.Routes.ts
@@ -25,7 +25,7 @@ describe("svm_spoke.routes", () => {
     routePda = createRoutePda(tokenMint, state, routeChainId);
 
     // Create ATA for the origin token to be stored by state (vault).
-    vault = getVaultAta(tokenMint, state);
+    vault = await getVaultAta(tokenMint, state);
 
     // Common accounts object
     setEnableRouteAccounts = {

--- a/test/svm/SvmSpoke.SlowFill.ts
+++ b/test/svm/SvmSpoke.SlowFill.ts
@@ -7,8 +7,9 @@ import {
   createMint,
   getOrCreateAssociatedTokenAccount,
   mintTo,
+  createApproveCheckedInstruction,
 } from "@solana/spl-token";
-import { PublicKey, Keypair } from "@solana/web3.js";
+import { PublicKey, Keypair, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
 import { common } from "./SvmSpoke.common";
 import { MerkleTree } from "@uma/common/dist/MerkleTree";
 import { slowFillHashFn, SlowFillLeaf, readProgramEvents, calculateRelayHashUint8Array } from "./utils";
@@ -30,6 +31,7 @@ describe("svm_spoke.slow_fill", () => {
   const payer = (anchor.AnchorProvider.env().wallet as anchor.Wallet).payer;
   const relayer = Keypair.generate();
   const otherRelayer = Keypair.generate();
+  const tokenDecimals = 6;
 
   let state: PublicKey,
     mint: PublicKey,
@@ -131,7 +133,7 @@ describe("svm_spoke.slow_fill", () => {
   };
 
   before("Creates token mint and associated token accounts", async () => {
-    mint = await createMint(connection, payer, owner, owner, 6);
+    mint = await createMint(connection, payer, owner, owner, tokenDecimals);
     relayerTA = (await getOrCreateAssociatedTokenAccount(connection, payer, mint, relayer.publicKey)).address;
     otherRelayerTA = (await getOrCreateAssociatedTokenAccount(connection, payer, mint, otherRelayer.publicKey)).address;
 
@@ -218,11 +220,21 @@ describe("svm_spoke.slow_fill", () => {
     const relayHash = Array.from(calculateRelayHashUint8Array(relayData, chainId));
 
     // Fill the relay first
-    await program.methods
+    const approveIx = await createApproveCheckedInstruction(
+      fillAccounts.relayerTokenAccount,
+      fillAccounts.mintAccount,
+      fillAccounts.state,
+      fillAccounts.signer,
+      BigInt(relayData.outputAmount.toString()),
+      tokenDecimals
+    );
+    const fillIx = await program.methods
       .fillV3Relay(relayHash, formatRelayData(relayData), new BN(1), relayer.publicKey)
       .accounts(fillAccounts)
       .signers([relayer])
-      .rpc();
+      .instruction();
+    const fillTx = new Transaction().add(approveIx, fillIx);
+    await sendAndConfirmTransaction(connection, fillTx, [relayer]);
 
     try {
       await program.methods
@@ -540,7 +552,7 @@ describe("svm_spoke.slow_fill", () => {
       .rpc();
 
     // Create and fund new accounts as derived from wrong mint account.
-    const wrongMint = await createMint(connection, payer, owner, owner, 6);
+    const wrongMint = await createMint(connection, payer, owner, owner, tokenDecimals);
     const wrongRecipientTA = (await getOrCreateAssociatedTokenAccount(connection, payer, wrongMint, recipient)).address;
     const wrongVault = (await getOrCreateAssociatedTokenAccount(connection, payer, wrongMint, state, true)).address;
     await mintTo(connection, payer, wrongMint, wrongVault, provider.publicKey, initialMintAmount);

--- a/test/svm/SvmSpoke.common.ts
+++ b/test/svm/SvmSpoke.common.ts
@@ -129,6 +129,23 @@ export type DepositDataValues = [
   Buffer
 ];
 
+export type RelayData = {
+  depositor: PublicKey;
+  recipient: PublicKey;
+  exclusiveRelayer: PublicKey;
+  inputToken: PublicKey;
+  outputToken: PublicKey;
+  inputAmount: BN;
+  outputAmount: BN;
+  originChainId: BN;
+  depositId: number;
+  fillDeadline: number;
+  exclusivityDeadline: number;
+  message: Buffer;
+};
+
+export type FillDataValues = [number[], RelayData, BN, PublicKey];
+
 export const common = {
   provider,
   connection: provider.connection,

--- a/test/svm/SvmSpoke.common.ts
+++ b/test/svm/SvmSpoke.common.ts
@@ -76,8 +76,10 @@ const createRoutePda = (originToken: PublicKey, state: PublicKey, routeChainId: 
   )[0];
 };
 
-const getVaultAta = (tokenMint: PublicKey, state: PublicKey) => {
-  return getAssociatedTokenAddressSync(tokenMint, state, true, TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID);
+const getVaultAta = async (tokenMint: PublicKey, state: PublicKey) => {
+  const tokenMintAccount = await provider.connection.getAccountInfo(tokenMint);
+  if (tokenMintAccount === null) throw new Error("Token Mint account not found");
+  return getAssociatedTokenAddressSync(tokenMint, state, true, tokenMintAccount.owner, ASSOCIATED_TOKEN_PROGRAM_ID);
 };
 
 async function setCurrentTime(program: Program<SvmSpoke>, state: any, signer: anchor.web3.Keypair, newTime: BN) {


### PR DESCRIPTION
Clients might have enabled [CPI-guards](https://spl.solana.com/token-2022/extensions#cpi-guard) that would prohibit transfers within CPI (e.g. deposits, fills). To support this, we need to transfer all user tokens with spoke pool authority, assuming the client has delegated exact deposit/fill amount.

Fixes: https://linear.app/uma/issue/ACX-3351/use-delegated-transfers-in-svm-spoke