### PR TITLE
fix: new svm program ids

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -14,8 +14,8 @@ multicall_handler = "Fk1RpqsfeWt8KnFCTW9NQVdVxYvxuqjGn6iPB9wrmM8h"
 svm_spoke = "JAZWcGrpSWNPTBj8QtJ9UyQqhJCDhG9GJkDeMf5NQBiq"
 
 [programs.mainnet]
-multicall_handler = "Fk1RpqsfeWt8KnFCTW9NQVdVxYvxuqjGn6iPB9wrmM8h"
-svm_spoke = "JAZWcGrpSWNPTBj8QtJ9UyQqhJCDhG9GJkDeMf5NQBiq"
+multicall_handler = "HaQe51FWtnmaEcuYEfPA7MRCXKrtqptat4oJdJ8zV5Be"
+svm_spoke = "DLv3NggMiSaef97YCkew5xKUHDh13tVGZ7tydt3ZeAru"
 
 [registry]
 url = "https://api.apr.dev"

--- a/programs/multicall-handler/src/lib.rs
+++ b/programs/multicall-handler/src/lib.rs
@@ -22,7 +22,7 @@ security_txt! {
 
 // If changing the program ID, make sure to check that the resulting handler_signer PDA has the highest bump of 255 so
 // to minimize the compute cost when finding the PDA.
-declare_id!("Fk1RpqsfeWt8KnFCTW9NQVdVxYvxuqjGn6iPB9wrmM8h");
+declare_id!("HaQe51FWtnmaEcuYEfPA7MRCXKrtqptat4oJdJ8zV5Be");
 
 #[program]
 pub mod multicall_handler {

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -14,7 +14,7 @@ security_txt! {
     auditors: "OpenZeppelin"
 }
 
-declare_id!("JAZWcGrpSWNPTBj8QtJ9UyQqhJCDhG9GJkDeMf5NQBiq");
+declare_id!("DLv3NggMiSaef97YCkew5xKUHDh13tVGZ7tydt3ZeAru");
 
 // External programs from idls directory (requires anchor run generateExternalTypes).
 declare_program!(message_transmitter);


### PR DESCRIPTION
We want pristine addresses for SVM program deployments for production.