### PR TITLE
[M-03] OFT Transfer Might Revert Due To Non-Zero ZRO Token Fee Quote

### DIFF
--- a/contracts/libraries/OFTTransportAdapter.sol
+++ b/contracts/libraries/OFTTransportAdapter.sol
@@ -33,6 +33,7 @@ contract OFTTransportAdapter {
 
     error OftFeeCapExceeded();
     error OftInsufficientBalanceForFee();
+    error OftLzFeeNotZero();
     error OftIncorrectAmountReceivedLD();
 
     /**
@@ -87,6 +88,7 @@ contract OFTTransportAdapter {
         uint256 nativeFee = fee.nativeFee;
         if (nativeFee > OFT_FEE_CAP) revert OftFeeCapExceeded();
         if (nativeFee > address(this).balance) revert OftInsufficientBalanceForFee();
+        if (fee.lzTokenFee != 0) revert OftLzFeeNotZero();
 
         // Approve the exact _amount for `_messenger` to spend. Fee will be paid in native token
         _token.forceApprove(address(_messenger), _amount);

--- a/contracts/test/MockOFTMessenger.sol
+++ b/contracts/test/MockOFTMessenger.sol
@@ -10,13 +10,21 @@ import "../interfaces/IOFT.sol";
  */
 contract MockOFTMessenger is IOFT {
     address public token;
+    uint256 nativeFee;
+    uint256 lzFee;
 
-    constructor(address _token) {
+    constructor(
+        address _token,
+        uint256 _nativeFee,
+        uint256 _lzFee
+    ) {
         token = _token;
+        nativeFee = _nativeFee;
+        lzFee = _lzFee;
     }
 
     function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory) {
-        return MessagingFee(0, 0);
+        return MessagingFee(nativeFee, lzFee);
     }
 
     function send(


### PR DESCRIPTION
The OFTTransportAdapter contract implements the [_transferViaOFT function](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/libraries/OFTTransportAdapter.sol#L57), meant to interact with the OFT messenger and send the funds with that method. To do so, it first [quotes the fees](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/libraries/OFTTransportAdapter.sol#L85), which are returned as [native or ZRO token fees](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/interfaces/IOFT.sol#L18-L19). Later, this same output is used as [part of the message](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/libraries/OFTTransportAdapter.sol#L94).

Even though the OFTTransportAdapter contract instructs that it will [pay the fees in native tokens](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/libraries/OFTTransportAdapter.sol#L85), there is no validation that the value for fees in ZRO tokens is zero, meaning that it will be passed once again to the messenger. This means that if the implementation of the messenger outputs both quotes at the same time, it might not recognize with which asset it will be paid, resulting in a reversion if it tries to get paid with ZRO.

As seen in an [example from LayerZero](https://docs.layerzero.network/v2/developers/evm/oft/quickstart#calling-send), in case of paying in native tokens, the lzTokenFee parameter is set to zero.

In order to prevent unexpected outcomes and reversions, especially if the messenger deviates in behavior, consider asserting that the returned lzTokenFee is zero when quoting for the cost. Furthermore, consider adding more scenarios to the [mocked contracts](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/test/MockOFTMessenger.sol#L18-L20) to validate the proper integration with protocols.