### PR TITLE
feat(svm): Permit historical fillDeadline on deposit

### DIFF
--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -92,7 +92,7 @@ pub fn _deposit_v3(
         return err!(CommonError::InvalidQuoteTimestamp);
     }
 
-    if fill_deadline < current_time || fill_deadline > current_time + state.fill_deadline_buffer {
+    if fill_deadline > current_time + state.fill_deadline_buffer {
         return err!(CommonError::InvalidFillDeadline);
     }
 

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -254,7 +254,7 @@ pub mod svm_spoke {
     /// - quote_timestamp: The HubPool timestamp that is used to determine the system fee paid by the depositor. This
     ///   must be set to some time between [currentTime - depositQuoteTimeBuffer, currentTime].
     /// - fill_deadline: The deadline for the relayer to fill the deposit. After this destination chain timestamp, the
-    ///   fill will revert on the destination chain. Must be set between [currentTime,currentTime+fillDeadlineBuffer].
+    ///   fill will revert on the destination chain. Must be set before currentTime + fillDeadlineBuffer.
     /// - exclusivity_parameter: Sets the exclusivity deadline timestamp for the exclusiveRelayer to fill the deposit.
     ///   1. If 0, no exclusivity period.
     ///   2. If less than MAX_EXCLUSIVITY_PERIOD_SECONDS, adds this value to the current block timestamp.

--- a/test/svm/SvmSpoke.Deposit.ts
+++ b/test/svm/SvmSpoke.Deposit.ts
@@ -322,6 +322,7 @@ describe("svm_spoke.deposit", () => {
     // Fill deadline is too far ahead (longer than fill_deadline_buffer + currentTime)
     const invalidFillDeadline = currentTime + fillDeadlineBuffer.toNumber() + 1; // 1 seconds beyond the buffer
     depositData.fillDeadline = new BN(invalidFillDeadline);
+    depositData.quoteTimestamp = new BN(currentTime);
 
     try {
       const depositDataValues = Object.values(depositData) as DepositDataValues;


### PR DESCRIPTION
Changes proposed in this PR:
- Mimics the changes in https://github.com/across-protocol/contracts/pull/870 in EVM:
```
This removes a sharp edge for pre-fill deposits, where the deposit comes after the fill. Permitting a historical fillDeadline gives more flexibility to the relayer around when they submit the deposit on the origin chain.
```