### PR TITLE
fix: hash message hash in relay hash

### DIFF
--- a/programs/svm-spoke/src/instructions/fill.rs
+++ b/programs/svm-spoke/src/instructions/fill.rs
@@ -201,6 +201,7 @@ pub struct CloseFillPda<'info> {
     #[account(seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]
     pub state: Account<'info, State>,
 
+    // No need to check seed derivation as this method only evaluates fill deadline that is recorded in this account.
     #[account(mut, close = signer)]
     pub fill_status: Account<'info, FillStatusAccount>,
 }

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -68,6 +68,7 @@ pub fn request_v3_slow_fill(ctx: Context<RequestV3SlowFill>, relay_data: Option<
 
     fill_status_account.status = FillStatus::RequestedSlowFill; // Update the fill status to RequestedSlowFill
     fill_status_account.relayer = ctx.accounts.signer.key();
+    fill_status_account.fill_deadline = relay_data.fill_deadline;
 
     // Emit the RequestedV3SlowFill event. Empty message is not hashed and emits zeroed bytes32 for easier observability
     let message_hash = hash_non_empty_message(&relay_data.message);
@@ -254,7 +255,8 @@ pub fn execute_v3_slow_relay_leaf<'info>(
         CpiContext::new_with_signer(ctx.accounts.token_program.to_account_info(), transfer_accounts, signer_seeds);
     transfer_checked(cpi_context, slow_fill_leaf.updated_output_amount, ctx.accounts.mint.decimals)?;
 
-    // Update the fill status to Filled. Note we don't set the relayer here as it is set when the slow fill was requested.
+    // Update the fill status to Filled. Note we don't set the relayer and fill deadline here as it is set when the slow
+    // fill was requested.
     fill_status_account.status = FillStatus::Filled;
 
     if !relay_data.message.is_empty() {

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -255,8 +255,7 @@ pub fn execute_v3_slow_relay_leaf<'info>(
         CpiContext::new_with_signer(ctx.accounts.token_program.to_account_info(), transfer_accounts, signer_seeds);
     transfer_checked(cpi_context, slow_fill_leaf.updated_output_amount, ctx.accounts.mint.decimals)?;
 
-    // Update the fill status to Filled. Note we don't set the relayer and fill deadline here as it is set when the slow
-    // fill was requested.
+    // Update the fill status. We don't set the relayer and fill deadline as it is set when the slow fill was requested.
     fill_status_account.status = FillStatus::Filled;
 
     if !relay_data.message.is_empty() {

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -439,13 +439,9 @@ pub mod svm_spoke {
     /// ### Required Accounts:
     /// - signer (Signer): The account that authorizes the closure. Must be the relayer in the fill_status PDA.
     /// - state (Writable): Spoke state PDA. Seed: ["state",state.seed] where seed is 0 on mainnet.
-    /// - fill_status (Writable): The FillStatusAccount PDA to be closed. Seed: ["fills",relay_hash].
-    ///
-    /// ### Parameters:
-    /// - _relay_hash: The hash identifying the relay for which the fill status account is being closed.
-    /// - relay_data: The data structure containing information about the relay.
-    pub fn close_fill_pda(ctx: Context<CloseFillPda>, _relay_hash: [u8; 32], relay_data: V3RelayData) -> Result<()> {
-        instructions::close_fill_pda(ctx, relay_data)
+    /// - fill_status (Writable): The FillStatusAccount PDA to be closed.
+    pub fn close_fill_pda(ctx: Context<CloseFillPda>) -> Result<()> {
+        instructions::close_fill_pda(ctx)
     }
 
     /// Claims a relayer refund for the caller.

--- a/programs/svm-spoke/src/state/fill.rs
+++ b/programs/svm-spoke/src/state/fill.rs
@@ -12,4 +12,5 @@ pub enum FillStatus {
 pub struct FillStatusAccount {
     pub status: FillStatus, // Tracks the status of the fill between Unfilled, requestedSlowFill, and Filled.
     pub relayer: Pubkey,    // Address of the relayer that made the fill to control who can close this PDA.
+    pub fill_deadline: u32, // Stores the fill deadline to control when this PDA can be safely closed.
 }

--- a/programs/svm-spoke/src/utils/merkle_proof_utils.rs
+++ b/programs/svm-spoke/src/utils/merkle_proof_utils.rs
@@ -5,7 +5,10 @@ use crate::{common::V3RelayData, error::CommonError, utils::hash_non_empty_messa
 pub fn get_v3_relay_hash(relay_data: &V3RelayData, chain_id: u64) -> [u8; 32] {
     let mut input = relay_data.try_to_vec().unwrap();
 
-    // Trim off the serialized message (4 bytes length + message bytes) as it is replaced with the hash.
+    // We have serialized the original V3RelayData struct above, but we need to replace the message field with its hash,
+    // so that relay hash can be reconstructed only from FilledV3Relay event that does not contain the original message
+    // but its hash. Trimming off the serialized message (4 bytes length + message bytes) and appending its hash turns
+    // out to be less compute intensive than serializing individual struct fields.
     input.truncate(input.len() - 4 - relay_data.message.len());
     input.extend_from_slice(&hash_non_empty_message(&relay_data.message));
 

--- a/test/svm/SvmSpoke.Bundle.ts
+++ b/test/svm/SvmSpoke.Bundle.ts
@@ -191,7 +191,7 @@ describe("svm_spoke.bundle", () => {
 
     // Check for the emitted event
     const events = await readEvents(connection, tx, [program]);
-    const event = events.find((event) => event.name === "relayedRootBundle").data;
+    const event = events.find((event) => event.name === "relayedRootBundle")?.data;
     assert.isTrue(event.rootBundleId.toString() === rootBundleId.toString(), "Root bundle ID should match");
     assert.isTrue(
       event.relayerRefundRoot.toString() === relayerRefundRootArray.toString(),
@@ -264,7 +264,7 @@ describe("svm_spoke.bundle", () => {
     // Verify the ExecutedRelayerRefundRoot event
     await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for event processing
     let events = await readProgramEvents(connection, program);
-    let event = events.find((event) => event.name === "executedRelayerRefundRoot").data;
+    let event = events.find((event) => event.name === "executedRelayerRefundRoot")?.data;
 
     // Remove the expectedValues object and use direct assertions
     assertSE(event.amountToReturn, relayerRefundLeaves[0].amountToReturn, "amountToReturn should match");
@@ -1480,7 +1480,7 @@ describe("svm_spoke.bundle", () => {
 
       await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for event processing
       const events = await readEvents(connection, tx, [program]);
-      const event = events.find((event) => event.name === "executedRelayerRefundRoot").data;
+      const event = events.find((event) => event.name === "executedRelayerRefundRoot")?.data;
       assert.isFalse(event.deferredRefunds, "deferredRefunds should be false");
     });
 
@@ -1489,7 +1489,7 @@ describe("svm_spoke.bundle", () => {
 
       await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for event processing
       const events = await readEvents(connection, tx, [program]);
-      const event = events.find((event) => event.name === "executedRelayerRefundRoot").data;
+      const event = events.find((event) => event.name === "executedRelayerRefundRoot")?.data;
       assert.isTrue(event.deferredRefunds, "deferredRefunds should be true");
     });
   });

--- a/test/svm/SvmSpoke.Fill.ts
+++ b/test/svm/SvmSpoke.Fill.ts
@@ -182,7 +182,7 @@ describe("svm_spoke.fill", () => {
     // Fetch and verify the FilledV3Relay event
     await new Promise((resolve) => setTimeout(resolve, 500));
     const events = await readProgramEvents(connection, program);
-    const event = events.find((event) => event.name === "filledV3Relay").data;
+    const event = events.find((event) => event.name === "filledV3Relay")?.data;
     assert.isNotNull(event, "FilledV3Relay event should be emitted");
 
     // Verify that the event data matches the relay data.
@@ -660,7 +660,7 @@ describe("svm_spoke.fill", () => {
     // Fetch and verify the FilledV3Relay event
     await new Promise((resolve) => setTimeout(resolve, 500));
     const events = await readProgramEvents(connection, program);
-    const event = events.find((event) => event.name === "filledV3Relay").data;
+    const event = events.find((event) => event.name === "filledV3Relay")?.data;
     assert.isNotNull(event, "FilledV3Relay event should be emitted");
 
     // Verify that the event data has zeroed message hash.

--- a/test/svm/SvmSpoke.Fill.ts
+++ b/test/svm/SvmSpoke.Fill.ts
@@ -16,10 +16,15 @@ import {
   ExtensionType,
 } from "@solana/spl-token";
 import { PublicKey, Keypair, TransactionInstruction, sendAndConfirmTransaction, Transaction } from "@solana/web3.js";
-import { readProgramEvents, calculateRelayHashUint8Array, sendTransactionWithLookupTable } from "../../src/SvmUtils";
+import {
+  readProgramEvents,
+  calculateRelayHashUint8Array,
+  sendTransactionWithLookupTable,
+  hashNonEmptyMessage,
+} from "../../src/SvmUtils";
 import { intToU8Array32 } from "./utils";
 import { common, RelayData, FillDataValues } from "./SvmSpoke.common";
-import { testAcrossPlusMessage, hashNonEmptyMessage } from "./utils";
+import { testAcrossPlusMessage } from "./utils";
 const { provider, connection, program, owner, chainId, seedBalance } = common;
 const { recipient, initializeState, setCurrentTime, assertSE, assert } = common;
 
@@ -288,7 +293,7 @@ describe("svm_spoke.fill", () => {
 
     // Attempt to close the fill PDA before the fill deadline should fail.
     try {
-      await program.methods.closeFillPda(relayHash, relayData).accounts(closeFillPdaAccounts).signers([relayer]).rpc();
+      await program.methods.closeFillPda().accounts(closeFillPdaAccounts).signers([relayer]).rpc();
       assert.fail("Closing fill PDA should have failed before fill deadline");
     } catch (err: any) {
       assert.include(
@@ -302,7 +307,7 @@ describe("svm_spoke.fill", () => {
     await setCurrentTime(program, state, relayer, new BN(relayData.fillDeadline + 1));
 
     // Close the fill PDA
-    await program.methods.closeFillPda(relayHash, relayData).accounts(closeFillPdaAccounts).signers([relayer]).rpc();
+    await program.methods.closeFillPda().accounts(closeFillPdaAccounts).signers([relayer]).rpc();
 
     // Verify the fill PDA is closed
     const fillStatusAccountAfter = await connection.getAccountInfo(accounts.fillStatus);

--- a/test/svm/SvmSpoke.RefundClaims.ts
+++ b/test/svm/SvmSpoke.RefundClaims.ts
@@ -185,7 +185,7 @@ describe("svm_spoke.refund_claims", () => {
     // Verify the ClaimedRelayerRefund event
     await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for event processing
     const events = await readProgramEvents(connection, program);
-    const event = events.find((event) => event.name === "claimedRelayerRefund").data;
+    const event = events.find((event) => event.name === "claimedRelayerRefund")?.data;
     assertSE(event.l2TokenAddress, mint, "l2TokenAddress should match");
     assertSE(event.claimAmount, relayerRefund, "Relayer refund amount should match");
     assertSE(event.refundAddress, relayer.publicKey, "Relayer refund address should match");
@@ -381,7 +381,7 @@ describe("svm_spoke.refund_claims", () => {
     // Verify the ClaimedRelayerRefund event
     await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for event processing
     const events = await readProgramEvents(connection, program);
-    const event = events.find((event) => event.name === "claimedRelayerRefund").data;
+    const event = events.find((event) => event.name === "claimedRelayerRefund")?.data;
     assertSE(event.l2TokenAddress, mint, "l2TokenAddress should match");
     assertSE(event.claimAmount, relayerRefund, "Relayer refund amount should match");
     assertSE(event.refundAddress, relayer.publicKey, "Relayer refund address should match");

--- a/test/svm/SvmSpoke.SlowFill.ts
+++ b/test/svm/SvmSpoke.SlowFill.ts
@@ -19,8 +19,8 @@ import {
   readProgramEvents,
   calculateRelayHashUint8Array,
   testAcrossPlusMessage,
-  hashNonEmptyMessage,
 } from "./utils";
+import { hashNonEmptyMessage } from "../../src/SvmUtils";
 
 const { provider, connection, program, owner, chainId, seedBalance, initializeState } = common;
 const { recipient, setCurrentTime, assertSE, assert } = common;

--- a/test/svm/SvmSpoke.SlowFill.ts
+++ b/test/svm/SvmSpoke.SlowFill.ts
@@ -202,7 +202,7 @@ describe("svm_spoke.slow_fill", () => {
     // Fetch and verify the RequestedV3SlowFill event
     await new Promise((resolve) => setTimeout(resolve, 500));
     const events = await readProgramEvents(connection, program);
-    const event = events.find((event) => event.name === "requestedV3SlowFill").data;
+    const event = events.find((event) => event.name === "requestedV3SlowFill")?.data;
     assert.isNotNull(event, "RequestedV3SlowFill event should be emitted");
 
     // Verify that the event data matches the relay data.
@@ -373,7 +373,7 @@ describe("svm_spoke.slow_fill", () => {
     // Fetch and verify the FilledV3Relay event
     await new Promise((resolve) => setTimeout(resolve, 500));
     const events = await readProgramEvents(connection, program);
-    const event = events.find((event) => event.name === "filledV3Relay").data;
+    const event = events.find((event) => event.name === "filledV3Relay")?.data;
     assert.isNotNull(event, "FilledV3Relay event should be emitted");
 
     // Verify that the event data matches the relay data.
@@ -660,8 +660,8 @@ describe("svm_spoke.slow_fill", () => {
     // Fetch and verify message hash in the RequestedV3SlowFill and FilledV3Relay events
     await new Promise((resolve) => setTimeout(resolve, 500));
     const events = await readProgramEvents(connection, program);
-    const requestEvent = events.find((event) => event.name === "requestedV3SlowFill").data;
-    const fillEvent = events.find((event) => event.name === "filledV3Relay").data;
+    const requestEvent = events.find((event) => event.name === "requestedV3SlowFill")?.data;
+    const fillEvent = events.find((event) => event.name === "filledV3Relay")?.data;
     assert.isNotNull(requestEvent, "RequestedV3SlowFill event should be emitted");
     assert.isNotNull(fillEvent, "FilledV3Relay event should be emitted");
     assertSE(requestEvent.messageHash, new Uint8Array(32), `MessageHash should be zeroed`);

--- a/test/svm/SvmSpoke.TokenBridge.ts
+++ b/test/svm/SvmSpoke.TokenBridge.ts
@@ -327,7 +327,7 @@ describe("svm_spoke.token_bridge", () => {
     await new Promise((resolve) => setTimeout(resolve, 500));
 
     const events = await readProgramEvents(connection, program);
-    const event = events.find((event) => event.name === "bridgedToHubPool").data;
+    const event = events.find((event) => event.name === "bridgedToHubPool")?.data;
     assert.isNotNull(event, "BridgedToHubPool event should be emitted");
     assert.strictEqual(event.amount.toString(), simpleBridgeAmount.toString(), "Invalid amount");
     assert.strictEqual(event.mint.toString(), mint.toString(), "Invalid mint");

--- a/test/svm/utils.ts
+++ b/test/svm/utils.ts
@@ -471,12 +471,3 @@ export function testAcrossPlusMessage() {
   ];
   return { encodedMessage, fillRemainingAccounts };
 }
-
-export function hashNonEmptyMessage(message: Buffer) {
-  if (message.length > 0) {
-    const hash = ethers.utils.keccak256(message);
-    return Uint8Array.from(Buffer.from(hash.slice(2), "hex"));
-  }
-  // else return zeroed bytes32
-  return new Uint8Array(32);
-}


### PR DESCRIPTION
After having implemented Across+ that replaces message with its hash in the emitted fill events, it becomes overly complex to discover `fill_status` PDA addresses as its derivation requires knowledge of full message. This PR overcomes this issue by changing how relay hash is calculated, so that message is replaced with its hash before calculating the hash of the whole relay data struct. This also drops relay hash and relay data parameters in the `close_fill_pda` by storing fill deadline in the `fill_status` account.

Same EVM changes are done in #779 