### PR TITLE
[M-02] Replay Attacks on SpokePoolPeriphery Possible

### DIFF
--- a/contracts/interfaces/SpokePoolPeripheryInterface.sol
+++ b/contracts/interfaces/SpokePoolPeripheryInterface.sol
@@ -90,6 +90,8 @@ interface SpokePoolPeripheryInterface {
         bool enableProportionalAdjustment;
         // Address of the SpokePool to use for depositing tokens after swap.
         address spokePool;
+        // User nonce to prevent replay attacks.
+        uint256 nonce;
     }
 
     // Extended deposit data to be used specifically for signing off on periphery deposits.
@@ -102,6 +104,8 @@ interface SpokePoolPeripheryInterface {
         uint256 inputAmount;
         // Address of the SpokePool to use for depositing tokens.
         address spokePool;
+        // User nonce to prevent replay attacks.
+        uint256 nonce;
     }
 
     /**

--- a/contracts/libraries/PeripherySigningLib.sol
+++ b/contracts/libraries/PeripherySigningLib.sol
@@ -8,9 +8,9 @@ library PeripherySigningLib {
     string internal constant EIP712_BASE_DEPOSIT_DATA_TYPE =
         "BaseDepositData(address inputToken,bytes32 outputToken,uint256 outputAmount,address depositor,bytes32 recipient,uint256 destinationChainId,bytes32 exclusiveRelayer,uint32 quoteTimestamp,uint32 fillDeadline,uint32 exclusivityParameter,bytes message)";
     string internal constant EIP712_DEPOSIT_DATA_TYPE =
-        "DepositData(Fees submissionFees,BaseDepositData baseDepositData,uint256 inputAmount,address spokePool)";
+        "DepositData(Fees submissionFees,BaseDepositData baseDepositData,uint256 inputAmount,address spokePool,uint256 nonce)";
     string internal constant EIP712_SWAP_AND_DEPOSIT_DATA_TYPE =
-        "SwapAndDepositData(Fees submissionFees,BaseDepositData depositData,address swapToken,address exchange,TransferType transferType,uint256 swapTokenAmount,uint256 minExpectedInputTokenAmount,bytes routerCalldata,bool enableProportionalAdjustment,address spokePool)";
+        "SwapAndDepositData(Fees submissionFees,BaseDepositData depositData,address swapToken,address exchange,TransferType transferType,uint256 swapTokenAmount,uint256 minExpectedInputTokenAmount,bytes routerCalldata,bool enableProportionalAdjustment,address spokePool,uint256 nonce)";
 
     // EIP712 Type hashes.
     bytes32 internal constant EIP712_FEES_TYPEHASH = keccak256(abi.encodePacked(EIP712_FEES_TYPE));
@@ -100,7 +100,8 @@ library PeripherySigningLib {
                     hashFees(depositData.submissionFees),
                     hashBaseDepositData(depositData.baseDepositData),
                     depositData.inputAmount,
-                    depositData.spokePool
+                    depositData.spokePool,
+                    depositData.nonce
                 )
             );
     }
@@ -127,7 +128,8 @@ library PeripherySigningLib {
                     swapAndDepositData.minExpectedInputTokenAmount,
                     keccak256(swapAndDepositData.routerCalldata),
                     swapAndDepositData.enableProportionalAdjustment,
-                    swapAndDepositData.spokePool
+                    swapAndDepositData.spokePool,
+                    swapAndDepositData.nonce
                 )
             );
     }


### PR DESCRIPTION
The [SpokePoolPeriphery contract](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePoolPeriphery.sol#L140) enables users to deposit or swap and deposit tokens into a SpokePool. In order to do that, the assets are first transferred from the depositor's account, then optionally swapped to a different token and finally deposited to a SpokePool.

Assets can be transferred from the depositor's account in several different ways, including approval followed by the [transferFrom call](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePoolPeriphery.sol#L236-L240), [approval through the ERC-2612 permit function followed by transferFrom](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePoolPeriphery.sol#L267-L268), [transfer through the Permit2 contract](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePoolPeriphery.sol#L295-L302) and [transfer through the ERC-3009 receiveWithAuthorization function](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePoolPeriphery.sol#L328-L338). The last three methods require additional user's signatures and may be executed by anyone on behalf of a given user.

However, the [data to be signed for deposits or swaps and deposits](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/interfaces/SpokePoolPeripheryInterface.sol#L70-L105) with ERC-2612 permit and with ERC-3009 receiveWithAuthorization does not contain a nonce, and as such, the signatures used for these methods once can be replayed later.

The attack can be performed if a victim signed data for a function relying on the ERC-2612 permit function and wants to deposit tokens once again using the same method and token [within the time window determined by the depositQuoteTimeBuffer parameter](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePool.sol#L1306-L1307). In such a case, an attacker can first approve tokens on behalf of the victim and then call the [swapAndBridgeWithPermit function](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePoolPeriphery.sol#L249) or the [depositWithPermit function](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/SpokePoolPeriphery.sol#L357) providing a signature for deposit or swap and deposit from the past, which included less tokens than the approved amount. As a result, the tokens will be deposited and potentially swapped before, using the data from an old signature, forcing the victim to either perform an unintended swap or to bridge tokens to a different chain than intended. Furthermore, since the attack consumes some part of the permit approval, it will not be possible to deposit tokens on behalf of a depositor using the new signature until the full amount of tokens is approved by them once again.

A similar attack is also possible for the functions relying on the ERC-3009 receiveWithAuthorization function, but it requires the amount of token to be transferred to be identical to the one from the past.

Consider adding a nonce field into the [SwapAndDepositData and DepositData structs](https://github.com/across-protocol/contracts/blob/b84dbfae35030e0f2caa5509b632c10106a32330/contracts/interfaces/SpokePoolPeripheryInterface.sol#L70-L105) and storing a nonce for each user in the SpokePoolPeriphery contract, which would be incremented when a signature is verified and accepted.