### PR TITLE
[L-02] Misleading Documentation

### DIFF
--- a/contracts/chain-adapters/Universal_Adapter.sol
+++ b/contracts/chain-adapters/Universal_Adapter.sol
@@ -71,8 +71,9 @@ contract Universal_Adapter is AdapterInterface, CircleCCTPAdapter, OFTTransportA
 
     /**
      * @notice Relays tokens from L1 to L2.
-     * @dev This function only uses the CircleCCTPAdapter to relay USDC tokens to CCTP enabled L2 chains.
-     * Relaying other tokens will cause this function to revert.
+     * @dev This function uses CircleCCTPAdapter to relay USDC and OFTTransportAdapterWithStore to relay
+     * OFT tokens to L2 chains that support these methods. Relaying other tokens will cause this function
+     * to revert.
      * @param l1Token Address of the token on L1.
      * @param l2Token Address of the token on L2. Unused
      * @param amount Amount of tokens to relay.


### PR DESCRIPTION
In the Universal_Adapter contract, the [inline documentation states](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/chain-adapters/Universal_Adapter.sol#L74) that the relayTokens function "only uses the CircleCCTPAdapter to relay USDC tokens to CCTP enabled L2 chains". While this is partially true for that token, the new implementation also allows to use the [OFT method](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/chain-adapters/Universal_Adapter.sol#L90-L92).

Consider updating the documentation to reflect the current behavior of the functionality.