### PR TITLE
fix(svm): N-06 remove unused instruction attribute

### DIFF
--- a/programs/svm-spoke/src/instructions/instruction_params.rs
+++ b/programs/svm-spoke/src/instructions/instruction_params.rs
@@ -22,7 +22,6 @@ pub struct InitializeInstructionParams<'info> {
 }
 
 #[derive(Accounts)]
-#[instruction(offset: u32, fragment: Vec<u8>)]
 pub struct WriteInstructionParamsFragment<'info> {
     pub signer: Signer<'info>,
 


### PR DESCRIPTION
OZ identified following issue:

```
The Accounts derive macro includes an attribute named Instruction that provides access to the instruction’s
arguments within the struct utilizing the macro. However, in the WriteInstructionParamsFragment struct, this
attribute is unnecessary, as neither the offset nor the fragment arguments are used within the struct.

This inclusion may lead to confusion for developers working on the codebase. As such, consider removing the
unused attribute to improve code clarity and maintainability.
```

This PR addresses the issue by removing the unused instruction attribute.