### PR TITLE
chore: Tweak Solana SpokePool name in deployments

### DIFF
--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -196,7 +196,7 @@
     "MulticallHandler": { "address": "0xAC537C12fE8f544D712d71ED4376a502EEa944d7", "blockNumber": 3179705 }
   },
   "133268194659241": {
-    "SvmSpoke": {
+    "SpokePool": {
       "address": "JAZWcGrpSWNPTBj8QtJ9UyQqhJCDhG9GJkDeMf5NQBiq",
       "blockNumber": 356313770
     },
@@ -214,7 +214,7 @@
     }
   },
   "34268394551451": {
-    "SvmSpoke": {
+    "SpokePool": {
       "address": "JAZWcGrpSWNPTBj8QtJ9UyQqhJCDhG9GJkDeMf5NQBiq",
       "blockNumber": 317101505
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
Avoid the name "SvmSpoke" because it references the architecture, not the chain itself. Revert to "SpokePool", since that's consistent with all other chains.