### PR TITLE
fix: Temporarily disable bridging Linea USDC.e

### DIFF
--- a/contracts/Linea_SpokePool.sol
+++ b/contracts/Linea_SpokePool.sol
@@ -153,11 +153,8 @@ contract Linea_SpokePool is SpokePool {
             WETH9Interface(l2TokenAddress).withdraw(amountToReturn + msg.value); // Unwrap into ETH.
             l2MessageService.sendMessage{ value: amountToReturn + msg.value }(withdrawalRecipient, msg.value, "");
         }
-        // If the l1Token is USDC, then we need sent it via the USDC Bridge.
-        else if (l2TokenAddress == l2UsdcBridge.usdc()) {
-            IERC20(l2TokenAddress).safeIncreaseAllowance(address(l2UsdcBridge), amountToReturn);
-            l2UsdcBridge.depositTo{ value: msg.value }(amountToReturn, withdrawalRecipient);
-        }
+        // If the l1Token is USDC, do nothing for the time being, pending Linea's CCTP upgrade.
+        else if (l2TokenAddress == l2UsdcBridge.usdc()) {}
         // For other tokens, we can use the Canonical Token Bridge.
         else {
             IERC20(l2TokenAddress).safeIncreaseAllowance(address(l2TokenBridge), amountToReturn);

--- a/test/evm/hardhat/chain-specific-spokepools/Linea_SpokePool.ts
+++ b/test/evm/hardhat/chain-specific-spokepools/Linea_SpokePool.ts
@@ -205,7 +205,7 @@ describe("Linea Spoke Pool", function () {
     // This should have sent tokens back to L1. Check the correct methods on the gateway are correctly called.
     expect(lineaTokenBridge.bridgeToken).to.have.been.calledWith(dai.address, amountToReturn, hubPool.address);
   });
-  it("Bridge USDC to hub pool correctly calls the L2 USDC Bridge", async function () {
+  it.skip("Bridge USDC to hub pool correctly calls the L2 USDC Bridge", async function () {
     const { leaves, tree } = await constructSingleRelayerRefundTree(
       usdc.address,
       await lineaSpokePool.callStatic.chainId()


### PR DESCRIPTION
nb. This change is probably not wanted in the context of Linea USDC; I prepared it just in case.

This will skip the Linea USDC.e bridge. Any tokens that were intended to be bridged will instead remain in the Linea SpokePool as a phantom surplus. Admin action will be required to pull them back subsequently.

At present this would amount to a single withdrawal of 76248674049 units of USDC.e, corresponding to Linea rootBundleId 6658, leaf 29, relayerRefundRoot
0x624cb9ba1ea2a22ae01abc472764da9e5726cdbc0bffe719168d9dcd4f780ce5.