### PR TITLE
fix: Add `--json` flag to checkStorageLayout's `forge inspect` command

### DIFF
--- a/scripts/checkStorageLayout.sh
+++ b/scripts/checkStorageLayout.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-CONTRACTS=("Arbitrum_SpokePool")
+CONTRACTS=("Arbitrum_SpokePool" "Optimism_SpokePool" "Polygon_SpokePool" "Linea_SpokePool" "ZkSync_SpokePool" "Ethereum_SpokePool" "Base_SpokePool" "Mode_SpokePool" "Blast_SpokePool" "AlephZero_SpokePool" "Redstone_SpokePool" "Scroll_SpokePool" "WorldChain_SpokePool" "Zora_SpokePool" "PolygonZkEVM_SpokePool")
 if [[ "$1" == "--overwrite" ]]; then
     for CONTRACT in "${CONTRACTS[@]}"; do
         echo "Overwrite flag detected. Creating new storage layout snapshot of the $CONTRACT contract"
-        forge inspect $CONTRACT storagelayout > ./storage-layouts/temp.$CONTRACT.json
+        forge inspect $CONTRACT storagelayout --json > ./storage-layouts/temp.$CONTRACT.json
         # Delete any astId keys from the file, which seem to change every time the bytecode changes
         # and the types object which also contains astId changes. We only care about the size and relative
         # location of state variable slots.
@@ -18,7 +18,7 @@ fi
 for CONTRACT in "${CONTRACTS[@]}"; do
     echo "Comparing storage layout snapshot of the $CONTRACT contract at ./storage-layouts/$CONTRACT.json with current storage layout"
     echo "Created temporary storage layout file at ./storage-layouts/proposed.$CONTRACT.json"
-    forge inspect $CONTRACT storagelayout > ./storage-layouts/temp.$CONTRACT.json
+    forge inspect $CONTRACT storagelayout --json > ./storage-layouts/temp.$CONTRACT.json
     cat ./storage-layouts/temp.$CONTRACT.json 
     # Delete any astId keys from the file, which seem to change every time the bytecode changes
     # and the types object which also contains astId changes. We only care about the size and relative

--- a/scripts/checkStorageLayout.sh
+++ b/scripts/checkStorageLayout.sh
@@ -19,7 +19,6 @@ for CONTRACT in "${CONTRACTS[@]}"; do
     echo "Comparing storage layout snapshot of the $CONTRACT contract at ./storage-layouts/$CONTRACT.json with current storage layout"
     echo "Created temporary storage layout file at ./storage-layouts/proposed.$CONTRACT.json"
     forge inspect $CONTRACT storagelayout --json > ./storage-layouts/temp.$CONTRACT.json
-    cat ./storage-layouts/temp.$CONTRACT.json 
     # Delete any astId keys from the file, which seem to change every time the bytecode changes
     # and the types object which also contains astId changes. We only care about the size and relative
     # location of state variable slots.

--- a/scripts/checkStorageLayout.sh
+++ b/scripts/checkStorageLayout.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONTRACTS=("Arbitrum_SpokePool" "Optimism_SpokePool" "Polygon_SpokePool" "Linea_SpokePool" "ZkSync_SpokePool" "Ethereum_SpokePool" "Base_SpokePool" "Mode_SpokePool" "Blast_SpokePool")
+CONTRACTS=("Arbitrum_SpokePool")
 if [[ "$1" == "--overwrite" ]]; then
     for CONTRACT in "${CONTRACTS[@]}"; do
         echo "Overwrite flag detected. Creating new storage layout snapshot of the $CONTRACT contract"
@@ -19,6 +19,7 @@ for CONTRACT in "${CONTRACTS[@]}"; do
     echo "Comparing storage layout snapshot of the $CONTRACT contract at ./storage-layouts/$CONTRACT.json with current storage layout"
     echo "Created temporary storage layout file at ./storage-layouts/proposed.$CONTRACT.json"
     forge inspect $CONTRACT storagelayout > ./storage-layouts/temp.$CONTRACT.json
+    cat ./storage-layouts/temp.$CONTRACT.json 
     # Delete any astId keys from the file, which seem to change every time the bytecode changes
     # and the types object which also contains astId changes. We only care about the size and relative
     # location of state variable slots.

--- a/storage-layouts/AlephZero_SpokePool.json
+++ b/storage-layouts/AlephZero_SpokePool.json
@@ -1,0 +1,166 @@
+{
+  "storage": [
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "_initialized",
+      "offset": 0,
+      "slot": "0"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "_initializing",
+      "offset": 1,
+      "slot": "0"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "1"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "51"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "_status",
+      "offset": 0,
+      "slot": "101"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "102"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "151"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "_HASHED_NAME",
+      "offset": 0,
+      "slot": "1151"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "_HASHED_VERSION",
+      "offset": 0,
+      "slot": "1152"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "1153"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "crossDomainAdmin",
+      "offset": 0,
+      "slot": "2153"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "withdrawalRecipient",
+      "offset": 0,
+      "slot": "2154"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "DEPRECATED_wrappedNativeToken",
+      "offset": 0,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "DEPRECATED_depositQuoteTimeBuffer",
+      "offset": 20,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "numberOfDeposits",
+      "offset": 24,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "pausedFills",
+      "offset": 28,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "pausedDeposits",
+      "offset": 29,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "rootBundles",
+      "offset": 0,
+      "slot": "2156"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "enabledDepositRoutes",
+      "offset": 0,
+      "slot": "2157"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "DEPRECATED_relayFills",
+      "offset": 0,
+      "slot": "2158"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "DEPRECATED_fillCounter",
+      "offset": 0,
+      "slot": "2159"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "DEPRECATED_depositCounter",
+      "offset": 0,
+      "slot": "2160"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "DEPRECATED_refundsRequested",
+      "offset": 0,
+      "slot": "2161"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "fillStatuses",
+      "offset": 0,
+      "slot": "2162"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2163"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "l2GatewayRouter",
+      "offset": 0,
+      "slot": "3162"
+    },
+    {
+      "contract": "contracts/AlephZero_SpokePool.sol:AlephZero_SpokePool",
+      "label": "whitelistedTokens",
+      "offset": 0,
+      "slot": "3163"
+    }
+  ]
+}

--- a/storage-layouts/PolygonZkEVM_SpokePool.json
+++ b/storage-layouts/PolygonZkEVM_SpokePool.json
@@ -1,0 +1,166 @@
+{
+  "storage": [
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "_initialized",
+      "offset": 0,
+      "slot": "0"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "_initializing",
+      "offset": 1,
+      "slot": "0"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "1"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "51"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "_status",
+      "offset": 0,
+      "slot": "101"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "102"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "151"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "_HASHED_NAME",
+      "offset": 0,
+      "slot": "1151"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "_HASHED_VERSION",
+      "offset": 0,
+      "slot": "1152"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "1153"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "crossDomainAdmin",
+      "offset": 0,
+      "slot": "2153"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "withdrawalRecipient",
+      "offset": 0,
+      "slot": "2154"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "DEPRECATED_wrappedNativeToken",
+      "offset": 0,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "DEPRECATED_depositQuoteTimeBuffer",
+      "offset": 20,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "numberOfDeposits",
+      "offset": 24,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "pausedFills",
+      "offset": 28,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "pausedDeposits",
+      "offset": 29,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "rootBundles",
+      "offset": 0,
+      "slot": "2156"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "enabledDepositRoutes",
+      "offset": 0,
+      "slot": "2157"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "DEPRECATED_relayFills",
+      "offset": 0,
+      "slot": "2158"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "DEPRECATED_fillCounter",
+      "offset": 0,
+      "slot": "2159"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "DEPRECATED_depositCounter",
+      "offset": 0,
+      "slot": "2160"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "DEPRECATED_refundsRequested",
+      "offset": 0,
+      "slot": "2161"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "fillStatuses",
+      "offset": 0,
+      "slot": "2162"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2163"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "l2PolygonZkEVMBridge",
+      "offset": 0,
+      "slot": "3162"
+    },
+    {
+      "contract": "contracts/PolygonZkEVM_SpokePool.sol:PolygonZkEVM_SpokePool",
+      "label": "adminCallValidated",
+      "offset": 20,
+      "slot": "3162"
+    }
+  ]
+}

--- a/storage-layouts/Redstone_SpokePool.json
+++ b/storage-layouts/Redstone_SpokePool.json
@@ -1,0 +1,190 @@
+{
+  "storage": [
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "_initialized",
+      "offset": 0,
+      "slot": "0"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "_initializing",
+      "offset": 1,
+      "slot": "0"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "1"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "51"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "_status",
+      "offset": 0,
+      "slot": "101"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "102"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "151"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "_HASHED_NAME",
+      "offset": 0,
+      "slot": "1151"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "_HASHED_VERSION",
+      "offset": 0,
+      "slot": "1152"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "1153"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "crossDomainAdmin",
+      "offset": 0,
+      "slot": "2153"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "withdrawalRecipient",
+      "offset": 0,
+      "slot": "2154"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "DEPRECATED_wrappedNativeToken",
+      "offset": 0,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "DEPRECATED_depositQuoteTimeBuffer",
+      "offset": 20,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "numberOfDeposits",
+      "offset": 24,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "pausedFills",
+      "offset": 28,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "pausedDeposits",
+      "offset": 29,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "rootBundles",
+      "offset": 0,
+      "slot": "2156"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "enabledDepositRoutes",
+      "offset": 0,
+      "slot": "2157"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "DEPRECATED_relayFills",
+      "offset": 0,
+      "slot": "2158"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "DEPRECATED_fillCounter",
+      "offset": 0,
+      "slot": "2159"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "DEPRECATED_depositCounter",
+      "offset": 0,
+      "slot": "2160"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "DEPRECATED_refundsRequested",
+      "offset": 0,
+      "slot": "2161"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "fillStatuses",
+      "offset": 0,
+      "slot": "2162"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2163"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "l1Gas",
+      "offset": 0,
+      "slot": "3162"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "l2Eth",
+      "offset": 4,
+      "slot": "3162"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "__deprecated_messenger",
+      "offset": 0,
+      "slot": "3163"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "tokenBridges",
+      "offset": 0,
+      "slot": "3164"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "remoteL1Tokens",
+      "offset": 0,
+      "slot": "3165"
+    },
+    {
+      "contract": "contracts/Redstone_SpokePool.sol:Redstone_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "3166"
+    }
+  ]
+}

--- a/storage-layouts/Scroll_SpokePool.json
+++ b/storage-layouts/Scroll_SpokePool.json
@@ -1,0 +1,166 @@
+{
+  "storage": [
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "_initialized",
+      "offset": 0,
+      "slot": "0"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "_initializing",
+      "offset": 1,
+      "slot": "0"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "1"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "51"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "_status",
+      "offset": 0,
+      "slot": "101"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "102"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "151"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "_HASHED_NAME",
+      "offset": 0,
+      "slot": "1151"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "_HASHED_VERSION",
+      "offset": 0,
+      "slot": "1152"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "1153"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "crossDomainAdmin",
+      "offset": 0,
+      "slot": "2153"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "withdrawalRecipient",
+      "offset": 0,
+      "slot": "2154"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "DEPRECATED_wrappedNativeToken",
+      "offset": 0,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "DEPRECATED_depositQuoteTimeBuffer",
+      "offset": 20,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "numberOfDeposits",
+      "offset": 24,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "pausedFills",
+      "offset": 28,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "pausedDeposits",
+      "offset": 29,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "rootBundles",
+      "offset": 0,
+      "slot": "2156"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "enabledDepositRoutes",
+      "offset": 0,
+      "slot": "2157"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "DEPRECATED_relayFills",
+      "offset": 0,
+      "slot": "2158"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "DEPRECATED_fillCounter",
+      "offset": 0,
+      "slot": "2159"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "DEPRECATED_depositCounter",
+      "offset": 0,
+      "slot": "2160"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "DEPRECATED_refundsRequested",
+      "offset": 0,
+      "slot": "2161"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "fillStatuses",
+      "offset": 0,
+      "slot": "2162"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2163"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "l2GatewayRouter",
+      "offset": 0,
+      "slot": "3162"
+    },
+    {
+      "contract": "contracts/Scroll_SpokePool.sol:Scroll_SpokePool",
+      "label": "l2ScrollMessenger",
+      "offset": 0,
+      "slot": "3163"
+    }
+  ]
+}

--- a/storage-layouts/WorldChain_SpokePool.json
+++ b/storage-layouts/WorldChain_SpokePool.json
@@ -1,0 +1,190 @@
+{
+  "storage": [
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "_initialized",
+      "offset": 0,
+      "slot": "0"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "_initializing",
+      "offset": 1,
+      "slot": "0"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "1"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "51"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "_status",
+      "offset": 0,
+      "slot": "101"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "102"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "151"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "_HASHED_NAME",
+      "offset": 0,
+      "slot": "1151"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "_HASHED_VERSION",
+      "offset": 0,
+      "slot": "1152"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "1153"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "crossDomainAdmin",
+      "offset": 0,
+      "slot": "2153"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "withdrawalRecipient",
+      "offset": 0,
+      "slot": "2154"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "DEPRECATED_wrappedNativeToken",
+      "offset": 0,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "DEPRECATED_depositQuoteTimeBuffer",
+      "offset": 20,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "numberOfDeposits",
+      "offset": 24,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "pausedFills",
+      "offset": 28,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "pausedDeposits",
+      "offset": 29,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "rootBundles",
+      "offset": 0,
+      "slot": "2156"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "enabledDepositRoutes",
+      "offset": 0,
+      "slot": "2157"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "DEPRECATED_relayFills",
+      "offset": 0,
+      "slot": "2158"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "DEPRECATED_fillCounter",
+      "offset": 0,
+      "slot": "2159"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "DEPRECATED_depositCounter",
+      "offset": 0,
+      "slot": "2160"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "DEPRECATED_refundsRequested",
+      "offset": 0,
+      "slot": "2161"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "fillStatuses",
+      "offset": 0,
+      "slot": "2162"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2163"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "l1Gas",
+      "offset": 0,
+      "slot": "3162"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "l2Eth",
+      "offset": 4,
+      "slot": "3162"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "__deprecated_messenger",
+      "offset": 0,
+      "slot": "3163"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "tokenBridges",
+      "offset": 0,
+      "slot": "3164"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "remoteL1Tokens",
+      "offset": 0,
+      "slot": "3165"
+    },
+    {
+      "contract": "contracts/WorldChain_SpokePool.sol:WorldChain_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "3166"
+    }
+  ]
+}

--- a/storage-layouts/Zora_SpokePool.json
+++ b/storage-layouts/Zora_SpokePool.json
@@ -1,0 +1,190 @@
+{
+  "storage": [
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "_initialized",
+      "offset": 0,
+      "slot": "0"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "_initializing",
+      "offset": 1,
+      "slot": "0"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "1"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "51"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "_status",
+      "offset": 0,
+      "slot": "101"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "102"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "151"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "_HASHED_NAME",
+      "offset": 0,
+      "slot": "1151"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "_HASHED_VERSION",
+      "offset": 0,
+      "slot": "1152"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "1153"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "crossDomainAdmin",
+      "offset": 0,
+      "slot": "2153"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "withdrawalRecipient",
+      "offset": 0,
+      "slot": "2154"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "DEPRECATED_wrappedNativeToken",
+      "offset": 0,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "DEPRECATED_depositQuoteTimeBuffer",
+      "offset": 20,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "numberOfDeposits",
+      "offset": 24,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "pausedFills",
+      "offset": 28,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "pausedDeposits",
+      "offset": 29,
+      "slot": "2155"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "rootBundles",
+      "offset": 0,
+      "slot": "2156"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "enabledDepositRoutes",
+      "offset": 0,
+      "slot": "2157"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "DEPRECATED_relayFills",
+      "offset": 0,
+      "slot": "2158"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "DEPRECATED_fillCounter",
+      "offset": 0,
+      "slot": "2159"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "DEPRECATED_depositCounter",
+      "offset": 0,
+      "slot": "2160"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "DEPRECATED_refundsRequested",
+      "offset": 0,
+      "slot": "2161"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "fillStatuses",
+      "offset": 0,
+      "slot": "2162"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "2163"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "l1Gas",
+      "offset": 0,
+      "slot": "3162"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "l2Eth",
+      "offset": 4,
+      "slot": "3162"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "__deprecated_messenger",
+      "offset": 0,
+      "slot": "3163"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "tokenBridges",
+      "offset": 0,
+      "slot": "3164"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "remoteL1Tokens",
+      "offset": 0,
+      "slot": "3165"
+    },
+    {
+      "contract": "contracts/Zora_SpokePool.sol:Zora_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "3166"
+    }
+  ]
+}


### PR DESCRIPTION
The `forge inspect` behavior changed in one of the `nightly` builds recently, and this broke CI because our CI pulls from the latest `nightly` version each time it runs. [The default behavior prints a table now](https://github.com/foundry-rs/foundry/blob/00efa0d5965269149f374ba142fb1c3c7edd6c94/crates/forge/bin/cmd/inspect.rs#L184), which honestly is pretty nice to look at and maybe we should use it. However, the table is a bit harder to modify using simple `jq` bash commands like we do today.

However, the simplest fix for now is to add the `--json` flag to `inspect` command. 

I've also added other spoke pools to the script.