### PR TITLE
[N-10] Unused Code

### DIFF
--- a/contracts/SpokePoolPeriphery.sol
+++ b/contracts/SpokePoolPeriphery.sol
@@ -162,7 +162,6 @@ contract SpokePoolPeriphery is SpokePoolPeripheryInterface, Lockable, MultiCalle
     /****************************************
      *                ERRORS                *
      ****************************************/
-    error InvalidSignatureLength();
     error MinimumExpectedInputAmount();
     error InvalidMsgValue();
     error InvalidSpokePool();

--- a/contracts/interfaces/SpokePoolPeripheryInterface.sol
+++ b/contracts/interfaces/SpokePoolPeripheryInterface.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
-import { IERC20Auth } from "../external/interfaces/IERC20Auth.sol";
 import { IPermit2 } from "../external/interfaces/IPermit2.sol";
 
 /**


### PR DESCRIPTION
Throughout the codebase, there are some instances of unused code, which could be removed:

In the SpokePoolPeriphery.sol file, the InvalidSignatureLength error is unused.
In the SpokePoolPeripheryInterface.sol file, the import is unused.
To improve the overall clarity, intentionality, and readability of the codebase, consider removing any currently unused code.