### PR TITLE
M-03 DoS Attack on Swapping via Permit2 Possible

### DIFF
--- a/contracts/SpokePoolPeriphery.sol
+++ b/contracts/SpokePoolPeriphery.sol
@@ -45,6 +45,7 @@ contract SwapProxy is Lockable {
     // Errors
     error SwapFailed();
     error UnsupportedTransferType();
+    error InvalidExchange();
 
     /**
      * @notice Constructs a new SwapProxy.
@@ -72,6 +73,9 @@ contract SwapProxy is Lockable {
         SpokePoolPeripheryInterface.TransferType transferType,
         bytes calldata routerCalldata
     ) external nonReentrant returns (uint256 outputAmount) {
+        // Prevent nonce invalidation attack by disallowing exchange to be the permit2 address
+        if (exchange == address(permit2)) revert InvalidExchange();
+
         // We'll return the final balance of output tokens
 
         // The exchange will either receive funds from this contract via:


### PR DESCRIPTION
The SwapProxy contract contains the performSwap function, which enables the caller to execute a swap using several different ways: by approving or sending tokens to the specified exchange and by approving tokens through the Permit2 contract.

However, since it is possible to provide any address as the exchange parameter and any call data through the routerCalldata parameter of the performSwap function, the SwapProxy contract may be forced to perform an arbitrary call to arbitrary address.

This could be exploited by an attacker, who could force the SwapProxy contract to call the invalidateNonces function of the Permit2 contract, specifying any spender and a nonce higher than the current one. As a result, the nonce for a given (token, spender) pair will be updated. If the performSwap function is called again later, it will attempt to use a subsequent nonce, which has been invalidated by the attacker and the code inside Permit2 will revert due to nonces mismatch.

As the performSwap function is the only place where the nonce passed to the Permit2 contract is updated, the possibility of swapping a given token on a certain exchange will be blocked forever, which impacts all the functions of the SpokePoolPeriphery contract related to swapping tokens. The attack may be performed for many different (tokens, exchange) pairs.

Consider not allowing the exchange parameter to be equal to the Permit2 contract address.