### PR TITLE
L-01 Custom Gas Tokens Can Get Stuck In `HubPool`

### DIFF
--- a/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol
+++ b/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol
@@ -181,6 +181,13 @@ contract ZkStack_CustomGasToken_Adapter is AdapterInterface, CircleCCTPAdapter {
         uint256 amount,
         address to
     ) external payable override {
+        // The Hub Pool will always bridge via CCTP to a ZkStack network if CCTP is enabled for that network. Therefore, we can short-circuit ZkStack-specific logic
+        // like pulling custom gas or getting the shared bridge address if CCTP is enabled and we are bridging USDC.
+        if (l1Token == address(usdcToken) && _isCCTPEnabled()) {
+            _transferUsdc(to, amount);
+            emit TokensRelayed(l1Token, l2Token, amount, to);
+            return;
+        }
         // A bypass proxy seems to no longer be needed to avoid deposit limits. The tracking of these limits seems to be deprecated.
         // See: https://github.com/matter-labs/era-contracts/blob/bce4b2d0f34bd87f1aaadd291772935afb1c3bd6/l1-contracts/contracts/bridge/L1ERC20Bridge.sol#L54-L55
         uint256 txBaseCost = _pullCustomGas(L2_GAS_LIMIT);
@@ -224,25 +231,22 @@ contract ZkStack_CustomGasToken_Adapter is AdapterInterface, CircleCCTPAdapter {
                 })
             );
         } else if (l1Token == address(usdcToken)) {
-            if (_isCCTPEnabled()) {
-                _transferUsdc(to, amount);
-            } else {
-                IERC20(CUSTOM_GAS_TOKEN).forceApprove(USDC_SHARED_BRIDGE, txBaseCost);
-                IERC20(l1Token).forceApprove(USDC_SHARED_BRIDGE, amount);
-                txHash = BRIDGE_HUB.requestL2TransactionTwoBridges(
-                    BridgeHubInterface.L2TransactionRequestTwoBridgesOuter({
-                        chainId: CHAIN_ID,
-                        mintValue: txBaseCost,
-                        l2Value: 0,
-                        l2GasLimit: L2_GAS_LIMIT,
-                        l2GasPerPubdataByteLimit: L1_GAS_TO_L2_GAS_PER_PUB_DATA_LIMIT,
-                        refundRecipient: L2_REFUND_ADDRESS,
-                        secondBridgeAddress: USDC_SHARED_BRIDGE,
-                        secondBridgeValue: 0,
-                        secondBridgeCalldata: _secondBridgeCalldata(to, l1Token, amount)
-                    })
-                );
-            }
+            // Since we already checked if we are bridging USDC via CCTP, if this conditional is hit, then we must be bridging USDC via the `USDC_SHARED_BRIDGE`.
+            IERC20(CUSTOM_GAS_TOKEN).forceApprove(USDC_SHARED_BRIDGE, txBaseCost);
+            IERC20(l1Token).forceApprove(USDC_SHARED_BRIDGE, amount);
+            txHash = BRIDGE_HUB.requestL2TransactionTwoBridges(
+                BridgeHubInterface.L2TransactionRequestTwoBridgesOuter({
+                    chainId: CHAIN_ID,
+                    mintValue: txBaseCost,
+                    l2Value: 0,
+                    l2GasLimit: L2_GAS_LIMIT,
+                    l2GasPerPubdataByteLimit: L1_GAS_TO_L2_GAS_PER_PUB_DATA_LIMIT,
+                    refundRecipient: L2_REFUND_ADDRESS,
+                    secondBridgeAddress: USDC_SHARED_BRIDGE,
+                    secondBridgeValue: 0,
+                    secondBridgeCalldata: _secondBridgeCalldata(to, l1Token, amount)
+                })
+            );
         } else {
             // An ERC20 that is not WETH and not the custom gas token.
             IERC20(CUSTOM_GAS_TOKEN).forceApprove(sharedBridge, txBaseCost);


### PR DESCRIPTION
> The ZkStack_CustomGasToken_Adapter contract is used to send messages from L1 to ZK Stack-based chains with a custom gas token. The public functions within this contract are expected to be called via delegatecall, which will execute this contract's logic within the context of the originating contract. Particularly, the HubPool will [delegatecall](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/HubPool.sol#L901-L909) the [relayTokens function](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol#L178). This relayTokens function is used to bridge tokens to a ZK Stack chain. This function calls _pullCustomGas to define txBaseCost on [line 186](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol#L186) to compute the amount of gas tokens needed and, more importantly, [pulls the needed gas token amount](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol#L299) from the funder.

> However, in the case when bridging using the [CCTP bridge](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol#L226-L228), the custom gas token is not needed, and thus the pulled tokens will end up stuck in the HubPool.

> This issue can be generalized to other computations as well. For instance, the [sharedBridge](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol#L187C17-L187C29) should only be defined when l1Token is different than usdcToken in ZkStack_CustomGasToken_Adapter, and [txBaseCost](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_Adapter.sol#L162) should not be computed when using the CCTP bridge in ZkStack_Adapter.

> Consider only pulling custom gas tokens within the relayTokens function when they are needed. More generally, consider avoiding unnecessary computation to define variables that will be used later to reduce gas costs.

The proposed solution is to first check if we are bridging USDC and CCTP is enabled and short-circuit the `relayTokens` call if this is the case, and otherwise fall back to our "happy path" of pulling the custom gas token and interfacing with the bridge hub.