### PR TITLE
N-02 Relay Tokens From L1 Emits Empty Transaction Hash When Relaying USDC through CCTP

### DIFF
--- a/contracts/chain-adapters/ZkStack_Adapter.sol
+++ b/contracts/chain-adapters/ZkStack_Adapter.sol
@@ -58,8 +58,6 @@ contract ZkStack_Adapter is AdapterInterface, CircleCCTPAdapter {
     // when calling a hub pool message relay, which would otherwise cause a large amount of ETH to be sent to L2.
     uint256 private immutable MAX_TX_GASPRICE;
 
-    event ZkStackMessageRelayed(bytes32 indexed canonicalTxHash);
-
     error ETHGasTokenRequired();
     error TransactionFeeTooHigh();
     error InvalidBridgeConfig();
@@ -140,7 +138,6 @@ contract ZkStack_Adapter is AdapterInterface, CircleCCTPAdapter {
         );
 
         emit MessageRelayed(target, message);
-        emit ZkStackMessageRelayed(canonicalTxHash);
     }
 
     /**
@@ -219,7 +216,6 @@ contract ZkStack_Adapter is AdapterInterface, CircleCCTPAdapter {
         }
 
         emit TokensRelayed(l1Token, l2Token, amount, to);
-        emit ZkStackMessageRelayed(txHash);
     }
 
     /**

--- a/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol
+++ b/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol
@@ -79,7 +79,6 @@ contract ZkStack_CustomGasToken_Adapter is AdapterInterface, CircleCCTPAdapter {
     // when calling a hub pool message relay, which would otherwise cause a large amount of the custom gas token to be sent to L2.
     uint256 private immutable MAX_TX_GASPRICE;
 
-    event ZkStackMessageRelayed(bytes32 indexed canonicalTxHash);
     error ETHGasTokenNotAllowed();
     error TransactionFeeTooHigh();
     error InvalidBridgeConfig();
@@ -164,7 +163,6 @@ contract ZkStack_CustomGasToken_Adapter is AdapterInterface, CircleCCTPAdapter {
         );
 
         emit MessageRelayed(target, message);
-        emit ZkStackMessageRelayed(canonicalTxHash);
     }
 
     /**
@@ -263,7 +261,6 @@ contract ZkStack_CustomGasToken_Adapter is AdapterInterface, CircleCCTPAdapter {
         }
 
         emit TokensRelayed(l1Token, l2Token, amount, to);
-        emit ZkStackMessageRelayed(txHash);
     }
 
     /**

--- a/test/evm/foundry/local/ZkStack_Adapter.t.sol
+++ b/test/evm/foundry/local/ZkStack_Adapter.t.sol
@@ -11,6 +11,7 @@ import { FinderInterface } from "@uma/core/contracts/data-verification-mechanism
 
 import { ZkStack_Adapter } from "../../../../contracts/chain-adapters/ZkStack_Adapter.sol";
 import { ZkStack_CustomGasToken_Adapter, FunderInterface } from "../../../../contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol";
+import { AdapterInterface } from "../../../../contracts/chain-adapters/interfaces/AdapterInterface.sol";
 import { WETH9Interface } from "../../../../contracts/external/interfaces/WETH9Interface.sol";
 import { WETH9 } from "../../../../contracts/external/WETH9.sol";
 import { MockBridgeHub, BridgeHubInterface } from "../../../../contracts/test/MockZkStackBridgeHub.sol";
@@ -197,7 +198,7 @@ contract ZkStackAdapterTest is Test {
             )
         );
         vm.expectEmit(address(zksAdapter));
-        emit ZkStack_Adapter.ZkStackMessageRelayed(expectedTxnHash);
+        emit AdapterInterface.MessageRelayed(target, message);
         zksAdapter.relayMessage{ value: baseCost }(target, message);
     }
 
@@ -228,7 +229,7 @@ contract ZkStackAdapterTest is Test {
         );
 
         vm.expectEmit(address(zksAdapter));
-        emit ZkStack_Adapter.ZkStackMessageRelayed(expectedTxnHash);
+        emit AdapterInterface.TokensRelayed(address(l1Weth), address(l2Weth), amountToSend, random);
         zksAdapter.relayTokens{ value: baseCost }(address(l1Weth), address(l2Weth), amountToSend, random);
         vm.stopPrank();
     }
@@ -254,7 +255,7 @@ contract ZkStackAdapterTest is Test {
         );
 
         vm.expectEmit(address(zksAdapter));
-        emit ZkStack_Adapter.ZkStackMessageRelayed(expectedTxnHash);
+        emit AdapterInterface.TokensRelayed(address(l1Usdc), address(l2Usdc), amountToSend, random);
         zksAdapter.relayTokens{ value: baseCost }(address(l1Usdc), address(l2Usdc), amountToSend, random);
     }
 
@@ -279,7 +280,7 @@ contract ZkStackAdapterTest is Test {
         );
 
         vm.expectEmit(address(zksAdapter));
-        emit ZkStack_Adapter.ZkStackMessageRelayed(expectedTxnHash);
+        emit AdapterInterface.TokensRelayed(address(l1Token), address(l2Token), amountToSend, random);
         zksAdapter.relayTokens{ value: baseCost }(address(l1Token), address(l2Token), amountToSend, random);
     }
 
@@ -305,7 +306,7 @@ contract ZkStackAdapterTest is Test {
             )
         );
         vm.expectEmit(address(zksCustomGasAdapter));
-        emit ZkStack_CustomGasToken_Adapter.ZkStackMessageRelayed(expectedTxnHash);
+        emit AdapterInterface.MessageRelayed(target, message);
         zksCustomGasAdapter.relayMessage(target, message);
         // Approve only the amount of the fee of the custom gas token. Since we don't actually transferFrom, the approval should stand.
         assertEq(l1CustomGasToken.allowance(address(zksCustomGasAdapter), sharedBridge), baseCost);
@@ -337,7 +338,7 @@ contract ZkStackAdapterTest is Test {
         );
 
         vm.expectEmit(address(zksCustomGasAdapter));
-        emit ZkStack_CustomGasToken_Adapter.ZkStackMessageRelayed(expectedTxnHash);
+        emit AdapterInterface.TokensRelayed(address(l1Weth), address(l2Weth), amountToSend, random);
         zksCustomGasAdapter.relayTokens(address(l1Weth), address(l2Weth), amountToSend, random);
         vm.stopPrank();
         // Approve only the amount of the fee of the custom gas token. Since we don't actually transferFrom, the approval should stand.
@@ -364,7 +365,7 @@ contract ZkStackAdapterTest is Test {
         );
 
         vm.expectEmit(address(zksCustomGasAdapter));
-        emit ZkStack_CustomGasToken_Adapter.ZkStackMessageRelayed(expectedTxnHash);
+        emit AdapterInterface.TokensRelayed(address(l1Usdc), address(l2Usdc), amountToSend, random);
         zksCustomGasAdapter.relayTokens(address(l1Usdc), address(l2Usdc), amountToSend, random);
         // Approve only the amount of the fee of the custom gas token. Since we don't actually transferFrom, the approval should stand.
         assertEq(l1CustomGasToken.allowance(address(zksCustomGasAdapter), usdcSharedBridge), baseCost);
@@ -391,7 +392,7 @@ contract ZkStackAdapterTest is Test {
         );
 
         vm.expectEmit(address(zksCustomGasAdapter));
-        emit ZkStack_CustomGasToken_Adapter.ZkStackMessageRelayed(expectedTxnHash);
+        emit AdapterInterface.TokensRelayed(address(l1Token), address(l2Token), amountToSend, random);
         zksCustomGasAdapter.relayTokens(address(l1Token), address(l2Token), amountToSend, random);
         // Approve only the amount of the fee of the custom gas token. Since we don't actually transferFrom, the approval should stand.
         assertEq(l1CustomGasToken.allowance(address(zksCustomGasAdapter), sharedBridge), baseCost);
@@ -417,7 +418,7 @@ contract ZkStackAdapterTest is Test {
             )
         );
         vm.expectEmit(address(zksCustomGasAdapter));
-        emit ZkStack_CustomGasToken_Adapter.ZkStackMessageRelayed(expectedTxnHash);
+        emit AdapterInterface.TokensRelayed(address(l1CustomGasToken), address(l2CustomGasToken), amountToSend, random);
         zksCustomGasAdapter.relayTokens(address(l1CustomGasToken), address(l2CustomGasToken), amountToSend, random);
 
         // Approve only the amount of the fee of the custom gas token. Since we don't actually transferFrom, the approval should stand.


### PR DESCRIPTION
> The relayTokens functions [[1]](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_Adapter.sol#L154) [[2]](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol#L178) are used to bridge tokens from L1 to ZK Stack. Both instances define a txHash variable [[1]](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_Adapter.sol#L164) [[2]](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol#L189) which will later be assigned to the transaction hash value returned by the BRIDGE_HUB when initiating a bridging transaction. However, in both cases [[1]](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_Adapter.sol#L182-L185) [[2]](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol#L226-L228) when CCTP is enabled, the _transferUsdc function is used, bypassing the BRIDGE_HUB. This function does not return a transaction hash, however, causing the relayTokens functions to emit an empty ZkStackMessageRelayed event [[1]](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_Adapter.sol#L222) [[2]](https://github.com/across-protocol/contracts/blob/77761d74152e319e6edd6d4d766cb46c39e6f38d/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol#L266). This behavior can be confusing for users, especially when trying to index the event based on the emitted hash.

> In case no off-chain components rely on the emitted event, consider removing the emitted event to avoid confusion. Otherwise, consider adding thorough documentation for the ZkStackMessageRelayed event, outlining its expected behavior.

I don't believe we use `ZkStackMessageRelayed` anywhere off-chain, so I agree with the suggestion to remove it if it is unnecessary. 