### PR TITLE
[N-02] Typographical Errors in Documentation and Comments

### DIFF
--- a/contracts/chain-adapters/OP_Adapter.sol
+++ b/contracts/chain-adapters/OP_Adapter.sol
@@ -38,7 +38,7 @@ contract OP_Adapter is CrossDomainEnabled, AdapterInterface, CircleCCTPAdapter {
     /**
      * @notice Constructs new Adapter.
      * @param _l1Weth WETH address on L1.
-     * @param _crossDomainMessenger XDomainMessenger Desination chain system contract.
+     * @param _crossDomainMessenger XDomainMessenger Destination chain system contract.
      * @param _l1StandardBridge Standard bridge contract.
      * @param _l1Usdc USDC address on L1.
      */

--- a/contracts/libraries/OFTTransportAdapter.sol
+++ b/contracts/libraries/OFTTransportAdapter.sol
@@ -53,7 +53,7 @@ contract OFTTransportAdapter {
      * @dev the caller has to provide both _token and _messenger. The caller is responsible for knowing the correct _messenger
      * @param _token token we're sending on current chain.
      * @param _messenger corresponding OFT messenger on current chain.
-     * @param _to address to receive a trasnfer on the destination chain.
+     * @param _to address to receive a transfer on the destination chain.
      * @param _amount amount to send.
      */
     function _transferViaOFT(


### PR DESCRIPTION
Typographical errors reduce readability and may cause misunderstandings. Throughout the codebase, multiple instances of typographical errors were identified:

In OP_Adapter.sol, the documentation in [line 41](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/chain-adapters/OP_Adapter.sol#L41) states "Desination", whereas it should be "Destination".
In OFTTransportAdapter.sol, the documentation in [line 54](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/libraries/OFTTransportAdapter.sol#L54) states "trasnfer", whereas it should be "transfer".
Consider correcting any instances of typographical errors and using spell-checking tools to avoid their recurrence.