### PR TITLE
feat: show how to add integrator ID to a deposit

### DIFF
--- a/scripts/svm/simpleDeposit.ts
+++ b/scripts/svm/simpleDeposit.ts
@@ -153,9 +153,7 @@ async function depositV3(): Promise<void> {
     depositTx.add(MemoIx);
   }
 
-  // const depositTx = new Transaction().add(approveIx, depositIx);
   const tx = await sendAndConfirmTransaction(provider.connection, depositTx, [signer]);
-
   console.log("Transaction signature:", tx);
 }
 

--- a/scripts/svm/simpleDeposit.ts
+++ b/scripts/svm/simpleDeposit.ts
@@ -148,7 +148,7 @@ async function depositV3(): Promise<void> {
     const MemoIx = new TransactionInstruction({
       keys: [{ pubkey: signer.publicKey, isSigner: true, isWritable: true }],
       data: Buffer.from(integratorId, "utf-8"),
-      programId: new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
+      programId: new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"), // Memo program ID
     });
     depositTx.add(MemoIx);
   }


### PR DESCRIPTION
This PR extends the current SimpleDeposit script to show how to use the [solana memo program](https://spl.solana.com/memo) to append a deposit ID.

See example tx that does not have the memo [here](https://explorer.solana.com/tx/kiKk6exRDQg7bqmBnVFXmfTwdoV16grKTm2citdRNYR836s6gxV366tpLXSdxtzHhqDGMHFmEwNpsL5uqkTBRMD?cluster=devnet) and one that has it [here](https://explorer.solana.com/tx/PnPBXiEj62dX7Kuvn3vZ33zhXq7MoXJ5JM5qYoxzyYfkZtEJCCerQbKE9bJCPc6oT6ng1TtdyKcFd8hSMsskd2i?cluster=devnet).