### PR TITLE
feat(svm): shorten svm chain ids

### DIFF
--- a/src/svm/helpers.ts
+++ b/src/svm/helpers.ts
@@ -7,7 +7,7 @@ import { ethers } from "ethers";
  */
 export const getSolanaChainId = (cluster: "devnet" | "mainnet"): BigNumber => {
   return BigNumber.from(
-    BigInt(ethers.utils.keccak256(ethers.utils.toUtf8Bytes(`solana-${cluster}`))) & BigInt("0xFFFFFFFFFFFFFFFF")
+    BigInt(ethers.utils.keccak256(ethers.utils.toUtf8Bytes(`solana-${cluster}`))) & BigInt("0xFFFFFFFFFFFF")
   );
 };
 


### PR DESCRIPTION
Changes proposed in this PR:
- Shorten SVM chain ids to 6 bytes to prevent them from overflowing js Number type


getSolanaChainId("devnet") => `133268194659241`
getSolanaChainId("mainnet")=> `34268394551451`