### PR TITLE
Fix type extension issues, like with `HardhatRuntimeEnvironment`

### DIFF
--- a/tasks/testChainAdapter.ts
+++ b/tasks/testChainAdapter.ts
@@ -20,7 +20,7 @@ task("testChainAdapter", "Verify a chain adapter")
   .setAction(async function (args, hre: HardhatRuntimeEnvironment) {
     const { deployments, ethers, getChainId, network } = hre;
     const provider = new ethers.providers.StaticJsonRpcProvider(network.config.url);
-    const signer = new ethers.Wallet.fromMnemonic(getMnemonic()).connect(provider);
+    const signer = ethers.Wallet.fromMnemonic(getMnemonic()).connect(provider);
 
     const hubChainId = await getChainId();
     const spokeChainId = parseInt(args.chain);

--- a/tasks/testChainAdapter.ts
+++ b/tasks/testChainAdapter.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { getMnemonic } from "@uma/common";
 import { task } from "hardhat/config";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { HardhatRuntimeEnvironment, HttpNetworkConfig } from "hardhat/types";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../utils/constants";
 import { askYesNoQuestion, resolveTokenOnChain } from "./utils";
 
@@ -19,7 +19,7 @@ task("testChainAdapter", "Verify a chain adapter")
   .addParam("amount", "Amount to bridge to the destination chain")
   .setAction(async function (args, hre: HardhatRuntimeEnvironment) {
     const { deployments, ethers, getChainId, network } = hre;
-    const provider = new ethers.providers.StaticJsonRpcProvider(network.config.url);
+    const provider = new ethers.providers.StaticJsonRpcProvider((network.config as any).url);
     const signer = ethers.Wallet.fromMnemonic(getMnemonic()).connect(provider);
 
     const hubChainId = await getChainId();

--- a/tasks/testChainAdapter.ts
+++ b/tasks/testChainAdapter.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { getMnemonic } from "@uma/common";
 import { task } from "hardhat/config";
-import { HardhatRuntimeEnvironment, HttpNetworkConfig } from "hardhat/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../utils/constants";
 import { askYesNoQuestion, resolveTokenOnChain } from "./utils";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "declaration": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "typeRoots": ["./node_modules/@types", "./src/types"]
+    "typeRoots": ["./node_modules/@types", "./src/types", "type-extensions"]
   },
   "include": [
     "./scripts",

--- a/type-extensions/hardhat-extensions.d.ts
+++ b/type-extensions/hardhat-extensions.d.ts
@@ -1,22 +1,2 @@
-import "hardhat/types/runtime";
+import "hardhat-deploy/src/type-extensions.ts";
 import "@nomiclabs/hardhat-ethers";
-import "hardhat-deploy";
-import { DeploymentsExtension } from "hardhat-deploy/dist/types";
-import { HardhatNetworkConfig, HttpNetworkConfig } from "hardhat/types";
-
-declare module "hardhat/types" {
-  interface HardhatNetworkConfig {
-    url?: string;
-  }
-
-  interface HttpNetworkConfig {
-    url: string;
-  }
-}
-
-declare module "hardhat/types/runtime" {
-  interface HardhatRuntimeEnvironment {
-    deployments: DeploymentsExtension;
-    getChainId: () => Promise<string>;
-  }
-}

--- a/type-extensions/hardhat-extensions.d.ts
+++ b/type-extensions/hardhat-extensions.d.ts
@@ -1,0 +1,22 @@
+import "hardhat/types/runtime";
+import "@nomiclabs/hardhat-ethers";
+import "hardhat-deploy";
+import { DeploymentsExtension } from "hardhat-deploy/dist/types";
+import { HardhatNetworkConfig, HttpNetworkConfig } from "hardhat/types";
+
+declare module "hardhat/types" {
+  interface HardhatNetworkConfig {
+    url?: string;
+  }
+
+  interface HttpNetworkConfig {
+    url: string;
+  }
+}
+
+declare module "hardhat/types/runtime" {
+  interface HardhatRuntimeEnvironment {
+    deployments: DeploymentsExtension;
+    getChainId: () => Promise<string>;
+  }
+}


### PR DESCRIPTION
LSP is sad when we don't provide info about type extensions, as a result a lot of our deployment scripts and testing scripts had unpleasant errors reported by VSCode, or LSPs in general, even though the code is fine.

This PR fixes `HardhatRuntimeEnvironment`. Works on my machine, but please test it on yours too