### PR TITLE
[N-01] Function Renaming Suggestion

### DIFF
--- a/contracts/SpokePoolPeriphery.sol
+++ b/contracts/SpokePoolPeriphery.sol
@@ -186,7 +186,7 @@ contract SpokePoolPeriphery is SpokePoolPeripheryInterface, Lockable, MultiCalle
     /**
      * @inheritdoc SpokePoolPeripheryInterface
      */
-    function deposit(
+    function depositNative(
         address spokePool,
         address recipient,
         address inputToken,

--- a/contracts/interfaces/SpokePoolPeripheryInterface.sol
+++ b/contracts/interfaces/SpokePoolPeripheryInterface.sol
@@ -105,7 +105,7 @@ interface SpokePoolPeripheryInterface {
     }
 
     /**
-     * @notice Passthrough function to `depositV3()` on the SpokePool contract.
+     * @notice Passthrough function to `depositV3()` on the SpokePool contract for native token deposits.
      * @dev Protects the caller from losing their ETH (or other native token) by reverting if the SpokePool address
      * they intended to call does not exist on this chain. Because this contract can be deployed at the same address
      * everywhere callers should be protected even if the transaction is submitted to an unintended network.
@@ -125,7 +125,7 @@ interface SpokePoolPeripheryInterface {
      * to 0 if exclusiveRelayer is set to 0x0, and vice versa.
      * @param fillDeadline Timestamp after which this deposit can no longer be filled.
      */
-    function deposit(
+    function depositNative(
         address spokePool,
         address recipient,
         address inputToken,

--- a/test/evm/foundry/local/SpokePoolPeriphery.t.sol
+++ b/test/evm/foundry/local/SpokePoolPeriphery.t.sol
@@ -478,7 +478,7 @@ contract SpokePoolPeripheryTest is Test {
             bytes32(0), // exclusiveRelayer
             new bytes(0)
         );
-        spokePoolPeriphery.deposit{ value: mintAmount }(
+        spokePoolPeriphery.depositNative{ value: mintAmount }(
             address(ethereumSpokePool), // spokePool address
             depositor, // recipient
             address(mockWETH), // inputToken
@@ -499,7 +499,7 @@ contract SpokePoolPeripheryTest is Test {
         // Should revert when trying to call deposit without msg.value
         vm.startPrank(depositor);
         vm.expectRevert(SpokePoolPeriphery.InvalidMsgValue.selector);
-        spokePoolPeriphery.deposit(
+        spokePoolPeriphery.depositNative(
             address(ethereumSpokePool), // spokePool address
             depositor, // recipient
             address(mockWETH), // inputToken


### PR DESCRIPTION
The deposit function of the SpokePoolPeriphery contract allows users to deposit native value to the SpokePool.

Although it is possible to specify the inputToken parameter, it is not possible to deposit other tokens through this function. Because of that, it could be renamed to depositNative or a similar name in order to make this fact clear.

Consider renaming the deposit function in order to improve readability of the codebase.