### PR TITLE
feat(svm): L-06 Unnecessary Use of InitSpace Macro

### DIFF
--- a/programs/svm-spoke/src/common/v3_relay_data.rs
+++ b/programs/svm-spoke/src/common/v3_relay_data.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct V3RelayData {
     pub depositor: Pubkey,
     pub recipient: Pubkey,
@@ -13,6 +13,5 @@ pub struct V3RelayData {
     pub deposit_id: [u8; 32],
     pub fill_deadline: u32,
     pub exclusivity_deadline: u32,
-    #[max_len(0)]
     pub message: Vec<u8>,
 }

--- a/programs/svm-spoke/src/instructions/bundle.rs
+++ b/programs/svm-spoke/src/instructions/bundle.rs
@@ -65,15 +65,13 @@ pub struct ExecuteRelayerRefundLeaf<'info> {
     pub system_program: Program<'info, System>,
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct RelayerRefundLeaf {
     pub amount_to_return: u64,
     pub chain_id: u64,
-    #[max_len(0)]
     pub refund_amounts: Vec<u64>,
     pub leaf_id: u32,
     pub mint_public_key: Pubkey,
-    #[max_len(0)]
     pub refund_addresses: Vec<Pubkey>,
 }
 

--- a/programs/svm-spoke/src/instructions/slow_fill.rs
+++ b/programs/svm-spoke/src/instructions/slow_fill.rs
@@ -105,7 +105,7 @@ fn unwrap_request_v3_slow_fill_params(
     }
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct V3SlowFill {
     pub relay_data: V3RelayData,
     pub chain_id: u64,

--- a/programs/svm-spoke/src/state/instruction_params.rs
+++ b/programs/svm-spoke/src/state/instruction_params.rs
@@ -3,16 +3,13 @@ use anchor_lang::prelude::*;
 use crate::{RelayerRefundLeaf, V3RelayData, V3SlowFill};
 
 #[account]
-#[derive(InitSpace)]
 pub struct ExecuteRelayerRefundLeafParams {
     pub root_bundle_id: u32,                    // ID of the root bundle to be used.
     pub relayer_refund_leaf: RelayerRefundLeaf, // Leaf to be verified against the proof and instruct bundle execution.
-    #[max_len(0)]
-    pub proof: Vec<[u8; 32]>,  // Proof to verify the leaf's inclusion in relayer refund merkle tree.
+    pub proof: Vec<[u8; 32]>,                   // Proof to verify the leaf's inclusion in relayer refund merkle tree.
 }
 
 #[account]
-#[derive(InitSpace)]
 pub struct FillV3RelayParams {
     pub relay_data: V3RelayData,
     pub repayment_chain_id: u64,
@@ -20,16 +17,13 @@ pub struct FillV3RelayParams {
 }
 
 #[account]
-#[derive(InitSpace)]
 pub struct RequestV3SlowFillParams {
     pub relay_data: V3RelayData,
 }
 
 #[account]
-#[derive(InitSpace)]
 pub struct ExecuteV3SlowRelayLeafParams {
     pub slow_fill_leaf: V3SlowFill,
     pub root_bundle_id: u32,
-    #[max_len(0)]
     pub proof: Vec<[u8; 32]>,
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Fix audit issue:
```
Throughout the codebase, the following structs use the InitSpace macro unnecessarily:

FillV3RelayParams

ExecuteRelayerRefundLeafParams

RequestV3SlowFillParams

ExecuteV3SlowRelayLeafParams

These accounts are initialized using the initialize_instruction_params method, which creates empty accounts with a size specified in the function's instructions. Consequently, the InitSpace macro, which implements the Space trait, becomes redundant as the INIT_SPACE constant generated by this trait is not utilized. The inclusion of the InitSpace macro in these cases adds unnecessary overhead and obscures the intended logic, given that its functionality is not employed.

Consider removing the InitSpace macro from these structs to simplify the codebase and remove superfluous logic. This adjustment would help improve code clarity and align it more closely with actual use patterns.
```