### PR TITLE
fix: use entire message when calculating relay hash for evm chains

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1011,7 +1011,7 @@ abstract contract SpokePool is
 
         V3RelayExecutionParams memory relayExecution = V3RelayExecutionParams({
             relay: relayData,
-            relayHash: _getV3RelayHash(relayData),
+            relayHash: getV3RelayHash(relayData),
             updatedOutputAmount: relayData.outputAmount,
             updatedRecipient: relayData.recipient,
             updatedMessage: relayData.message,
@@ -1059,7 +1059,7 @@ abstract contract SpokePool is
 
         V3RelayExecutionParams memory relayExecution = V3RelayExecutionParams({
             relay: relayData,
-            relayHash: _getV3RelayHash(relayData),
+            relayHash: getV3RelayHash(relayData),
             updatedOutputAmount: updatedOutputAmount,
             updatedRecipient: updatedRecipient,
             updatedMessage: updatedMessage,
@@ -1106,7 +1106,7 @@ abstract contract SpokePool is
         }
         if (relayData.fillDeadline < currentTime) revert ExpiredFillDeadline();
 
-        bytes32 relayHash = _getV3RelayHash(relayData);
+        bytes32 relayHash = getV3RelayHash(relayData);
         if (fillStatuses[relayHash] != uint256(FillStatus.Unfilled)) revert InvalidSlowFillRequest();
         fillStatuses[relayHash] = uint256(FillStatus.RequestedSlowFill);
 
@@ -1195,7 +1195,7 @@ abstract contract SpokePool is
         // deposit params like outputAmount, message and recipient.
         V3RelayExecutionParams memory relayExecution = V3RelayExecutionParams({
             relay: relayData,
-            relayHash: _getV3RelayHash(relayData),
+            relayHash: getV3RelayHash(relayData),
             updatedOutputAmount: slowFillLeaf.updatedOutputAmount,
             updatedRecipient: relayData.recipient,
             updatedMessage: relayData.message,
@@ -1313,6 +1313,10 @@ abstract contract SpokePool is
 
     function getRelayerRefund(address l2TokenAddress, address refundAddress) public view returns (uint256) {
         return relayerRefund[l2TokenAddress][refundAddress];
+    }
+
+    function getV3RelayHash(V3RelayData memory relayData) public view returns (bytes32) {
+        return keccak256(abi.encode(relayData, chainId()));
     }
 
     /**************************************
@@ -1638,10 +1642,6 @@ abstract contract SpokePool is
 
     function _computeAmountPostFees(uint256 amount, int256 feesPct) private pure returns (uint256) {
         return (amount * uint256(int256(1e18) - feesPct)) / 1e18;
-    }
-
-    function _getV3RelayHash(V3RelayData memory relayData) private view returns (bytes32) {
-        return keccak256(abi.encode(relayData, chainId()));
     }
 
     // Unwraps ETH and does a transfer to a recipient address. If the recipient is a smart contract then sends wrappedNativeToken.

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1641,24 +1641,7 @@ abstract contract SpokePool is
     }
 
     function _getV3RelayHash(V3RelayData memory relayData) private view returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(
-                    relayData.depositor,
-                    relayData.recipient,
-                    relayData.exclusiveRelayer,
-                    relayData.inputToken,
-                    relayData.outputToken,
-                    relayData.inputAmount,
-                    relayData.outputAmount,
-                    relayData.originChainId,
-                    relayData.depositId,
-                    relayData.fillDeadline,
-                    relayData.exclusivityDeadline,
-                    _hashNonEmptyMessage(relayData.message),
-                    chainId()
-                )
-            );
+        return keccak256(abi.encode(relayData, chainId()));
     }
 
     // Unwraps ETH and does a transfer to a recipient address. If the recipient is a smart contract then sends wrappedNativeToken.

--- a/test/evm/hardhat/fixtures/SpokePool.Fixture.ts
+++ b/test/evm/hardhat/fixtures/SpokePool.Fixture.ts
@@ -180,39 +180,13 @@ export function getRelayHash(
 }
 
 export function getV3RelayHash(relayData: V3RelayData, destinationChainId: number): string {
-  const messageHash = relayData.message == "0x" ? ethers.constants.HashZero : ethers.utils.keccak256(relayData.message);
   return ethers.utils.keccak256(
     defaultAbiCoder.encode(
       [
-        "bytes32", // depositor
-        "bytes32", // recipient
-        "bytes32", // exclusiveRelayer
-        "bytes32", // inputToken
-        "bytes32", // outputToken
-        "uint256", // inputAmount
-        "uint256", // outputAmount
-        "uint256", // originChainId
-        "uint256", // depositId
-        "uint32", // fillDeadline
-        "uint32", // exclusivityDeadline
-        "bytes32", // messageHash
-        "uint256", // destinationChainId
+        "tuple(bytes32 depositor, bytes32 recipient, bytes32 exclusiveRelayer, bytes32 inputToken, bytes32 outputToken, uint256 inputAmount, uint256 outputAmount, uint256 originChainId, uint256 depositId, uint32 fillDeadline, uint32 exclusivityDeadline, bytes message)",
+        "uint256 destinationChainId",
       ],
-      [
-        relayData.depositor,
-        relayData.recipient,
-        relayData.exclusiveRelayer,
-        relayData.inputToken,
-        relayData.outputToken,
-        relayData.inputAmount,
-        relayData.outputAmount,
-        relayData.originChainId,
-        relayData.depositId,
-        relayData.fillDeadline,
-        relayData.exclusivityDeadline,
-        messageHash,
-        destinationChainId,
-      ]
+      [relayData, destinationChainId]
     )
   );
 }


### PR DESCRIPTION
If we have two separate methods to calculate the relay hash, separated by whether the L2's spoke pool is updated or not, then relayers may produce two valid deposits for the same fill, or even worse, a slow fill may be executed for a deposit which has already been filled. To mitigate this, we should consider not changing the way we calculate relay hashes for evm chains.