### PR TITLE
[M-02] Compromised Messengers Cannot Be Removed

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1738,7 +1738,7 @@ abstract contract SpokePool is
     }
 
     function _setOftMessenger(address _token, address _messenger) internal {
-        if (IOFT(_messenger).token() != _token) {
+        if (_messenger != address(0) && IOFT(_messenger).token() != _token) {
             revert OFTTokenMismatch();
         }
         oftMessengers[_token] = _messenger;

--- a/test/evm/foundry/local/Universal_SpokePool.t.sol
+++ b/test/evm/foundry/local/Universal_SpokePool.t.sol
@@ -305,6 +305,28 @@ contract UniversalSpokePoolTest is Test {
         assertEq(spokePool.oftMessengers(address(usdt)), address(oftMessenger));
     }
 
+    function testSetOftMessenger_removeMessenger() public {
+        IOFT oftMessenger = IOFT(new MockOFTMessenger(address(usdt)));
+        bytes memory message = abi.encodeWithSignature(
+            "setOftMessenger(address,address)",
+            address(usdt),
+            address(oftMessenger)
+        );
+        bytes memory value = abi.encode(address(spokePool), message);
+        helios.updateStorageSlot(spokePool.getSlotKey(nonce), keccak256(value));
+        spokePool.executeMessage(nonce, value, 100);
+        assertEq(spokePool.oftMessengers(address(usdt)), address(oftMessenger));
+
+        nonce++;
+
+        // Remove the messenger by setting to address(0)
+        message = abi.encodeWithSignature("setOftMessenger(address,address)", address(usdt), address(0));
+        value = abi.encode(address(spokePool), message);
+        helios.updateStorageSlot(spokePool.getSlotKey(nonce), keccak256(value));
+        spokePool.executeMessage(nonce, value, 100);
+        assertEq(spokePool.oftMessengers(address(usdt)), address(0));
+    }
+
     function testNonZeroLzFee() public {
         // Mock an OFT messenger that returns a non-zero lzTokenFee
         MockOFTMessenger oftMessengerWithNonZeroLzFee = new MockOFTMessenger(address(usdt));

--- a/test/evm/hardhat/chain-adapters/Arbitrum_Adapter.ts
+++ b/test/evm/hardhat/chain-adapters/Arbitrum_Adapter.ts
@@ -56,7 +56,7 @@ let l1ERC20GatewayRouter: FakeContract,
 const arbitrumChainId = CHAIN_IDs.ARBITRUM;
 const oftArbitrumEid = getOftEid(arbitrumChainId);
 
-describe.only("Arbitrum Chain Adapter", function () {
+describe("Arbitrum Chain Adapter", function () {
   beforeEach(async function () {
     [owner, dataWorker, liquidityProvider, refundAddress] = await ethers.getSigners();
     ({ weth, dai, l2Weth, l2Dai, hubPool, mockSpoke, timer, usdc, l2Usdc, usdt, l2Usdt } = await hubPoolFixture());

--- a/test/evm/hardhat/chain-specific-spokepools/Arbitrum_SpokePool.ts
+++ b/test/evm/hardhat/chain-specific-spokepools/Arbitrum_SpokePool.ts
@@ -323,4 +323,18 @@ describe("Arbitrum Spoke Pool", function () {
       ).to.be.revertedWith("OftIncorrectAmountSentLD");
     });
   });
+
+  it("Cross domain owner can set and remove an OFT messenger", async function () {
+    l2OftMessenger.token.returns(l2UsdtContract.address);
+
+    await expect(arbitrumSpokePool.setOftMessenger(l2UsdtContract.address, l2OftMessenger.address)).to.be.reverted;
+
+    await arbitrumSpokePool.connect(crossDomainAlias).setOftMessenger(l2UsdtContract.address, l2OftMessenger.address);
+    expect(await arbitrumSpokePool.oftMessengers(l2UsdtContract.address)).to.equal(l2OftMessenger.address);
+
+    await expect(arbitrumSpokePool.setOftMessenger(l2UsdtContract.address, zeroAddress)).to.be.reverted;
+
+    await arbitrumSpokePool.connect(crossDomainAlias).setOftMessenger(l2UsdtContract.address, zeroAddress);
+    expect(await arbitrumSpokePool.oftMessengers(l2UsdtContract.address)).to.equal(zeroAddress);
+  });
 });


### PR DESCRIPTION
In the SpokePool contract, the [_setOftMessenger](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/SpokePool.sol#L1739) function allows for adding or updating an OFT messenger address for a particular token. However, if the current messenger is compromised or needs to be taken down, there is no functionality that would allow the admin to remove it from the available messengers (without replacing it with a new one).

Furthermore, it is not possible to use the _setOftMessenger function to set it to zero, as there is a [validation done over its token](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/SpokePool.sol#L1740) that would revert if the messenger is set to the zero address or to an address that does not have the token method implemented or to an address that does not match the passed one. Since temporarily setting a (compromised) messenger address to a dummy contract that implements the token method could also be dangerous as it might not stop the whole OFT flow, the admin might not be able to react fast enough and stop using it.

Consider implementing a method that would allow the admin to remove a messenger from the storage.