### PR TITLE
[M-05] Incorrect EIP-712 Encoding

### DIFF
--- a/contracts/interfaces/SpokePoolPeripheryInterface.sol
+++ b/contracts/interfaces/SpokePoolPeripheryInterface.sol
@@ -17,11 +17,11 @@ interface SpokePoolPeripheryInterface {
     // Enum describing the method of transferring tokens to an exchange.
     enum TransferType {
         // Approve the exchange so that it may transfer tokens from this contract.
-        Approval,
+        Approval, // 0
         // Transfer tokens to the exchange before calling it in this contract.
-        Transfer,
+        Transfer, // 1
         // Approve the exchange by authorizing a transfer with Permit2.
-        Permit2Approval
+        Permit2Approval // 2
     }
 
     // Submission fees can be set by user to pay whoever submits the transaction in a gasless flow.

--- a/contracts/libraries/PeripherySigningLib.sol
+++ b/contracts/libraries/PeripherySigningLib.sol
@@ -10,7 +10,7 @@ library PeripherySigningLib {
     string internal constant EIP712_DEPOSIT_DATA_TYPE =
         "DepositData(Fees submissionFees,BaseDepositData baseDepositData,uint256 inputAmount,address spokePool)";
     string internal constant EIP712_SWAP_AND_DEPOSIT_DATA_TYPE =
-        "SwapAndDepositData(Fees submissionFees,BaseDepositData depositData,address swapToken,address exchange,TransferType transferType,uint256 swapTokenAmount,uint256 minExpectedInputTokenAmount,bytes routerCalldata,bool enableProportionalAdjustment,address spokePool)";
+        "SwapAndDepositData(Fees submissionFees,BaseDepositData depositData,address swapToken,address exchange,uint8 transferType,uint256 swapTokenAmount,uint256 minExpectedInputTokenAmount,bytes routerCalldata,bool enableProportionalAdjustment,address spokePool)";
 
     // EIP712 Type hashes.
     bytes32 internal constant EIP712_FEES_TYPEHASH = keccak256(abi.encodePacked(EIP712_FEES_TYPE));
@@ -122,7 +122,7 @@ library PeripherySigningLib {
                     hashBaseDepositData(swapAndDepositData.depositData),
                     swapAndDepositData.swapToken,
                     swapAndDepositData.exchange,
-                    swapAndDepositData.transferType,
+                    uint8(swapAndDepositData.transferType),
                     swapAndDepositData.swapTokenAmount,
                     swapAndDepositData.minExpectedInputTokenAmount,
                     keccak256(swapAndDepositData.routerCalldata),

--- a/contracts/libraries/PeripherySigningLib.sol
+++ b/contracts/libraries/PeripherySigningLib.sol
@@ -122,7 +122,7 @@ library PeripherySigningLib {
                     hashBaseDepositData(swapAndDepositData.depositData),
                     swapAndDepositData.swapToken,
                     swapAndDepositData.exchange,
-                    uint8(swapAndDepositData.transferType),
+                    swapAndDepositData.transferType,
                     swapAndDepositData.swapTokenAmount,
                     swapAndDepositData.minExpectedInputTokenAmount,
                     keccak256(swapAndDepositData.routerCalldata),


### PR DESCRIPTION
The PeripherySigningLib library contains the EIP-712 encodings of certain types as well as helper functions to generate their EIP-712 compliant hashed data.

However, the data type of the SwapAndDepositData struct is incorrect as it contains the TransferType member of an enum type, which is not supported by the EIP-712 standard.

Consider replacing the TransferType enum name used to generate the SwapAndDepositData's data type with uint8 in order to be compliant with EIP-712.