### PR TITLE
[N-12] Misleading Documentation

### DIFF
--- a/contracts/SpokePoolPeriphery.sol
+++ b/contracts/SpokePoolPeriphery.sol
@@ -133,8 +133,6 @@ contract SwapProxy is Lockable {
 /**
  * @title SpokePoolPeriphery
  * @notice Contract for performing more complex interactions with an Across spoke pool deployment.
- * @dev Variables which may be immutable are not marked as immutable, nor defined in the constructor, so that this
- * contract may be deployed deterministically at the same address across different networks.
  * @custom:security-contact bugs@across.to
  */
 contract SpokePoolPeriphery is SpokePoolPeripheryInterface, Lockable, MultiCaller, EIP712 {
@@ -322,7 +320,7 @@ contract SpokePoolPeriphery is SpokePoolPeripheryInterface, Lockable, MultiCalle
     ) external override nonReentrant {
         (bytes32 r, bytes32 s, uint8 v) = PeripherySigningLib.deserializeSignature(receiveWithAuthSignature);
         uint256 _submissionFeeAmount = swapAndDepositData.submissionFees.amount;
-        // While any contract can vacuously implement `transferWithAuthorization` (or just have a fallback),
+        // While any contract can vacuously implement `receiveWithAuthorization` (or just have a fallback),
         // if tokens were not sent to this contract, by this call to swapData.swapToken, this function will revert
         // when attempting to swap tokens it does not own.
         IERC20Auth(address(swapAndDepositData.swapToken)).receiveWithAuthorization(

--- a/contracts/interfaces/SpokePoolPeripheryInterface.sol
+++ b/contracts/interfaces/SpokePoolPeripheryInterface.sol
@@ -149,7 +149,7 @@ interface SpokePoolPeripheryInterface {
     /**
      * @notice Swaps an EIP-2612 token on this chain via specified router before submitting Across deposit atomically.
      * Caller can specify their slippage tolerance for the swap and Across deposit params.
-     * @dev If the swapToken does not implement `permit` to the specifications of EIP-2612, the permit call will be ignored and the function will continue.
+     * @dev If the swapToken does not implement `permit` to the specifications of EIP-2612, the permit call result will be ignored and the function will continue.
      * @param signatureOwner The owner of the permit signature and swapAndDepositData signature. Assumed to be the depositor for the Across spoke pool.
      * @param swapAndDepositData Specifies the params we need to perform a swap on a generic exchange.
      * @param deadline Deadline before which the permit signature is valid.
@@ -205,7 +205,7 @@ interface SpokePoolPeripheryInterface {
 
     /**
      * @notice Deposits an EIP-2612 token Across input token into the Spoke Pool contract.
-     * @dev If the token does not implement `permit` to the specifications of EIP-2612, the permit call will be ignored and the function will continue.
+     * @dev If the token does not implement `permit` to the specifications of EIP-2612, the permit call result will be ignored and the function will continue.
      * @param signatureOwner The owner of the permit signature and depositData signature. Assumed to be the depositor for the Across spoke pool.
      * @param depositData Specifies the Across deposit params to send.
      * @param deadline Deadline before which the permit signature is valid.

--- a/contracts/interfaces/SpokePoolPeripheryInterface.sol
+++ b/contracts/interfaces/SpokePoolPeripheryInterface.sol
@@ -9,8 +9,6 @@ import { IPermit2 } from "../external/interfaces/IPermit2.sol";
 /**
  * @title SpokePoolPeriphery
  * @notice Contract for performing more complex interactions with an Across spoke pool deployment.
- * @dev Variables which may be immutable are not marked as immutable, nor defined in the constructor, so that this
- * contract may be deployed deterministically at the same address across different networks.
  * @custom:security-contact bugs@across.to
  */
 interface SpokePoolPeripheryInterface {
@@ -151,7 +149,7 @@ interface SpokePoolPeripheryInterface {
     /**
      * @notice Swaps an EIP-2612 token on this chain via specified router before submitting Across deposit atomically.
      * Caller can specify their slippage tolerance for the swap and Across deposit params.
-     * @dev If the swapToken in swapData does not implement `permit` to the specifications of EIP-2612, this function will fail.
+     * @dev If the swapToken does not implement `permit` to the specifications of EIP-2612, the permit call will be ignored and the function will continue.
      * @param signatureOwner The owner of the permit signature and swapAndDepositData signature. Assumed to be the depositor for the Across spoke pool.
      * @param swapAndDepositData Specifies the params we need to perform a swap on a generic exchange.
      * @param deadline Deadline before which the permit signature is valid.
@@ -207,7 +205,7 @@ interface SpokePoolPeripheryInterface {
 
     /**
      * @notice Deposits an EIP-2612 token Across input token into the Spoke Pool contract.
-     * @dev If `acrossInputToken` does not implement `permit` to the specifications of EIP-2612, this function will fail.
+     * @dev If the token does not implement `permit` to the specifications of EIP-2612, the permit call will be ignored and the function will continue.
      * @param signatureOwner The owner of the permit signature and depositData signature. Assumed to be the depositor for the Across spoke pool.
      * @param depositData Specifies the Across deposit params to send.
      * @param deadline Deadline before which the permit signature is valid.


### PR DESCRIPTION
Throughout the codebase, there are several instances of misleading documentation. The examples are listed below.

The swapAndBridgeWithPermit and depositWithPermit functions are documented to fail if the provided token does not support the EIP-2612 permit function. However, the implementation contradicts this statement as in both functions, the call to permit is wrapped in a try/catch block, and any failure is silently ignored.
The comment refers to the transferWithAuthorization function, while it should mention the receiveWithAuthorization function instead.
The documentation of the SpokePoolPeriphery contract and the SpokePoolPeripheryInterface interface contain an outdated comment claiming that certain variables are not marked immutable or set in the constructor to allow deterministic deployment. This is no longer true as the variables are now immutable and set via the constructor.
Consider fixing the instances mentioned above in order to enhance the clarity of the codebase.