### PR TITLE
fix(svm): L-09 close instruction_params account after execute_relayer_refund_leaf

### DIFF
--- a/programs/svm-spoke/src/instructions/bundle.rs
+++ b/programs/svm-spoke/src/instructions/bundle.rs
@@ -18,7 +18,7 @@ pub struct ExecuteRelayerRefundLeaf<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(seeds = [b"instruction_params", signer.key().as_ref()], bump)]
+    #[account(mut, seeds = [b"instruction_params", signer.key().as_ref()], bump, close = signer)]
     pub instruction_params: Account<'info, ExecuteRelayerRefundLeafParams>, // Contains all leaf & proof information.
 
     #[account(seeds = [b"state", state.seed.to_le_bytes().as_ref()], bump)]

--- a/test/svm/SvmSpoke.Bundle.ts
+++ b/test/svm/SvmSpoke.Bundle.ts
@@ -241,12 +241,22 @@ describe("svm_spoke.bundle", () => {
       program: program.programId,
     };
     const proofAsNumbers = proof.map((p) => Array.from(p));
-    await loadExecuteRelayerRefundLeafParams(program, owner, stateAccountData.rootBundleId, leaf, proofAsNumbers);
+    const instructionParams = await loadExecuteRelayerRefundLeafParams(
+      program,
+      owner,
+      stateAccountData.rootBundleId,
+      leaf,
+      proofAsNumbers
+    );
     const tx = await program.methods
       .executeRelayerRefundLeaf()
       .accounts(executeRelayerRefundLeafAccounts)
       .remainingAccounts(remainingAccounts)
       .rpc();
+
+    // Verify the instruction params account has been automatically closed.
+    const instructionParamsInfo = await program.provider.connection.getAccountInfo(instructionParams);
+    assert.isNull(instructionParamsInfo, "Instruction params account should be closed");
 
     // Verify the ExecutedRelayerRefundRoot event
     let events = await readEventsUntilFound(connection, tx, [program]);


### PR DESCRIPTION
OZ identified following issue:

```
The instruction_params account used in the ExecuteRelayerRefundLeaf instruction remains open after execution,
despite becoming unnecessary once the instruction completes. Leaving the account open leads to resource
inefficiencies. Although a close_instruction_params function can address this issue, it introduces
unnecessary complexity. A more elegant and efficient approach is to leverage Anchor's close attribute to
handle account closure automatically. Unclosed accounts within Solana persist on-chain indefinitely, wasting
storage resources and keeping the lamports from rent locked and unavailable for other operations.

Consider using Anchor's close attribute to ensure that the instruction_params account is automatically
closed, reclaiming resources and simplifying the code.
```

This PR addresses the issue by closing `instruction_params` account at the end of `execute_relayer_refund_leaf` instruction.
