### PR TITLE
feat(svm): L-07 transfer ownership event

### DIFF
--- a/programs/svm-spoke/src/event.rs
+++ b/programs/svm-spoke/src/event.rs
@@ -7,6 +7,11 @@ pub struct SetXDomainAdmin {
 }
 
 #[event]
+pub struct TransferredOwnership {
+    pub new_owner: Pubkey,
+}
+
+#[event]
 pub struct PausedDeposits {
     pub is_paused: bool,
 }

--- a/programs/svm-spoke/src/instructions/admin.rs
+++ b/programs/svm-spoke/src/instructions/admin.rs
@@ -10,7 +10,7 @@ use crate::{
     error::SvmError,
     event::{
         EmergencyDeletedRootBundle, EnabledDepositRoute, PausedDeposits, PausedFills, RelayedRootBundle,
-        SetXDomainAdmin,
+        SetXDomainAdmin, TransferredOwnership,
     },
     state::{RootBundle, Route, State},
     utils::{initialize_current_time, set_seed},
@@ -98,6 +98,7 @@ pub fn pause_fills(ctx: Context<PauseFills>, pause: bool) -> Result<()> {
     Ok(())
 }
 
+#[event_cpi]
 #[derive(Accounts)]
 pub struct TransferOwnership<'info> {
     #[account(address = state.owner @ SvmError::NotOwner)]
@@ -110,6 +111,8 @@ pub struct TransferOwnership<'info> {
 pub fn transfer_ownership(ctx: Context<TransferOwnership>, new_owner: Pubkey) -> Result<()> {
     let state = &mut ctx.accounts.state;
     state.owner = new_owner;
+
+    emit_cpi!(TransferredOwnership { new_owner });
 
     Ok(())
 }

--- a/test/svm/SvmSpoke.Ownership.ts
+++ b/test/svm/SvmSpoke.Ownership.ts
@@ -124,7 +124,7 @@ describe("svm_spoke.ownership", () => {
 
   it("Transfers ownership", async () => {
     // Transfer ownership to newOwner
-    const transferOwnershipAccounts = { state, signer: owner };
+    const transferOwnershipAccounts = { state, signer: owner, program: program.programId };
     const tx = await program.methods.transferOwnership(newOwner.publicKey).accounts(transferOwnershipAccounts).rpc();
 
     // Verify the TransferredOwnership event
@@ -142,7 +142,7 @@ describe("svm_spoke.ownership", () => {
 
     // Try to transfer ownership as non-owner
     try {
-      const transferOwnershipAccounts = { state, signer: nonOwner.publicKey };
+      const transferOwnershipAccounts = { state, signer: nonOwner.publicKey, program: program.programId };
       await program.methods
         .transferOwnership(nonOwner.publicKey)
         .accounts(transferOwnershipAccounts)

--- a/test/svm/SvmSpoke.Ownership.ts
+++ b/test/svm/SvmSpoke.Ownership.ts
@@ -125,7 +125,16 @@ describe("svm_spoke.ownership", () => {
   it("Transfers ownership", async () => {
     // Transfer ownership to newOwner
     const transferOwnershipAccounts = { state, signer: owner };
-    await program.methods.transferOwnership(newOwner.publicKey).accounts(transferOwnershipAccounts).rpc();
+    const tx = await program.methods.transferOwnership(newOwner.publicKey).accounts(transferOwnershipAccounts).rpc();
+
+    // Verify the TransferredOwnership event
+    let events = await readEventsUntilFound(provider.connection, tx, [program]);
+    let transferredOwnershipEvents = events.filter((event) => event.name === "transferredOwnership");
+    assert.equal(
+      transferredOwnershipEvents[0].data.newOwner.toString(),
+      newOwner.publicKey.toString(),
+      "TransferredOwnership event should indicate the new owner"
+    );
 
     // Verify the new owner
     let stateAccountData = await program.account.state.fetch(state);


### PR DESCRIPTION
Changes proposed in this PR:
Fix the following issue identified by OZ:
```
The [transfer_ownership](https://github.com/across-protocol/contracts/blob/0f2600f83e8a5738d0d62a78b05ff37adda4c1c9/programs/svm-spoke/src/instructions/admin.rs#L110) function does not emit any relevant events after performing sensitive actions.

Consider emitting events after sensitive changes take place to facilitate off-chain tracking and monitoring.
```