### PR TITLE
improve(ERC7683OriginSettler): Specify destinationSettler inside orderData

### DIFF
--- a/contracts/erc7683/AcrossOriginSettler.sol
+++ b/contracts/erc7683/AcrossOriginSettler.sol
@@ -17,16 +17,7 @@ contract AcrossOriginSettler is ERC7683OrderDepositor, Ownable, MultiCaller {
     using SafeERC20 for IERC20;
     using AddressToBytes32 for address;
 
-    event SetDestinationSettler(
-        uint256 indexed chainId,
-        address indexed prevDestinationSettler,
-        address indexed destinationSettler
-    );
-
     SpokePool public immutable SPOKE_POOL;
-
-    // Mapping of chainIds to destination settler addresses.
-    mapping(uint256 => address) public destinationSettlers;
 
     constructor(
         SpokePool _spokePool,
@@ -34,12 +25,6 @@ contract AcrossOriginSettler is ERC7683OrderDepositor, Ownable, MultiCaller {
         uint256 _quoteBeforeDeadline
     ) ERC7683OrderDepositor(_permit2, _quoteBeforeDeadline) {
         SPOKE_POOL = _spokePool;
-    }
-
-    function setDestinationSettler(uint256 chainId, address destinationSettler) external onlyOwner {
-        address prevDestinationSettler = destinationSettlers[chainId];
-        destinationSettlers[chainId] = destinationSettler;
-        emit SetDestinationSettler(chainId, prevDestinationSettler, destinationSettler);
     }
 
     function _callDeposit(
@@ -98,10 +83,5 @@ contract AcrossOriginSettler is ERC7683OrderDepositor, Ownable, MultiCaller {
             depositNonce == 0
                 ? SPOKE_POOL.numberOfDeposits()
                 : SPOKE_POOL.getUnsafeDepositId(address(this), depositor.toBytes32(), depositNonce);
-    }
-
-    function _destinationSettler(uint256 chainId) internal view override returns (address) {
-        if (destinationSettlers[chainId] == address(0)) revert NoDestinationSettlerForChain(chainId);
-        return destinationSettlers[chainId];
     }
 }

--- a/contracts/erc7683/ERC7683OrderDepositor.sol
+++ b/contracts/erc7683/ERC7683OrderDepositor.sol
@@ -244,7 +244,7 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
         relayData.message = acrossOrderData.message;
         fillInstructions[0] = FillInstruction({
             destinationChainId: SafeCast.toUint64(acrossOrderData.destinationChainId),
-            destinationSettler: _destinationSettler(acrossOrderData.destinationChainId).toBytes32(),
+            destinationSettler: acrossOrderData.destinationSettler.toBytes32(),
             originData: abi.encode(relayData)
         });
 
@@ -308,7 +308,7 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
         relayData.message = acrossOrderData.message;
         fillInstructions[0] = FillInstruction({
             destinationChainId: SafeCast.toUint64(acrossOrderData.destinationChainId),
-            destinationSettler: _destinationSettler(acrossOrderData.destinationChainId).toBytes32(),
+            destinationSettler: acrossOrderData.destinationSettler.toBytes32(),
             originData: abi.encode(relayData)
         });
 
@@ -369,6 +369,4 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
         uint32 exclusivityPeriod,
         bytes memory message
     ) internal virtual;
-
-    function _destinationSettler(uint256 chainId) internal view virtual returns (address);
 }

--- a/contracts/erc7683/ERC7683OrderDepositor.sol
+++ b/contracts/erc7683/ERC7683OrderDepositor.sol
@@ -245,7 +245,7 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
         fillInstructions[0] = FillInstruction({
             destinationChainId: SafeCast.toUint64(acrossOrderData.destinationChainId),
             destinationSettler: acrossOrderData.destinationSettler.toBytes32(),
-            originData: abi.encode(relayData)
+            originData: abi.encode(relayData, acrossOrderData.destinationSettler)
         });
 
         resolvedOrder = ResolvedCrossChainOrder({
@@ -256,7 +256,9 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
             minReceived: minReceived,
             maxSpent: maxSpent,
             fillInstructions: fillInstructions,
-            orderId: keccak256(abi.encode(relayData, acrossOrderData.destinationChainId))
+            orderId: keccak256(
+                abi.encode(relayData, acrossOrderData.destinationSettler, acrossOrderData.destinationChainId)
+            )
         });
     }
 
@@ -309,7 +311,7 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
         fillInstructions[0] = FillInstruction({
             destinationChainId: SafeCast.toUint64(acrossOrderData.destinationChainId),
             destinationSettler: acrossOrderData.destinationSettler.toBytes32(),
-            originData: abi.encode(relayData)
+            originData: abi.encode(relayData, acrossOrderData.destinationSettler)
         });
 
         resolvedOrder = ResolvedCrossChainOrder({
@@ -320,7 +322,9 @@ abstract contract ERC7683OrderDepositor is IOriginSettler {
             minReceived: minReceived,
             maxSpent: maxSpent,
             fillInstructions: fillInstructions,
-            orderId: keccak256(abi.encode(relayData, acrossOrderData.destinationChainId))
+            orderId: keccak256(
+                abi.encode(relayData, acrossOrderData.destinationSettler, acrossOrderData.destinationChainId)
+            )
         });
     }
 

--- a/contracts/erc7683/ERC7683Permit2Lib.sol
+++ b/contracts/erc7683/ERC7683Permit2Lib.sol
@@ -13,6 +13,7 @@ struct AcrossOrderData {
     uint256 destinationChainId;
     bytes32 recipient;
     address exclusiveRelayer;
+    address destinationSettler;
     uint256 depositNonce;
     uint32 exclusivityPeriod;
     bytes message;
@@ -34,7 +35,8 @@ bytes constant ACROSS_ORDER_DATA_TYPE = abi.encodePacked(
     "uint256 outputAmount,",
     "uint256 destinationChainId,",
     "bytes32 recipient,",
-    "address exclusiveRelayer,"
+    "address exclusiveRelayer,",
+    "address destinationSettler,",
     "uint256 depositNonce,",
     "uint32 exclusivityPeriod,",
     "bytes message)"
@@ -106,6 +108,7 @@ library ERC7683Permit2Lib {
                     orderData.destinationChainId,
                     orderData.recipient,
                     orderData.exclusiveRelayer,
+                    orderData.destinationSettler,
                     orderData.exclusivityPeriod,
                     keccak256(orderData.message)
                 )

--- a/contracts/interfaces/V3SpokePoolInterface.sol
+++ b/contracts/interfaces/V3SpokePoolInterface.sol
@@ -339,6 +339,7 @@ interface V3SpokePoolInterface {
     error ClaimedMerkleLeaf();
     error InvalidPayoutAdjustmentPct();
     error WrongERC7683OrderId();
+    error InvalidDestinationSettler();
     error LowLevelCallFailed(bytes data);
     error InsufficientSpokePoolBalanceToExecuteLeaf();
     error NoRelayerRefundToClaim();


### PR DESCRIPTION
This way the OriginSettler doesn't need to store known DestinationSettler addresses.

Currently, the only way for the OriginSettler to produce a valid `FundsDeposited` event is if the user-specified `destinationSettler` is whitelisted on the origin settler. 