### PR TITLE
[L-05] Inflexible Fee Recipient Field Blocks Open Relaying

### DIFF
--- a/contracts/SpokePoolPeriphery.sol
+++ b/contracts/SpokePoolPeriphery.sol
@@ -644,7 +644,9 @@ contract SpokePoolPeriphery is SpokePoolPeripheryInterface, Lockable, MultiCalle
         uint256 amount
     ) private {
         if (amount > 0) {
-            IERC20(feeToken).safeTransfer(recipient, amount);
+            // Use msg.sender as recipient if recipient is zero address, otherwise use the specified recipient
+            address feeRecipient = recipient == address(0) ? msg.sender : recipient;
+            IERC20(feeToken).safeTransfer(feeRecipient, amount);
         }
     }
 


### PR DESCRIPTION
Currently, every DepositData and SwapAndDepositData payload must include a hard-coded fee recipient address, and upon successful deposit or swap-and-bridge the periphery pays submission fees to that exact address.

While this ensures the user knows in advance exactly who will receive their fee, it also prevents open relayer competition or fallback options when the chosen relayer is unavailable or underperforms.

Consider keeping the explicit fee recipient field option in SwapAndDepositData but introduce a "zero‐address" convention:

If the fee recipient is equal to the zero address, the periphery should default to using msg.sender as the payee.
Otherwise, transfer fees to the signed recipient as today.