### PR TITLE
[M-01] Insufficient Validation of Sent Amount in OFTTransportAdapter

### DIFF
--- a/contracts/libraries/OFTTransportAdapter.sol
+++ b/contracts/libraries/OFTTransportAdapter.sol
@@ -34,6 +34,7 @@ contract OFTTransportAdapter {
     error OftFeeCapExceeded();
     error OftInsufficientBalanceForFee();
     error OftIncorrectAmountReceivedLD();
+    error OftIncorrectAmountSentLD();
 
     /**
      * @notice intiailizes the OFTTransportAdapter contract.
@@ -95,5 +96,7 @@ contract OFTTransportAdapter {
 
         // The HubPool expects that the amount received by the SpokePool is exactly the sent amount
         if (_amount != oftReceipt.amountReceivedLD) revert OftIncorrectAmountReceivedLD();
+        // Also check the amount sent on origin chain to harden security
+        if (_amount != oftReceipt.amountSentLD) revert OftIncorrectAmountSentLD();
     }
 }


### PR DESCRIPTION
In the OFTTransportAdapter contract, the [_transferViaOFT function](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/libraries/OFTTransportAdapter.sol#L94-L97) gets the OFTReceipt output containing two elements: the amount sent at origin and the amount received at destination. The current implementation only validates the amount received at destination, ensuring it matches the input amount specified by the user. This approach, however, overlooks the validation of the amount sent, potentially increasing the attack surface.

Due to the lack of validation of values sent at origin, a scenario might happen in which the messenger could take more assets at origin, deposit the correct lesser amount at destination, and pass the check. [LayerZero's documentation on the _debit function](https://docs.layerzero.network/v2/developers/evm/oft/quickstart#constructing-an-oft-contract) states that "In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90, therefore amountSentLD CAN differ from amountReceivedLD.". The current implementation tries to mitigate this through the [forceApprove call](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/libraries/OFTTransportAdapter.sol#L92) method associated with the token. Still if its implementation allows flexible or greater values than the amount sent, the outcome would rely on the assumption that the messenger does not take more than needed.

Consider imposing restrictions on the values sent at origin to reduce the attack surface and prevent situations as the aforementioned ones. Additionally, consider validating that the tokens used through the OFT messenger do not present a behavior deviation or edge cases when using the approval functionality.