### PR TITLE
chore(ZkStack_Adapter): Remove unused canonicalTxHash

### DIFF
--- a/contracts/chain-adapters/ZkStack_Adapter.sol
+++ b/contracts/chain-adapters/ZkStack_Adapter.sol
@@ -123,8 +123,7 @@ contract ZkStack_Adapter is AdapterInterface, CircleCCTPAdapter {
     function relayMessage(address target, bytes memory message) external payable override {
         uint256 txBaseCost = _computeETHTxCost(L2_GAS_LIMIT);
 
-        // Returns the hash of the requested L2 transaction. This hash can be used to follow the transaction status.
-        bytes32 canonicalTxHash = BRIDGE_HUB.requestL2TransactionDirect{ value: txBaseCost }(
+        BRIDGE_HUB.requestL2TransactionDirect{ value: txBaseCost }(
             BridgeHubInterface.L2TransactionRequestDirect({
                 chainId: CHAIN_ID,
                 mintValue: txBaseCost,

--- a/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol
+++ b/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol
@@ -148,8 +148,7 @@ contract ZkStack_CustomGasToken_Adapter is AdapterInterface, CircleCCTPAdapter {
         uint256 txBaseCost = _pullCustomGas(L2_GAS_LIMIT);
         IERC20(CUSTOM_GAS_TOKEN).forceApprove(BRIDGE_HUB.sharedBridge(), txBaseCost);
 
-        // Returns the hash of the requested L2 transaction. This hash can be used to follow the transaction status.
-        bytes32 canonicalTxHash = BRIDGE_HUB.requestL2TransactionDirect(
+        BRIDGE_HUB.requestL2TransactionDirect(
             BridgeHubInterface.L2TransactionRequestDirect({
                 chainId: CHAIN_ID,
                 mintValue: txBaseCost,


### PR DESCRIPTION
This variable is no longer used. Removing it addresses a warning being emitted by solc.

```
Warning: Unused local variable.
   --> contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol:152:9:
    |
152 |         bytes32 canonicalTxHash = BRIDGE_HUB.requestL2TransactionDirect(
    |         ^^^^^^^^^^^^^^^^^^^^^^^
```