### PR TITLE
chore: Re-license certain interface files

### DIFF
--- a/contracts/interfaces/HubPoolInterface.sol
+++ b/contracts/interfaces/HubPoolInterface.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/interfaces/LpTokenFactoryInterface.sol
+++ b/contracts/interfaces/LpTokenFactoryInterface.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/interfaces/SpokePoolInterface.sol
+++ b/contracts/interfaces/SpokePoolInterface.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/interfaces/SpokePoolMessageHandler.sol
+++ b/contracts/interfaces/SpokePoolMessageHandler.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 // This interface is expected to be implemented by any contract that expects to receive messages from the SpokePool.

--- a/contracts/interfaces/V3SpokePoolInterface.sol
+++ b/contracts/interfaces/V3SpokePoolInterface.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 // Contains structs and functions used by SpokePool contracts to facilitate universal settlement.


### PR DESCRIPTION
Licensing these as BUSL can create confusion and potential legal ambiguity for third-parties who are simply trying to integrate existing deployments that are operated under the Across protocol.

I optimistically selected MIT because it puts minimal obligations on integrators, but another license might be preferred.