### PR TITLE
feat(svm): N-01 Incomplete or Misleading Comments

### DIFF
--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -310,9 +310,12 @@ pub mod svm_spoke {
         )
     }
 
-    /// Equivalent to deposit_v3 except the deposit_nonce is not used to derive the deposit_id for the depositor. This
-    /// Lets the caller influence the deposit ID to make it deterministic for the depositor. The computed depositID is
-    /// the keccak256 hash of [signer, depositor, deposit_nonce].
+    /// Equivalent to deposit_v3, except that it doesn't use the global `number_of_deposits` counter as the deposit
+    /// nonce. Instead, it allows the caller to pass a `deposit_nonce`. This function is designed for anyone who
+    /// wants to pre-compute their resultant deposit ID, which can be useful for filling a deposit faster and
+    /// avoiding the risk of a deposit ID unexpectedly changing due to another deposit front-running this one and
+    /// incrementing the global deposit ID counter. This enables the caller to influence the deposit ID, making it
+    /// deterministic for the depositor. The computed `depositID` is the keccak256 hash of [signer, depositor, deposit_nonce].
     pub fn unsafe_deposit_v3(
         ctx: Context<DepositV3>,
         depositor: Pubkey,
@@ -486,7 +489,7 @@ pub mod svm_spoke {
     ///           BUNDLE FUNCTIONS           *
     /// *************************************
 
-    /// Executes relayer refund leaf. Only callable by owner.
+    /// Executes relayer refund leaf.
     ///
     /// Processes a relayer refund leaf, verifying its inclusion in a previous Merkle root and that it was not
     /// previously executed. Function has two modes of operation: a) transfers all relayer refunds directly to
@@ -494,7 +497,8 @@ pub mod svm_spoke {
     /// refund. In the happy path, (a) should be used. (b) should only be used if there is a relayer within the bundle
     /// who can't receive the transfer for some reason, such as failed token transfers due to blacklisting. Executing
     /// relayer refunds requires the caller to create a LUT and load the execution params into it. This is needed to
-    /// fit the data in a single instruction. The exact structure and validation of the leaf is defined in the UMIP.
+    /// fit the data in a single instruction. The exact structure and validation of the leaf is defined in the Accross
+    /// UMIP: <https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-179.md>.
     ///
     /// instruction_params Parameters:
     /// - root_bundle_id: The ID of the root bundle containing the relayer refund root.

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -498,7 +498,7 @@ pub mod svm_spoke {
     /// who can't receive the transfer for some reason, such as failed token transfers due to blacklisting. Executing
     /// relayer refunds requires the caller to create a LUT and load the execution params into it. This is needed to
     /// fit the data in a single instruction. The exact structure and validation of the leaf is defined in the Accross
-    /// UMIP: https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-179.md.
+    /// UMIP: https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-179.md
     ///
     /// instruction_params Parameters:
     /// - root_bundle_id: The ID of the root bundle containing the relayer refund root.

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -498,7 +498,7 @@ pub mod svm_spoke {
     /// who can't receive the transfer for some reason, such as failed token transfers due to blacklisting. Executing
     /// relayer refunds requires the caller to create a LUT and load the execution params into it. This is needed to
     /// fit the data in a single instruction. The exact structure and validation of the leaf is defined in the Accross
-    /// UMIP: <https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-179.md>.
+    /// UMIP: https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-179.md.
     ///
     /// instruction_params Parameters:
     /// - root_bundle_id: The ID of the root bundle containing the relayer refund root.


### PR DESCRIPTION
**Changes proposed in this PR:**
- Fixes the following issue identified by Open Zeppelin:

> Throughout the codebase, multiple instances of incomplete or misleading comments were identified:
> This [comment](https://github.com/across-protocol/contracts/blob/0f2600f83e8a5738d0d62a78b05ff37adda4c1c9/programs/svm-spoke/src/lib.rs#L313) above unsafe_deposit_v3 states that the deposit_nonce is not used to derive the deposit_id, whereas [it is](https://github.com/across-protocol/contracts/.blob/0f2600f83e8a5738d0d62a78b05ff37adda4c1c9/programs/svm-spoke/src/instructions/deposit.rs#L229) so used.
> 
> This [comment](https://github.com/across-protocol/contracts/blob/401e24ccca1b3af919dd521e58acd445297b65b6/programs/svm-spoke/src/lib.rs#L489) above execute_relayer_refund_leaf states that it can only be called by the owner, whereas it can be called by anyone. For context, [relay_root_bundle](https://github.com/across-protocol/contracts/blob/401e24ccca1b3af919dd521e58acd445297b65b6/programs/svm-spoke/src/lib.rs#L169) is the admin function where the admin provides the latest root bundles and increments the bundle ID within the program state.
> 
> This [comment](https://github.com/across-protocol/contracts/blob/401e24ccca1b3af919dd521e58acd445297b65b6/programs/svm-spoke/src/lib.rs#L497) above execute_relayer_refund_leaf states that the structure and validation of the leaf are defined in the UMIP, but there is no link or number of the UMIP.

Fixes ACX-3577
