### PR TITLE
[N-03] Optimization Opportunities

### DIFF
--- a/contracts/handlers/MulticallHandler.sol
+++ b/contracts/handlers/MulticallHandler.sol
@@ -120,7 +120,7 @@ contract MulticallHandler is AcrossMessageHandler, ReentrancyGuard {
         }
     }
 
-    function makeCallWithBalance(address target, bytes memory callData, uint256 value, Replacement[] memory replacement) external onlySelf {
+    function makeCallWithBalance(address target, bytes memory callData, uint256 value, Replacement[] calldata replacement) external onlySelf {
         for (uint256 i = 0; i < replacement.length; i++) {
             uint256 bal = 0;
             if (replacement[i].token != address(0)) {

--- a/test/evm/foundry/local/SpokePoolPeriphery.t.sol
+++ b/test/evm/foundry/local/SpokePoolPeriphery.t.sol
@@ -520,12 +520,14 @@ contract SpokePoolPeripheryTest is Test {
 
     function testDepositWithNonContractSpokePool() public {
         // Should revert when trying to call deposit with a non-contract address as spokePool
+        // Give the depositor some ETH for the transaction
+        deal(depositor, 1 ether);
         vm.startPrank(depositor);
 
         // Use an EOA address (depositor) as a non-contract address for spokePool
         address nonContractAddress = depositor;
 
-        // The call should revert because Solidity will check if the address has code before making the call
+        // The call should revert when the spokePool is not a contract
         vm.expectRevert();
         spokePoolPeriphery.deposit{ value: 1 wei }(
             nonContractAddress, // spokePool - this is not a contract

--- a/test/evm/foundry/local/SpokePoolPeriphery.t.sol
+++ b/test/evm/foundry/local/SpokePoolPeriphery.t.sol
@@ -529,7 +529,7 @@ contract SpokePoolPeripheryTest is Test {
 
         // The call should revert when the spokePool is not a contract
         vm.expectRevert();
-        spokePoolPeriphery.deposit{ value: 1 wei }(
+        spokePoolPeriphery.depositNative{ value: 1 wei }(
             nonContractAddress, // spokePool - this is not a contract
             depositor, // recipient
             address(mockWETH), // inputToken

--- a/test/evm/foundry/local/SpokePoolPeriphery.t.sol
+++ b/test/evm/foundry/local/SpokePoolPeriphery.t.sol
@@ -531,13 +531,13 @@ contract SpokePoolPeripheryTest is Test {
         vm.expectRevert();
         spokePoolPeriphery.depositNative{ value: 1 wei }(
             nonContractAddress, // spokePool - this is not a contract
-            depositor, // recipient
+            depositor.toBytes32(), // recipient
             address(mockWETH), // inputToken
             1 wei, // inputAmount
             bytes32(0), // outputToken
             1 wei, // outputAmount
             destinationChainId,
-            address(0), // exclusiveRelayer
+            bytes32(0), // exclusiveRelayer
             uint32(block.timestamp), // quoteTimestamp
             uint32(block.timestamp) + fillDeadlineBuffer, // fillDeadline
             0, // exclusivityParameter


### PR DESCRIPTION
Throughout the codebase, there are several places where the code could be optimized in order to save gas. The examples are:

1. The checks validating that a given address refers to a contract in lines 204, 231 and 553 are not necessary as in case when the addresses do not refer to contracts, the subsequent calls at lines 207, 233 and 555 will revert as the Solidity compiler inserts similar code size checks before each high-level call.

2. The "0x" string passed to permit call could be replaced with "".

3. The check could be removed as the same check is already performed in SpokePools. This would additionally allow users to deposit non-native tokens through the SpokePoolPeriphery.deposit function.

4. The replacement argument of the makeCallWithBalance function could be stored in calldata instead of memory.

5. The use of the Lockable contract is inefficient. OpenZeppelin's ReentrancyGuard delivers significantly lower gas overhead by using a two‐word uint256 status in place of a bool, reducing SSTORE costs, and swapping long revert strings for a 4-byte custom error to shrink both bytecode and revert gas. For deployments on chains that support EIP-1153 (transient storage), adopting ReentrancyGuardTransient can further nearly eliminate reentrancy‐guard gas costs.

Consider applying the suggestions above in order to provide more gas efficient code.