### PR TITLE
ci: fix publish build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "20.x"
           always-auth: true
           registry-url: "https://registry.npmjs.org"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts",
-  "version": "3.0.26-beta.0",
+  "version": "3.0.26-beta.1",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
CI publish fails with
```
error @solana/web3-v2.js@2.0.0: The engine "node" is incompatible with this module. Expected version ">=20.18.0". Got "18.20.6"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```