### PR TITLE
fix(svm): use borch serializer

### DIFF
--- a/test/svm/SvmSpoke.SlowFill.ts
+++ b/test/svm/SvmSpoke.SlowFill.ts
@@ -9,7 +9,7 @@ import {
   mintTo,
   createApproveCheckedInstruction,
 } from "@solana/spl-token";
-import { PublicKey, Keypair, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
+import { PublicKey, Keypair, Transaction, sendAndConfirmTransaction, ComputeBudgetProgram } from "@solana/web3.js";
 import { common } from "./SvmSpoke.common";
 import { MerkleTree } from "@uma/common/dist/MerkleTree";
 import {
@@ -372,7 +372,7 @@ describe("svm_spoke.slow_fill", () => {
       .rpc();
 
     // Execute V3 slow relay leaf after requesting slow fill
-    await program.methods
+    const ix = await program.methods
       .executeV3SlowRelayLeaf(
         Array.from(relayHash),
         { ...leaf, relayData: formatRelayData(relayData) },
@@ -381,7 +381,9 @@ describe("svm_spoke.slow_fill", () => {
       )
       .accounts(executeSlowRelayLeafAccounts)
       .remainingAccounts(fillRemainingAccounts)
-      .rpc();
+      .instruction();
+    const computeBudgetInstruction = ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 });
+    await sendAndConfirmTransaction(connection, new Transaction().add(computeBudgetInstruction, ix), [payer]);
 
     // Verify the results
     const fVaultBal = (await connection.getTokenAccountBalance(vault)).value.amount;

--- a/test/svm/utils.ts
+++ b/test/svm/utils.ts
@@ -164,14 +164,17 @@ export function calculateRelayerRefundLeafHashUint8Array(relayData: RelayerRefun
 
   const refundAddressesBuffer = Buffer.concat(relayData.refundAddresses.map((address) => address.toBuffer()));
 
+  // TODO: We better consider reusing Borch serializer in production.
   const contentToHash = Buffer.concat([
     // SVM leaves require the first 64 bytes to be 0 to ensure EVM leaves can never be played on SVM and vice versa.
     Buffer.alloc(64, 0),
     relayData.amountToReturn.toArrayLike(Buffer, "le", 8),
     relayData.chainId.toArrayLike(Buffer, "le", 8),
+    new BN(relayData.refundAmounts.length).toArrayLike(Buffer, "le", 4),
     refundAmountsBuffer,
     relayData.leafId.toArrayLike(Buffer, "le", 4),
     relayData.mintPublicKey.toBuffer(),
+    new BN(relayData.refundAddresses.length).toArrayLike(Buffer, "le", 4),
     refundAddressesBuffer,
   ]);
 
@@ -222,6 +225,7 @@ export interface SlowFillLeaf {
   updatedOutputAmount: BN;
 }
 
+// TODO: We better consider reusing Borch serializer in production.
 export function slowFillHashFn(slowFillLeaf: SlowFillLeaf): string {
   const contentToHash = Buffer.concat([
     // SVM leaves require the first 64 bytes to be 0 to ensure EVM leaves can never be played on SVM and vice versa.
@@ -237,6 +241,7 @@ export function slowFillHashFn(slowFillLeaf: SlowFillLeaf): string {
     slowFillLeaf.relayData.depositId.toArrayLike(Buffer, "le", 4),
     slowFillLeaf.relayData.fillDeadline.toArrayLike(Buffer, "le", 4),
     slowFillLeaf.relayData.exclusivityDeadline.toArrayLike(Buffer, "le", 4),
+    new BN(slowFillLeaf.relayData.message.length).toArrayLike(Buffer, "le", 4),
     slowFillLeaf.relayData.message,
     slowFillLeaf.chainId.toArrayLike(Buffer, "le", 8),
     slowFillLeaf.updatedOutputAmount.toArrayLike(Buffer, "le", 8),


### PR DESCRIPTION
We had custom serialization implementation when hashing relayer refund and slow fill leaves. This just concatenated array elements without encoding array length. This PR fixes by using Anchor's borch serializer that encodes this more consistently. 