### PR TITLE
fix(svm): N-04 reset use of PDA signer in multicall handler

### DIFF
--- a/programs/multicall-handler/src/lib.rs
+++ b/programs/multicall-handler/src/lib.rs
@@ -17,11 +17,13 @@ pub mod multicall_handler {
     pub fn handle_v3_across_message(ctx: Context<HandleV3AcrossMessage>, message: Vec<u8>) -> Result<()> {
         // Some instructions might require being signed by handler PDA.
         let (handler_signer, bump) = Pubkey::find_program_address(&[b"handler_signer"], &crate::ID);
-        let mut use_handler_signer = false;
 
         let compiled_ixs: Vec<CompiledIx> = AnchorDeserialize::deserialize(&mut &message[..])?;
 
         for compiled_ix in compiled_ixs {
+            // Will only sign with handler PDA if it is included in this instruction's accounts (checked below).
+            let mut use_handler_signer = false;
+
             let mut accounts = Vec::with_capacity(compiled_ix.account_key_indexes.len());
             let mut account_infos = Vec::with_capacity(compiled_ix.account_key_indexes.len());
 


### PR DESCRIPTION
OZ identified following issue:

```
Across deposits may include additional message data that must be processed during relayer fills, in which
case the data is deserialized and processed as various accounts and instructions that are invoked on the
message handler specified in the relayer data. In the provided multicall_handler example, the handler_signer
may be included as an additional signer in the CPI calls decoded from the message. However, it may be
included when not necessary. This is because, in each program call, use_handler_signer is set if any accounts
in the call match the handler_signer key, but it is never reset to false before checking subsequent calls.

Consider correcting this logic by resetting the value of use_handler_signer at the top of the outermost for
loop to avoid passing additional unnecessary signers in CPI calls.
```

This PR addresses the issue by resetting `use_handler_signer` to `false` at the start of processing each instruction.

Fixes: https://linear.app/uma/issue/ACX-3593/n-04-unneccessary-pda-signer-can-be-used-in-multicall-handler