### PR TITLE
[N-05] Insufficient Documentation

### DIFF
--- a/contracts/SpokePoolPeriphery.sol
+++ b/contracts/SpokePoolPeriphery.sol
@@ -222,6 +222,7 @@ contract SpokePoolPeriphery is SpokePoolPeripheryInterface, Lockable, MultiCalle
 
     /**
      * @inheritdoc SpokePoolPeripheryInterface
+     * @dev Does not support native tokens as swap output. Only ERC20 tokens can be deposited via this function.
      */
     function swapAndBridge(SwapAndDepositData calldata swapAndDepositData) external payable override nonReentrant {
         // If a user performs a swapAndBridge with the swap token as the native token, wrap the value and treat the rest of transaction
@@ -245,6 +246,7 @@ contract SpokePoolPeriphery is SpokePoolPeripheryInterface, Lockable, MultiCalle
 
     /**
      * @inheritdoc SpokePoolPeripheryInterface
+     * @dev Does not support native tokens as swap output. Only ERC20 tokens can be deposited via this function.
      */
     function swapAndBridgeWithPermit(
         address signatureOwner,
@@ -278,6 +280,7 @@ contract SpokePoolPeriphery is SpokePoolPeripheryInterface, Lockable, MultiCalle
 
     /**
      * @inheritdoc SpokePoolPeripheryInterface
+     * @dev Does not support native tokens as swap output. Only ERC20 tokens can be deposited via this function.
      */
     function swapAndBridgeWithPermit2(
         address signatureOwner,
@@ -310,6 +313,7 @@ contract SpokePoolPeriphery is SpokePoolPeripheryInterface, Lockable, MultiCalle
 
     /**
      * @inheritdoc SpokePoolPeripheryInterface
+     * @dev Does not support native tokens as swap output. Only ERC20 tokens can be deposited via this function.
      */
     function swapAndBridgeWithAuthorization(
         address signatureOwner,

--- a/contracts/handlers/MulticallHandler.sol
+++ b/contracts/handlers/MulticallHandler.sol
@@ -48,7 +48,6 @@ contract MulticallHandler is AcrossMessageHandler, ReentrancyGuard {
     error ReplacementCallFailed(bytes calldData);
     error CalldataTooShort(uint256 callDataLength, uint256 offset);
 
-
     modifier onlySelf() {
         _requireSelf();
         _;
@@ -120,7 +119,22 @@ contract MulticallHandler is AcrossMessageHandler, ReentrancyGuard {
         }
     }
 
-    function makeCallWithBalance(address target, bytes memory callData, uint256 value, Replacement[] memory replacement) external onlySelf {
+    /**
+     * @notice Executes a call while replacing specified calldata offsets with current token/native balances.
+     * @dev Modifies calldata in-place using OR operations. Target calldata positions must be zeroed out.
+     * Cannot handle negative balances, making it incompatible with DEXs requiring negative input amounts.
+     * For native balance (token = address(0)), the entire balance is used as call value.
+     * @param target The contract address to call
+     * @param callData The calldata to execute, with zero values at replacement positions
+     * @param value The native token value to send (ignored if native balance replacement is used)
+     * @param replacement Array of Replacement structs specifying token addresses and byte offsets for balance injection
+     */
+    function makeCallWithBalance(
+        address target,
+        bytes memory callData,
+        uint256 value,
+        Replacement[] memory replacement
+    ) external onlySelf {
         for (uint256 i = 0; i < replacement.length; i++) {
             uint256 bal = 0;
             if (replacement[i].token != address(0)) {


### PR DESCRIPTION
Throughout the codebase, there are several places where the documentation could be expanded to better describe the code. The instances are listed below:

The makeCallWithBalance function of the MulticallHandler contract allows to replace specified offsets of a given call data with current token or native balances, but the purpose of this function and the correct way of using it may not be immediately clear to the users, it would benefit from the additional documentation describing its purpose, limitations and correct usage. One additional limitation that could also be listed is that this function is not capable of filling negative balances, hence decentralized exchanges, which require input token amounts to be nagative, are not supported.

The documentation of the swapAndBridge, swapAndBridgeWithPermit, swapAndBridgeWithPermit2 and swapAndBridgeWithAuthorization functions could mention that they do not support native value as the output token of the swaps and, as a result, it is only possible to deposit non-native tokens to a SpokePool through these functions.

Consider expanding documentation in the places mentioned above in order to improve the clarity of the codebase.