### PR TITLE
chore: add OFT and xERC20 interface files for typechain generation

### DIFF
--- a/contracts/interfaces/IHypXERC20Router.sol
+++ b/contracts/interfaces/IHypXERC20Router.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+/**
+ * @notice Interface for interfacing with Hyperlane's xERC20 messaging
+ */
+interface IHypXERC20Router {
+    /**
+     * @notice Retuns the underlying token available for bridging
+     */
+    function wrappedToken() external view returns (address);
+
+    /**
+     * @notice Returns the gas payment required to dispatch a message to the given domain's router.
+     * @param _destinationDomain The domain of the router.
+     * @return _gasPayment Payment computed by the registered InterchainGasPaymaster.
+     */
+    function quoteGasPayment(uint32 _destinationDomain) external view returns (uint256);
+
+    /**
+     * @notice Transfers `_amountOrId` token to `_recipient` on `_destination` domain.
+     * @dev Delegates transfer logic to `_transferFromSender` implementation.
+     * @dev Emits `SentTransferRemote` event on the origin chain.
+     * @param _destination The identifier of the destination chain.
+     * @param _recipient The address of the recipient on the destination chain.
+     * @param _amountOrId The amount or identifier of tokens to be sent to the remote recipient.
+     * @return messageId The identifier of the dispatched message.
+     */
+    function transferRemote(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _amountOrId
+    ) external payable returns (bytes32 messageId);
+}

--- a/contracts/interfaces/IOFT.sol
+++ b/contracts/interfaces/IOFT.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+/**
+ * @notice This file contains minimal copies of relevant structs / interfaces for OFT bridging. Source code link:
+ * https://github.com/LayerZero-Labs/LayerZero-v2/blob/9a4049ae3a374e1c0ef01ac9fb53dd83f4257a68/packages/layerzero-v2/evm/oapp/contracts/oft/interfaces/IOFT.sol
+ * It's also published as a part of an npm package: @layerzerolabs/oft-evm. The published code is incompatible with
+ * our compiler version requirements, so we copy it here instead
+ */
+
+struct MessagingReceipt {
+    bytes32 guid;
+    uint64 nonce;
+    MessagingFee fee;
+}
+
+struct MessagingFee {
+    uint256 nativeFee;
+    uint256 lzTokenFee;
+}
+
+/**
+ * @dev Struct representing token parameters for the OFT send() operation.
+ */
+struct SendParam {
+    uint32 dstEid; // Destination endpoint ID.
+    bytes32 to; // Recipient address.
+    uint256 amountLD; // Amount to send in local decimals.
+    uint256 minAmountLD; // Minimum amount to send in local decimals.
+    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.
+    bytes composeMsg; // The composed message for the send() operation.
+    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.
+}
+
+/**
+ * @dev Struct representing OFT receipt information.
+ */
+struct OFTReceipt {
+    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.
+    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.
+    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.
+}
+
+/**
+ * @title IOFT
+ * @dev Interface for the OftChain (OFT) token.
+ * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.
+ * @dev This specific interface ID is '0x02e49c2c'.
+ */
+interface IOFT {
+    /**
+     * @notice Retrieves the address of the token associated with the OFT.
+     * @return token The address of the ERC20 token implementation.
+     */
+    function token() external view returns (address);
+
+    /**
+     * @notice Provides a quote for the send() operation.
+     * @param _sendParam The parameters for the send() operation.
+     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.
+     * @return fee The calculated LayerZero messaging fee from the send() operation.
+     *
+     * @dev MessagingFee: LayerZero msg fee
+     *  - nativeFee: The native fee.
+     *  - lzTokenFee: The lzToken fee.
+     */
+    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);
+
+    /**
+     * @notice Executes the send() operation.
+     * @param _sendParam The parameters for the send operation.
+     * @param _fee The fee information supplied by the caller.
+     *      - nativeFee: The native fee.
+     *      - lzTokenFee: The lzToken fee.
+     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.
+     * @return receipt The LayerZero messaging receipt from the send() operation.
+     * @return oftReceipt The OFT receipt information.
+     *
+     * @dev MessagingReceipt: LayerZero msg receipt
+     *  - guid: The unique identifier for the sent message.
+     *  - nonce: The nonce of the sent message.
+     *  - fee: The LayerZero fee incurred for the message.
+     */
+    function send(
+        SendParam calldata _sendParam,
+        MessagingFee calldata _fee,
+        address _refundAddress
+    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);
+}


### PR DESCRIPTION
Bring in some external interfaces from upcoming OFT + xERC20 update. Exact copies from [audit branch](https://github.com/across-protocol/contracts/tree/march-25-evm-audit). These are nice to have in the `relayer` repo for typechain.