### PR TITLE
fix: address LUT issues on tests

### DIFF
--- a/src/svm/instructionParamsUtils.ts
+++ b/src/svm/instructionParamsUtils.ts
@@ -1,4 +1,13 @@
-import { Keypair, TransactionInstruction, Transaction, sendAndConfirmTransaction, PublicKey } from "@solana/web3.js";
+import {
+  Keypair,
+  TransactionInstruction,
+  Transaction,
+  sendAndConfirmTransaction,
+  PublicKey,
+  Connection,
+  clusterApiUrl,
+  ConfirmOptions,
+} from "@solana/web3.js";
 import { Program, BN } from "@coral-xyz/anchor";
 import { RelayData, SlowFillLeaf, RelayerRefundLeafSolana } from "../types/svm";
 import { SvmSpoke } from "../../target/types/svm_spoke";

--- a/src/svm/instructionParamsUtils.ts
+++ b/src/svm/instructionParamsUtils.ts
@@ -1,13 +1,4 @@
-import {
-  Keypair,
-  TransactionInstruction,
-  Transaction,
-  sendAndConfirmTransaction,
-  PublicKey,
-  Connection,
-  clusterApiUrl,
-  ConfirmOptions,
-} from "@solana/web3.js";
+import { Keypair, TransactionInstruction, Transaction, sendAndConfirmTransaction, PublicKey } from "@solana/web3.js";
 import { Program, BN } from "@coral-xyz/anchor";
 import { RelayData, SlowFillLeaf, RelayerRefundLeafSolana } from "../types/svm";
 import { SvmSpoke } from "../../target/types/svm_spoke";

--- a/src/svm/transactionUtils.ts
+++ b/src/svm/transactionUtils.ts
@@ -52,7 +52,10 @@ export async function sendTransactionWithLookupTable(
       addresses: lookupAddresses.slice(i, i + maxExtendedAccounts),
     });
 
-    await web3.sendAndConfirmTransaction(connection, new web3.Transaction().add(extendInstruction), [sender]);
+    await web3.sendAndConfirmTransaction(connection, new web3.Transaction().add(extendInstruction), [sender], {
+      commitment: "confirmed",
+      skipPreflight: true,
+    });
   }
 
   // Wait for slot to advance. LUTs only active after slot advance.


### PR DESCRIPTION
addresses an issue we were seeing with unit tests after an anchor update. Now, all tests work.

reason this was needed is as follows:
```
Note that after you create or extend a lookup table, it must "warm up" for one slot before the lookup table or newly added addresses can be used in transactions. You can only access lookup tables and addresses added in slots prior to the current one.
```

![Safari 2024-12-19 15 14 03](https://github.com/user-attachments/assets/16ee5835-41e1-4def-91e4-18b18073afda)

