### PR TITLE
fix(ZkSync_SpokePool): Add __gap

### DIFF
--- a/contracts/ZkSync_SpokePool.sol
+++ b/contracts/ZkSync_SpokePool.sol
@@ -121,4 +121,9 @@ contract ZkSync_SpokePool is SpokePool {
     }
 
     function _requireAdminSender() internal override onlyFromCrossDomainAdmin {}
+
+    // Reserve storage slots for future versions of this base contract to add state variables without
+    // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
+    // are added. This is at bottom of contract to make sure it's always at the end of storage.
+    uint256[1000] private __gap;
 }

--- a/storage-layouts/ZkSync_SpokePool.json
+++ b/storage-layouts/ZkSync_SpokePool.json
@@ -167,6 +167,12 @@
       "label": "zkErc20Bridge",
       "offset": 0,
       "slot": "3163"
+    },
+    {
+      "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
+      "label": "__gap",
+      "offset": 0,
+      "slot": "3164"
     }
   ]
 }


### PR DESCRIPTION
This contract gets extended by the Lens_SpokePool which doesn't add any storage but we should add it in case a future variable gets added to the Lens_SpokePool
