### PR TITLE
improve(enableToken): Don't skip BSC

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "pre-commit-hook": "sh scripts/preCommitHook.sh"
   },
   "dependencies": {
-    "@across-protocol/constants": "^3.1.63",
+    "@across-protocol/constants": "^3.1.66",
     "@coral-xyz/anchor": "^0.31.1",
     "@defi-wonderland/smock": "^2.3.4",
     "@eth-optimism/contracts": "^0.5.40",

--- a/tasks/enableL1TokenAcrossEcosystem.ts
+++ b/tasks/enableL1TokenAcrossEcosystem.ts
@@ -8,7 +8,7 @@ const { ARBITRUM, OPTIMISM } = CHAIN_IDs;
 const NO_SYMBOL = "----";
 const NO_ADDRESS = "------------------------------------------";
 
-const IGNORED_CHAINS = [CHAIN_IDs.BOBA, CHAIN_IDs.BSC, CHAIN_IDs.SOLANA];
+const IGNORED_CHAINS = [CHAIN_IDs.BOBA, CHAIN_IDs.SOLANA];
 const V4_CHAINS = [CHAIN_IDs.BSC, CHAIN_IDs.LISK, CHAIN_IDs.LINEA];
 
 // Supported mainnet chain IDs.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@across-protocol/constants@^3.1.63":
-  version "3.1.63"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.63.tgz#c031fb30c79ff86448b5ccaca8a411d552ef144f"
-  integrity sha512-61MyPKT7X+qaZsAATDpcWpZoVAK1VwfWua0zTX5SU5UExzCartV+CsAfsrYaF5ttGBebtI33cS+754MGfA71bA==
+"@across-protocol/constants@^3.1.66":
+  version "3.1.66"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.66.tgz#952964fe1ae98ac8bd928655d81a20744da8dbe7"
+  integrity sha512-PP0445MLMnFWFzCvpXZQHD4n3DBJIQoIt3RSENNjCOJbkxDd4pqqDOAwN/BWv1jS6kLhKt6/U2poHRGJ4UPPXg==
 
 "@across-protocol/contracts@^0.1.4":
   version "0.1.4"


### PR DESCRIPTION
BSC routes are still required as a destination chain on v3 SpokePools, so don't skip it. BSC is separately skipped as an origin chain though.