### PR TITLE
chore: match foundry zksync configs with hardhat

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -51,8 +51,8 @@ This is because this `deployments.json` file is used by bots in [`@across-protoc
 
 | Contract Name    | Address                                                                                                                     |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| zkSync_SpokePool | [0xE0B015E54d54fc84a6cB9B666099c46adE9335FF](https://explorer.zksync.io/address/0xE0B015E54d54fc84a6cB9B666099c46adE9335FF) |
-| MulticallHandler | [0x863859ef502F0Ee9676626ED5B418037252eFeb2](https://explorer.zksync.io/address/0x863859ef502F0Ee9676626ED5B418037252eFeb2) |
+| zkSync_SpokePool | [0xE0B015E54d54fc84a6cB9B666099c46adE9335FF](https://era.zksync.network/address/0xE0B015E54d54fc84a6cB9B666099c46adE9335FF) |
+| MulticallHandler | [0x863859ef502F0Ee9676626ED5B418037252eFeb2](https://era.zksync.network/address/0x863859ef502F0Ee9676626ED5B418037252eFeb2) |
 
 ## Arbitrum mainnet (42161)
 
@@ -133,7 +133,7 @@ This is because this `deployments.json` file is used by bots in [`@across-protoc
 
 ## Ink mainnet (57073)
 
-| Contract Name | Address                                                                                                                          |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Ink_SpokePool | [0xeF684C38F94F48775959ECf2012D7E864ffb9dd4](https://explorer.inkonchain.com/address/0xeF684C38F94F48775959ECf2012D7E864ffb9dd4) |
-| MulticallHandler   | [0x924a9f036260DdD5808007E1AA95f08eD08aA569](https://explorer.inkonchain.com/address/0x924a9f036260DdD5808007E1AA95f08eD08aA569) |
+| Contract Name    | Address                                                                                                                          |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Ink_SpokePool    | [0xeF684C38F94F48775959ECf2012D7E864ffb9dd4](https://explorer.inkonchain.com/address/0xeF684C38F94F48775959ECf2012D7E864ffb9dd4) |
+| MulticallHandler | [0x924a9f036260DdD5808007E1AA95f08eD08aA569](https://explorer.inkonchain.com/address/0x924a9f036260DdD5808007E1AA95f08eD08aA569) |

--- a/foundry.toml
+++ b/foundry.toml
@@ -32,8 +32,10 @@ evm_version = "shanghai"
 
 [rpc_endpoints]
 ethereum = "${NODE_URL_1}"
+zksync = "${NODE_URL_324}"
 
 [etherscan]
 ethereum = { key = "${ETHERSCAN_API_KEY}" }
+zksync = { key = "${ZKSYNC_ETHERSCAN_API_KEY}" }
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/foundry.toml
+++ b/foundry.toml
@@ -24,11 +24,13 @@ remappings = [
 ]
 via_ir = true
 optimizer_runs = 1_000_000
-solc_version = "0.8.25"
+solc_version = "0.8.23"
 revert_strings = "strip"
 
-solc = "0.8.25"
-evm_version = "shanghai"
+solc = "0.8.23"
+
+[profile.default.zksync]
+zksolc = "1.5.2"
 
 [rpc_endpoints]
 ethereum = "${NODE_URL_1}"

--- a/script/DeployMulticallHandler.s.sol
+++ b/script/DeployMulticallHandler.s.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import { Script } from "forge-std/Script.sol";
+import { Test } from "forge-std/Test.sol";
+
+import { MulticallHandler } from "../contracts/handlers/MulticallHandler.sol";
+import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
+
+// How to run:
+// 1. `source .env` where `.env has MNEMONIC="x x x ... x" and ETHERSCAN_API_KEY="x" entries
+// 2. forge script script/DeployMulticallHandler.s.sol:DeployMulticallHandler --rpc-url $NODE_URL_1-vvvv
+// 3. Verify the above works in simulation mode.
+// 4. Deploy on mainnet by adding --broadcast --verify flags.
+// 5. forge script script/DeployMulticallHandler.s.sol:DeployMulticallHandler --rpc-url $NODE_URL_1 --broadcast --verify -vvvv
+contract DeployMulticallHandler is Script, Test {
+    bytes32 constant salt = bytes32(uint256(0x00000000000000000000000000000000000000000000000000000012345678));
+
+    function run() external {
+        string memory deployerMnemonic = vm.envString("MNEMONIC");
+        uint256 deployerPrivateKey = vm.deriveKey(deployerMnemonic, 0);
+        address deployer = vm.addr(deployerPrivateKey);
+        vm.startBroadcast(deployerPrivateKey);
+
+        address handler = Create2.deploy(0, salt, type(MulticallHandler).creationCode);
+    }
+}


### PR DESCRIPTION
Hardhat [does not support](https://github.com/zkSync-Community-Hub/zksync-developers/discussions/732) verification of contracts on the zksync etherscan block explorer, so when we deploy contracts to zksync, we may want to start using foundry so that we may verify contracts. This also switches our default zksync block explorer in the contracts repo to the etherscan block explorer (now that the SpokePool/MulticallHandler contracts are verified). 