### PR TITLE
[N-08] Typographical Errors

### DIFF
--- a/contracts/SpokePoolPeriphery.sol
+++ b/contracts/SpokePoolPeriphery.sol
@@ -497,7 +497,7 @@ contract SpokePoolPeriphery is SpokePoolPeripheryInterface, Lockable, MultiCalle
     }
 
     /**
-     * @notice Returns the contract's EIP712 domain separator, used to sign hashed depositData/swapAndDepositData types.
+     * @notice Returns the contract's EIP712 domain separator, used to sign hashed DepositData/SwapAndDepositData types.
      */
     function domainSeparator() external view returns (bytes32) {
         return _domainSeparatorV4();

--- a/contracts/handlers/MulticallHandler.sol
+++ b/contracts/handlers/MulticallHandler.sol
@@ -45,7 +45,7 @@ contract MulticallHandler is AcrossMessageHandler, ReentrancyGuard {
     error CallReverted(uint256 index, Call[] calls);
     error NotSelf();
     error InvalidCall(uint256 index, Call[] calls);
-    error ReplacementCallFailed(bytes calldData);
+    error ReplacementCallFailed(bytes callData);
     error CalldataTooShort(uint256 callDataLength, uint256 offset);
 
 

--- a/contracts/interfaces/SpokePoolPeripheryInterface.sol
+++ b/contracts/interfaces/SpokePoolPeripheryInterface.sol
@@ -110,7 +110,7 @@ interface SpokePoolPeripheryInterface {
      * they intended to call does not exist on this chain. Because this contract can be deployed at the same address
      * everywhere callers should be protected even if the transaction is submitted to an unintended network.
      * This contract should only be used for native token deposits, as this problem only exists for native tokens.
-     * @param recipient Address to receive funds at on destination chain.
+     * @param recipient Address to receive funds on destination chain.
      * @param inputToken Token to lock into this contract to initiate deposit.
      * @param inputAmount Amount of tokens to deposit.
      * @param outputAmount Amount of tokens to receive on destination chain.


### PR DESCRIPTION
Throughout the codebase, several instances of typographical errors were identified:

On line 48 of the MulticallHandler.sol file, \calldData\ should be \callData\.
On line 113 of the SpokePoolPeripheryInterface.sol file, \on\ could be removed.
On line 500 of the SpokePoolPeriphery.sol file, \depositData/swapAndDepositData\ could be \DepositData/SwapAndDepositData\.
Consider correcting all instances of typographical errors in order to improve the clarity and readability of the codebase.