### PR TITLE
feat: optionally adjust output amount by swap price improvement over min

### DIFF
--- a/contracts/SpokePoolV3Periphery.sol
+++ b/contracts/SpokePoolV3Periphery.sol
@@ -142,11 +142,9 @@ contract SpokePoolV3Periphery is SpokePoolV3PeripheryInterface, Lockable, MultiC
         uint256 acrossOutputAmount
     );
 
-    /**
-     *
+    /****************************************
      *                ERRORS                *
-     *
-     */
+     ****************************************/
     error InvalidPermit2();
     error ContractInitialized();
     error InvalidSignatureLength();

--- a/contracts/SpokePoolV3Periphery.sol
+++ b/contracts/SpokePoolV3Periphery.sol
@@ -641,9 +641,12 @@ contract SpokePoolV3Periphery is SpokePoolV3PeripheryInterface, Lockable, MultiC
         // that we weren't partial filled).
         if (srcBalanceBefore - _swapToken.balanceOf(address(this)) != _swapTokenAmount) revert LeftoverSrcTokens();
 
-        // Calculate adjusted output amount proportionally when we receive more than expected
+        // Calculate adjusted output amount proportionally when we receive more than expected and adjustment is enabled
         uint256 adjustedOutputAmount = swapAndDepositData.depositData.outputAmount;
-        if (returnAmount > swapAndDepositData.minExpectedInputTokenAmount) {
+        if (
+            returnAmount > swapAndDepositData.minExpectedInputTokenAmount &&
+            swapAndDepositData.enableProportionalAdjustment
+        ) {
             adjustedOutputAmount =
                 (swapAndDepositData.depositData.outputAmount * returnAmount) /
                 swapAndDepositData.minExpectedInputTokenAmount;

--- a/contracts/SpokePoolV3Periphery.sol
+++ b/contracts/SpokePoolV3Periphery.sol
@@ -142,9 +142,11 @@ contract SpokePoolV3Periphery is SpokePoolV3PeripheryInterface, Lockable, MultiC
         uint256 acrossOutputAmount
     );
 
-    /****************************************
+    /**
+     *
      *                ERRORS                *
-     ****************************************/
+     *
+     */
     error InvalidPermit2();
     error ContractInitialized();
     error InvalidSignatureLength();
@@ -533,8 +535,9 @@ contract SpokePoolV3Periphery is SpokePoolV3PeripheryInterface, Lockable, MultiC
         bytes32 typedDataHash,
         bytes calldata signature
     ) private view {
-        if (!SignatureChecker.isValidSignatureNow(signatureOwner, _hashTypedDataV4(typedDataHash), signature))
+        if (!SignatureChecker.isValidSignatureNow(signatureOwner, _hashTypedDataV4(typedDataHash), signature)) {
             revert InvalidSignature();
+        }
     }
 
     /**
@@ -602,9 +605,11 @@ contract SpokePoolV3Periphery is SpokePoolV3PeripheryInterface, Lockable, MultiC
 
         // The exchange will either receive funds from this contract via a direct transfer, an approval to spend funds on this contract, or via an
         // EIP1271 permit2 signature.
-        if (_transferType == TransferType.Approval) _swapToken.forceApprove(_exchange, _swapTokenAmount);
-        else if (_transferType == TransferType.Transfer) _swapToken.transfer(_exchange, _swapTokenAmount);
-        else {
+        if (_transferType == TransferType.Approval) {
+            _swapToken.forceApprove(_exchange, _swapTokenAmount);
+        } else if (_transferType == TransferType.Transfer) {
+            _swapToken.transfer(_exchange, _swapTokenAmount);
+        } else {
             _swapToken.forceApprove(address(permit2), _swapTokenAmount);
             expectingPermit2Callback = true;
             permit2.permit(
@@ -636,6 +641,14 @@ contract SpokePoolV3Periphery is SpokePoolV3PeripheryInterface, Lockable, MultiC
         // that we weren't partial filled).
         if (srcBalanceBefore - _swapToken.balanceOf(address(this)) != _swapTokenAmount) revert LeftoverSrcTokens();
 
+        // Calculate adjusted output amount proportionally when we receive more than expected
+        uint256 adjustedOutputAmount = swapAndDepositData.depositData.outputAmount;
+        if (returnAmount > swapAndDepositData.minExpectedInputTokenAmount) {
+            adjustedOutputAmount =
+                (swapAndDepositData.depositData.outputAmount * returnAmount) /
+                swapAndDepositData.minExpectedInputTokenAmount;
+        }
+
         emit SwapBeforeBridge(
             _exchange,
             swapAndDepositData.routerCalldata,
@@ -644,7 +657,7 @@ contract SpokePoolV3Periphery is SpokePoolV3PeripheryInterface, Lockable, MultiC
             _swapTokenAmount,
             returnAmount,
             swapAndDepositData.depositData.outputToken,
-            swapAndDepositData.depositData.outputAmount
+            adjustedOutputAmount
         );
 
         // Deposit the swapped tokens into Across and bridge them using remainder of input params.
@@ -654,7 +667,7 @@ contract SpokePoolV3Periphery is SpokePoolV3PeripheryInterface, Lockable, MultiC
             address(_acrossInputToken),
             swapAndDepositData.depositData.outputToken,
             returnAmount,
-            swapAndDepositData.depositData.outputAmount,
+            adjustedOutputAmount,
             swapAndDepositData.depositData.destinationChainId,
             swapAndDepositData.depositData.exclusiveRelayer,
             swapAndDepositData.depositData.quoteTimestamp,

--- a/contracts/interfaces/SpokePoolV3PeripheryInterface.sol
+++ b/contracts/interfaces/SpokePoolV3PeripheryInterface.sol
@@ -97,6 +97,10 @@ interface SpokePoolV3PeripheryInterface {
         uint256 minExpectedInputTokenAmount;
         // The calldata to use when calling the exchange.
         bytes routerCalldata;
+        // When enabled (true), if the swap returns more tokens than minExpectedInputTokenAmount,
+        // the outputAmount will be increased proportionally.
+        // When disabled (false), the original outputAmount is used regardless of how many tokens are returned.
+        bool enableProportionalAdjustment;
     }
 
     // Extended deposit data to be used specifically for signing off on periphery deposits.

--- a/contracts/libraries/PeripherySigningLib.sol
+++ b/contracts/libraries/PeripherySigningLib.sol
@@ -10,7 +10,7 @@ library PeripherySigningLib {
     string internal constant EIP712_DEPOSIT_DATA_TYPE =
         "DepositData(Fees submissionFees,BaseDepositData baseDepositData,uint256 inputAmount)";
     string internal constant EIP712_SWAP_AND_DEPOSIT_DATA_TYPE =
-        "SwapAndDepositData(Fees submissionFees,BaseDepositData depositData,address swapToken,address exchange,TransferType transferType,uint256 swapTokenAmount,uint256 minExpectedInputTokenAmount,bytes routerCalldata)";
+        "SwapAndDepositData(Fees submissionFees,BaseDepositData depositData,address swapToken,address exchange,TransferType transferType,uint256 swapTokenAmount,uint256 minExpectedInputTokenAmount,bytes routerCalldata,bool enableProportionalAdjustment)";
 
     // EIP712 Type hashes.
     bytes32 internal constant EIP712_FEES_TYPEHASH = keccak256(abi.encodePacked(EIP712_FEES_TYPE));
@@ -124,7 +124,8 @@ library PeripherySigningLib {
                     swapAndDepositData.transferType,
                     swapAndDepositData.swapTokenAmount,
                     swapAndDepositData.minExpectedInputTokenAmount,
-                    keccak256(swapAndDepositData.routerCalldata)
+                    keccak256(swapAndDepositData.routerCalldata),
+                    swapAndDepositData.enableProportionalAdjustment
                 )
             );
     }

--- a/test/evm/foundry/local/SpokePoolPeriphery.t.sol
+++ b/test/evm/foundry/local/SpokePoolPeriphery.t.sol
@@ -164,8 +164,6 @@ contract SpokePoolPeripheryTest is Test {
             new ERC1967Proxy(address(implementation), abi.encodeCall(Ethereum_SpokePool.initialize, (0, owner)))
         );
         ethereumSpokePool = Ethereum_SpokePool(payable(spokePoolProxy));
-        ethereumSpokePool.setEnableRoute(address(mockWETH), destinationChainId, true);
-        ethereumSpokePool.setEnableRoute(address(mockERC20), destinationChainId, true);
         spokePoolPeriphery.initialize(V3SpokePoolInterface(ethereumSpokePool), mockWETH, address(proxy), permit2);
         vm.stopPrank();
 

--- a/test/evm/foundry/local/SpokePoolPeriphery.t.sol
+++ b/test/evm/foundry/local/SpokePoolPeriphery.t.sol
@@ -48,6 +48,35 @@ contract Exchange {
         require(tokenIn.transferFrom(msg.sender, address(this), amountIn));
         require(tokenOut.transfer(msg.sender, amountOutMin));
     }
+
+    // Enhanced swap function that returns more tokens than the minimum
+    function swapWithExtraOutput(
+        IERC20 tokenIn,
+        IERC20 tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        uint256 extraOutputPercentage,
+        bool usePermit2
+    ) external {
+        if (tokenIn.balanceOf(address(this)) >= amountIn) {
+            tokenIn.transfer(address(1), amountIn);
+            // Calculate the extra amount based on percentage (in basis points)
+            uint256 actualOutput = amountOutMin + ((amountOutMin * extraOutputPercentage) / 10000);
+            require(tokenOut.transfer(msg.sender, actualOutput));
+            return;
+        }
+
+        // Acquire tokens from the sender
+        if (usePermit2) {
+            permit2.transferFrom(msg.sender, address(this), uint160(amountIn), address(tokenIn));
+        } else {
+            require(tokenIn.transferFrom(msg.sender, address(this), amountIn));
+        }
+
+        // Calculate the extra amount based on percentage (in basis points)
+        uint256 actualOutput = amountOutMin + ((amountOutMin * extraOutputPercentage) / 10000);
+        require(tokenOut.transfer(msg.sender, actualOutput));
+    }
 }
 
 // Utility contract which lets us perform external calls to an internal library.
@@ -207,6 +236,66 @@ contract SpokePoolPeripheryTest is Test {
                 depositor
             )
         );
+        vm.stopPrank();
+    }
+
+    function testSwapAndBridgeWithProportionalOutput() public {
+        // Prepare test data
+        uint256 extraOutputPercentage = 2000; // 20% extra output
+        uint256 minExpectedAmount = depositAmount;
+        uint256 actualReturnAmount = (depositAmount * 120) / 100;
+        uint256 expectedAdjustedOutput = (depositAmount * 120) / 100;
+
+        // Deal more tokens to the exchange to cover the extra output
+        deal(address(mockERC20), address(dex), actualReturnAmount, true);
+
+        // Create custom calldata for the swapWithExtraOutput function
+        bytes memory customCalldata = abi.encodeWithSelector(
+            dex.swapWithExtraOutput.selector,
+            IERC20(address(mockWETH)),
+            IERC20(address(mockERC20)),
+            mintAmount,
+            minExpectedAmount,
+            extraOutputPercentage,
+            false
+        );
+
+        // Prepare the swap and deposit data
+        SpokePoolV3PeripheryInterface.SwapAndDepositData memory swapData = _defaultSwapAndDepositData(
+            address(mockWETH),
+            mintAmount,
+            0,
+            address(0),
+            dex,
+            SpokePoolV3PeripheryInterface.TransferType.Approval,
+            address(mockERC20),
+            depositAmount,
+            depositor
+        );
+
+        // Update the router calldata to use our custom swap function
+        swapData.routerCalldata = customCalldata;
+
+        // Should emit expected deposit event with proportionally adjusted output amount
+        vm.startPrank(depositor);
+        vm.expectEmit(address(ethereumSpokePool));
+        emit V3SpokePoolInterface.FundsDeposited(
+            address(mockERC20).toBytes32(),
+            address(0).toBytes32(),
+            actualReturnAmount,
+            expectedAdjustedOutput, // This should be proportionally increased
+            destinationChainId,
+            0, // depositId
+            uint32(block.timestamp),
+            uint32(block.timestamp) + fillDeadlineBuffer,
+            0, // exclusivityDeadline
+            depositor.toBytes32(),
+            depositor.toBytes32(),
+            address(0).toBytes32(), // exclusiveRelayer
+            new bytes(0)
+        );
+
+        proxy.swapAndBridge(swapData);
         vm.stopPrank();
     }
 
@@ -978,6 +1067,107 @@ contract SpokePoolPeripheryTest is Test {
         );
 
         // Check that fee recipient receives expected amount
+        assertEq(mockWETH.balanceOf(relayer), submissionFeeAmount);
+    }
+
+    function testPermit2SwapAndBridgeWithProportionalOutput() public {
+        // Prepare test data
+        uint256 extraOutputPercentage = 2000; // 20% extra output
+        uint256 minExpectedAmount = depositAmount;
+        uint256 actualReturnAmount = minExpectedAmount + ((minExpectedAmount * extraOutputPercentage) / 10000);
+        uint256 expectedAdjustedOutput = (depositAmount * actualReturnAmount) / minExpectedAmount;
+
+        // Deal more tokens to the exchange to cover the extra output
+        deal(address(mockERC20), address(dex), actualReturnAmount, true);
+
+        // Create custom calldata for the swapWithExtraOutput function
+        bytes memory customCalldata = abi.encodeWithSelector(
+            dex.swapWithExtraOutput.selector,
+            IERC20(address(mockWETH)),
+            IERC20(address(mockERC20)),
+            mintAmount,
+            minExpectedAmount,
+            extraOutputPercentage,
+            true // Use permit2
+        );
+
+        // Prepare the swap and deposit data with submission fee
+        SpokePoolV3PeripheryInterface.SwapAndDepositData memory swapAndDepositData = _defaultSwapAndDepositData(
+            address(mockWETH),
+            mintAmount,
+            submissionFeeAmount,
+            relayer,
+            dex,
+            SpokePoolV3PeripheryInterface.TransferType.Permit2Approval,
+            address(mockERC20),
+            depositAmount,
+            depositor
+        );
+
+        // Update the router calldata to use our custom swap function
+        swapAndDepositData.routerCalldata = customCalldata;
+
+        // Signature transfer details
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({ token: address(mockWETH), amount: mintAmountWithSubmissionFee }),
+            nonce: 2, // Use a different nonce from previous test
+            deadline: block.timestamp + 100
+        });
+
+        bytes32 typehash = keccak256(
+            abi.encodePacked(PERMIT_TRANSFER_TYPE_STUB, PeripherySigningLib.EIP712_SWAP_AND_DEPOSIT_TYPE_STRING)
+        );
+        bytes32 tokenPermissions = keccak256(abi.encode(TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));
+
+        // Get the permit2 signature
+        bytes32 msgHash = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                domainSeparator,
+                keccak256(
+                    abi.encode(
+                        typehash,
+                        tokenPermissions,
+                        address(spokePoolPeriphery),
+                        permit.nonce,
+                        permit.deadline,
+                        hashUtils.hashSwapAndDepositData(swapAndDepositData)
+                    )
+                )
+            )
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, msgHash);
+        bytes memory signature = bytes.concat(r, s, bytes1(v));
+
+        // Should emit expected deposit event with proportionally adjusted output amount
+        vm.expectEmit(address(ethereumSpokePool));
+        emit V3SpokePoolInterface.FundsDeposited(
+            address(mockERC20).toBytes32(),
+            address(0).toBytes32(),
+            actualReturnAmount,
+            expectedAdjustedOutput, // This should be proportionally increased
+            destinationChainId,
+            0, // depositId
+            uint32(block.timestamp),
+            uint32(block.timestamp) + fillDeadlineBuffer,
+            0, // exclusivityDeadline
+            depositor.toBytes32(),
+            depositor.toBytes32(),
+            address(0).toBytes32(), // exclusiveRelayer
+            new bytes(0)
+        );
+
+        spokePoolPeriphery.swapAndBridgeWithPermit2(
+            depositor, // signatureOwner
+            swapAndDepositData,
+            permit,
+            signature
+        );
+
+        // Check that fee recipient receives expected amount
+        // The relayer receives submission fee amount from each test that uses fees
+        // In this case, we're running after testPermit2SwapAndBridgeValidWitness which gives 1 fee
         assertEq(mockWETH.balanceOf(relayer), submissionFeeAmount);
     }
 


### PR DESCRIPTION
This PR adds an option so that callers can have their bridge output increased proportionally to the improvement the swap returns over the min allowed swap output.

This essentially assumes the bridge quote was generated based on the min and that the percentage should stay fixed.