### PR TITLE
[N-06] Non-Explicit Imports

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -12,7 +12,8 @@ import "./upgradeable/MultiCallerUpgradeable.sol";
 import "./upgradeable/EIP712CrossChainUpgradeable.sol";
 import "./upgradeable/AddressLibUpgradeable.sol";
 import "./libraries/AddressConverters.sol";
-import "./libraries/OFTTransportAdapter.sol";
+import { IOFT } from "./interfaces/IOFT.sol";
+import { OFTTransportAdapter } from "./libraries/OFTTransportAdapter.sol";
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/chain-adapters/Arbitrum_Adapter.sol
+++ b/contracts/chain-adapters/Arbitrum_Adapter.sol
@@ -8,7 +8,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IOFT } from "../interfaces/IOFT.sol";
 import "../external/interfaces/CCTPInterfaces.sol";
 import "../libraries/CircleCCTPAdapter.sol";
-import "../libraries/OFTTransportAdapterWithStore.sol";
+import { OFTTransportAdapterWithStore } from "../libraries/OFTTransportAdapterWithStore.sol";
 import { ArbitrumInboxLike as ArbitrumL1InboxLike, ArbitrumL1ERC20GatewayLike } from "../interfaces/ArbitrumBridge.sol";
 
 /**

--- a/contracts/chain-adapters/Universal_Adapter.sol
+++ b/contracts/chain-adapters/Universal_Adapter.sol
@@ -7,8 +7,7 @@ import "../libraries/CircleCCTPAdapter.sol";
 import { SpokePoolInterface } from "../interfaces/SpokePoolInterface.sol";
 import { HubPoolStore } from "./utilities/HubPoolStore.sol";
 import { IOFT } from "../interfaces/IOFT.sol";
-
-import "../libraries/OFTTransportAdapterWithStore.sol";
+import { OFTTransportAdapterWithStore } from "../libraries/OFTTransportAdapterWithStore.sol";
 
 interface IOwnable {
     function owner() external view returns (address);


### PR DESCRIPTION
The use of non-explicit imports in the codebase can decrease code clarity and may create naming conflicts between locally defined and imported variables. This is particularly relevant when multiple contracts exist within the same Solidity file or when inheritance chains are long.

Throughout the codebase, multiple instances of non-explicit/global imports were identified:

The [import "./libraries/OFTTransportAdapter.sol";](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/SpokePool.sol#L15) import in SpokePool.sol
The [import "../libraries/OFTTransportAdapterWithStore.sol";](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/chain-adapters/Universal_Adapter.sol#L11) import in Universal_Adapter.sol
Following the principle that clearer code is better code, consider using the named import syntax (import {A, B, C} from "X") to explicitly declare which contracts are being imported.