### PR TITLE
feat(svm): Refactor deposit ID to use big-endian encoding in Bytes32 format

### DIFF
--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -117,7 +117,7 @@ pub fn _deposit_v3(
     // If the passed in deposit_id is all zeros, then we use the state's number of deposits as deposit_id.
     if deposit_id == ZERO_DEPOSIT_ID {
         state.number_of_deposits += 1;
-        applied_deposit_id[..4].copy_from_slice(&state.number_of_deposits.to_le_bytes());
+        applied_deposit_id[28..].copy_from_slice(&state.number_of_deposits.to_be_bytes());
     }
 
     emit_cpi!(V3FundsDeposited {

--- a/src/svm/conversionUtils.ts
+++ b/src/svm/conversionUtils.ts
@@ -1,6 +1,6 @@
 import { BN } from "@coral-xyz/anchor";
 import { PublicKey } from "@solana/web3.js";
-import { ethers } from "ethers";
+import { BigNumber, ethers } from "ethers";
 
 /**
  * Converts an integer to a 32-byte Uint8Array.
@@ -44,7 +44,20 @@ export function u8Array32ToInt(u8Array: Uint8Array | number[]): bigint {
   const isValidArray = (arr: any): arr is number[] => Array.isArray(arr) && arr.every(Number.isInteger);
 
   if ((u8Array instanceof Uint8Array || isValidArray(u8Array)) && u8Array.length === 32) {
-    return Array.from(u8Array.slice(28, 32)).reduce<bigint>((num, byte) => (num << 8n) | BigInt(byte), 0n);
+    return Array.from(u8Array).reduce<bigint>((num, byte) => (num << 8n) | BigInt(byte), 0n);
+  }
+
+  throw new Error("Input must be a Uint8Array or an array of 32 numbers.");
+}
+
+/**
+ * Converts a 32-byte Uint8Array to a BigNumber.
+ */
+export function u8Array32ToBigNumber(u8Array: Uint8Array | number[]): BigNumber {
+  const isValidArray = (arr: any): arr is number[] => Array.isArray(arr) && arr.every(Number.isInteger);
+  if ((u8Array instanceof Uint8Array || isValidArray(u8Array)) && u8Array.length === 32) {
+    const hexString = "0x" + Buffer.from(u8Array).toString("hex");
+    return BigNumber.from(hexString);
   }
 
   throw new Error("Input must be a Uint8Array or an array of 32 numbers.");

--- a/src/svm/conversionUtils.ts
+++ b/src/svm/conversionUtils.ts
@@ -6,33 +6,11 @@ import { BigNumber, ethers } from "ethers";
  * Converts an integer to a 32-byte Uint8Array.
  */
 export function intToU8Array32(num: number | BN): number[] {
-  let bigIntValue: bigint;
+  const bigIntValue = BigInt(num instanceof BN ? num.toString() : num);
+  if (bigIntValue < 0) throw new Error("Input must be a non-negative integer or BN");
 
-  if (typeof num === "number") {
-    if (!Number.isInteger(num) || num < 0) {
-      throw new Error("Input must be a non-negative integer");
-    }
-    bigIntValue = BigInt(num);
-  } else if (BN.isBN(num)) {
-    if (num.isNeg()) {
-      throw new Error("Input must be a non-negative BN");
-    }
-    bigIntValue = BigInt(num.toString());
-  } else {
-    throw new Error("Input must be a non-negative integer or BN");
-  }
-
-  const u8Array = new Array(32).fill(0);
-
-  // Get the 4-byte BE representation of the number
-  const beBytes = Array.from(bigIntValue.toString(16).padStart(8, "0").match(/.{2}/g) || []).map((byte) =>
-    parseInt(byte, 16)
-  );
-
-  // Insert the BE bytes into the last 4 bytes of the array
-  for (let i = 0; i < 4; i++) {
-    u8Array[28 + i] = beBytes[i] || 0;
-  }
+  const hexString = bigIntValue.toString(16).padStart(64, "0"); // 32 bytes = 64 hex chars
+  const u8Array = Array.from(Buffer.from(hexString, "hex"));
 
   return u8Array;
 }

--- a/test/svm/SvmSpoke.Deposit.ts
+++ b/test/svm/SvmSpoke.Deposit.ts
@@ -1,6 +1,6 @@
 import * as anchor from "@coral-xyz/anchor";
 import { BN } from "@coral-xyz/anchor";
-import { ethers } from "ethers";
+import { BigNumber, ethers } from "ethers";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
@@ -17,7 +17,7 @@ import {
 import { PublicKey, Keypair, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
 import { common } from "./SvmSpoke.common";
 import { DepositDataValues } from "../../src/types/svm";
-import { intToU8Array32, readEventsUntilFound } from "../../src/svm";
+import { intToU8Array32, readEventsUntilFound, u8Array32ToInt, u8Array32ToBigNumber } from "../../src/svm";
 const { provider, connection, program, owner, seedBalance, initializeState, depositData } = common;
 const { createRoutePda, getVaultAta, assertSE, assert, getCurrentTime, depositQuoteTimeBuffer, fillDeadlineBuffer } =
   common;
@@ -195,6 +195,9 @@ describe("svm_spoke.deposit", () => {
       assertSE(event[key], value, `${key} should match`);
     }
 
+    assertSE(u8Array32ToInt(event.depositId), 1, `depositId should recover to 1`);
+    assertSE(u8Array32ToBigNumber(event.depositId), BigNumber.from(1), `depositId should recover to 1`);
+
     // Execute the second deposit_v3 call
     const tx2 = await approvedDepositV3(depositDataValues);
     events = await readEventsUntilFound(connection, tx2, [program]);
@@ -205,6 +208,9 @@ describe("svm_spoke.deposit", () => {
       if (key === "exclusivityParameter") key = "exclusivityDeadline"; // the prop and the event names differ on this key.
       assertSE(event[key], value, `${key} should match`);
     }
+
+    assertSE(u8Array32ToInt(event.depositId), 2, `depositId should recover to 2`);
+    assertSE(u8Array32ToBigNumber(event.depositId), BigNumber.from(2), `depositId should recover to 2`);
   });
 
   it("Fails to deposit tokens to a route that is uninitalized", async () => {

--- a/test/svm/SvmSpoke.Deposit.ts
+++ b/test/svm/SvmSpoke.Deposit.ts
@@ -195,6 +195,7 @@ describe("svm_spoke.deposit", () => {
       assertSE(event[key], value, `${key} should match`);
     }
 
+    // Test the id recovery with the conversion utils
     assertSE(u8Array32ToInt(event.depositId), 1, `depositId should recover to 1`);
     assertSE(u8Array32ToBigNumber(event.depositId), BigNumber.from(1), `depositId should recover to 1`);
 
@@ -209,6 +210,7 @@ describe("svm_spoke.deposit", () => {
       assertSE(event[key], value, `${key} should match`);
     }
 
+    // Test the id recovery with the conversion utils
     assertSE(u8Array32ToInt(event.depositId), 2, `depositId should recover to 2`);
     assertSE(u8Array32ToBigNumber(event.depositId), BigNumber.from(2), `depositId should recover to 2`);
   });


### PR DESCRIPTION
Changes proposed in this PR:
- Updated deposit ID storage format to use big-endian encoding 
- Refactored byte manipulation logic to ensure consistent big-endian encoding and decoding for 32byte arrays

Motivation:

Previously, "safe" (`deposit_v3`) deposit IDs were stored in little-endian (LE) format, causing friction for relayers and off-chain tools due to format conversions. Challenges included:
1. Relayers had to convert BE (EVM standard) to LE, adding complexity.
2. Special handling was required to extract and parse IDs stored in LE format see [this](https://github.com/across-protocol/contracts/blob/25fc095c2d75da8922a220acfcea8c4dd5c9295f/src/svm/solanaProgramUtils.ts#L213-L228)
3. Diverged from EVM conventions, complicating cross-chain operations.
	
Solution:

This PR stores "safe" (`deposit_v3`) deposit IDs in BE format, storing `number_of_deposits` in the right-most bits. This aligns with EVM, simplifies cross-chain operations and reduces off-chain parsing complexity

Note: The “unsafe” deposit (`unsafe_deposit_v3`) does not require any changes and is unaffected by these challenges, as it uses a generated hash without endianness considerations.