### PR TITLE
improve: type extension recognition for `HardhatRuntimeEnvironment`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,9 @@
     "./test-utils.ts",
     "tasks/enableL1TokenAcrossEcosystem.ts",
     "utils/utils.ts",
-    "src/types"
+    "src/types",
+    "tasks",
+    "deploy"
   ],
   "files": ["./hardhat.config.ts"]
 }


### PR DESCRIPTION
### Problem: 
<img width="497" alt="squigglies" src="https://github.com/user-attachments/assets/697c2ce9-8b48-4ad2-b0a1-acdd712f4f68" />

`deployments, ethers, getChainId` don't get recognized by Typescript language server and give red squigglies, which makes hre hard to work with. This happens in multiple places in the contracts repo.

### Solution:

Add `tasks/` and `deploy/` to `include` section in `tsconfig.json`. https://www.typescriptlang.org/tsconfig/#include

It makes the language server "include" these folders and resolve types properly for them. This shouldn't have any side effects. The only one I can guess is npm package, which should be fixable by `.npmignore`. But I checked the `yarn pack` output, and the `tasks/` and `deploy/` folders stayed similar to our current [npm package](https://www.npmjs.com/package/@across-protocol/contracts?activeTab=code). 


Edit: after looking at CI output, I realize that I'd have to fix a lot of TS linter errors before this can go in. Do you guys think it's worth doing? 😄 