### PR TITLE
feat(svm): N-07 TODO Comments in the Code

### DIFF
--- a/programs/svm-spoke/src/event.rs
+++ b/programs/svm-spoke/src/event.rs
@@ -84,7 +84,6 @@ pub struct FilledV3Relay {
     pub relayer: Pubkey,
     pub depositor: Pubkey,
     pub recipient: Pubkey,
-    // TODO: update EVM implementation to use message_hash in all fill related events.
     pub message_hash: [u8; 32],
     pub relay_execution_info: V3RelayExecutionEventInfo,
 }

--- a/programs/svm-spoke/src/utils/message_utils.rs
+++ b/programs/svm-spoke/src/utils/message_utils.rs
@@ -88,7 +88,6 @@ pub fn invoke_handler<'info>(
 
     let instruction = Instruction { program_id: message.handler, accounts, data };
 
-    // TODO: consider if the message handler requires signed invocation.
     invoke(&instruction, account_infos)?;
 
     Ok(())


### PR DESCRIPTION
Changes proposed in this PR:
- Fixes the following issue identifier by Open Zeppelin:

> During development, having well-described TODO comments will make the process of tracking and resolving them easier. Without this information, these comments might age and important information for the security of the system might be forgotten by the time it is released to production.
> 
> Throughout the [codebase](hhttps://github.com/across-protocol/contracts/tree/0f2600f83e8a5738d0d62a78b05ff37adda4c1c9), multiple instances of unaddressed TODO comments were identified:
> 
> In [line 87](https://github.com/across-protocol/contracts/blob/0f2600f83e8a5738d0d62a78b05ff37adda4c1c9/programs/svm-spoke/src/event.rs#L87) of event.rs.
> 
> In [line 91](https://github.com/across-protocol/contracts/blob/0f2600f83e8a5738d0d62a78b05ff37adda4c1c9/programs/svm-spoke/src/utils/message_utils.rs#L91) of message_utils.rs.
> 
> Consider removing all instances of TODO comments and instead tracking them in the issues backlog. Alternatively, consider linking each inline TODO to a corresponding backlog issue.

Fixes ACX-3596