### PR TITLE
[H-01] Incorrect Nonce Passed to the Permit2.permit Function

### DIFF
--- a/contracts/SpokePoolPeriphery.sol
+++ b/contracts/SpokePoolPeriphery.sol
@@ -36,8 +36,8 @@ contract SwapProxy is Lockable {
     // EIP 1271 bytes indicating an invalid signature.
     bytes4 private constant EIP1271_INVALID_SIGNATURE = 0xffffffff;
 
-    // Nonce for this contract to use for EIP1271 "signatures".
-    uint48 private eip1271Nonce;
+    // Mapping from (token, spender) to nonce for Permit2 operations
+    mapping(address => mapping(address => uint48)) private permit2Nonces;
 
     // Slot for checking whether this contract is expecting a callback from permit2. Used to confirm whether it should return a valid signature response.
     bool private expectingPermit2Callback;
@@ -92,7 +92,7 @@ contract SwapProxy is Lockable {
                         token: inputToken,
                         amount: uint160(inputAmount),
                         expiration: uint48(block.timestamp),
-                        nonce: eip1271Nonce++
+                        nonce: permit2Nonces[inputToken][exchange]++
                     }),
                     spender: exchange,
                     sigDeadline: block.timestamp


### PR DESCRIPTION
The [performSwap function](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePoolPeriphery.sol#L67) of the SwapProxy contract allows to provide tokens for a swap to a specified exchange using several different methods. In particular, it allows to approve tokens for the swap [through the Permit2 contract](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePoolPeriphery.sol#L86-L101). In order to do that, it [approves the given token amount to the Permit2 contract](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePoolPeriphery.sol#L86), and [calls the permit function of the Permit2 contract](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePoolPeriphery.sol#L88-L101).

However, the [nonce specified for that call](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePoolPeriphery.sol#L95) is global for the entire contract, while the Permit2 contract stores [separate nonce for each (owner, token, spender) tuple](https://github.com/Uniswap/permit2/blob/cc56ad0f3439c502c246fc5cfcc3db92bb8b7219/src/interfaces/IAllowanceTransfer.sol#L85). As a result, any attempt to use a different (token, spender) pair than the ones used in the first performSwap function call will result in the [revert](https://github.com/Uniswap/permit2/blob/cc56ad0f3439c502c246fc5cfcc3db92bb8b7219/src/AllowanceTransfer.sol#L138) due to nonces mismatch.

Consider storing and using separate nonces for each (token, spender) pair in the SwapProxy contract.