### PR TITLE
[N-09] Lack of Security Contact

### DIFF
--- a/contracts/AdapterStore.sol
+++ b/contracts/AdapterStore.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.0;
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { IOFT } from "./interfaces/IOFT.sol";
 
+/**
+ * @custom:security-contact bugs@across.to
+ */
 library MessengerTypes {
     bytes32 public constant OFT_MESSENGER = bytes32("OFT_MESSENGER");
 }
@@ -12,6 +15,7 @@ library MessengerTypes {
  * @dev A helper contract for chain adapters on the hub chain that support OFT messaging. Handles
  * @dev token => messenger mapping storage. Adapters can't store this themselves as they're called
  * @dev via `delegateCall` and their storage is not part of available context.
+ * @custom:security-contact bugs@across.to
  */
 contract AdapterStore is Ownable {
     // (messengerType, dstDomainId, srcChainToken) => messenger address

--- a/contracts/libraries/OFTTransportAdapterWithStore.sol
+++ b/contracts/libraries/OFTTransportAdapterWithStore.sol
@@ -4,7 +4,10 @@ pragma solidity ^0.8.0;
 import { OFTTransportAdapter } from "./OFTTransportAdapter.sol";
 import { AdapterStore, MessengerTypes } from "../AdapterStore.sol";
 
-// A wrapper of `OFTTransportAdapter` to be used by chain-specific adapters
+/**
+ * @dev A wrapper of `OFTTransportAdapter` to be used by chain-specific adapters
+ * @custom:security-contact bugs@across.to
+ */
 contract OFTTransportAdapterWithStore is OFTTransportAdapter {
     // Helper storage contract to keep track of token => IOFT relationships
     AdapterStore public immutable OFT_ADAPTER_STORE;


### PR DESCRIPTION
Providing a specific security contact (such as an email or ENS name) within a smart contract significantly simplifies the process for individuals to communicate if they identify a vulnerability in the code. This practice is quite beneficial as it permits the code owners to dictate the communication channel for vulnerability disclosure, eliminating the risk of miscommunication or failure to report due to a lack of knowledge on how to do so. In addition, if the contract incorporates third-party libraries and a bug surfaces in those, it becomes easier for their maintainers to contact the appropriate person about the problem and provide mitigation instructions.

Throughout the codebase, multiple instances of contracts missing a security contact were identified:

The [MessengerTypes library](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/AdapterStore.sol#L6)
The [AdapterStore contract](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/AdapterStore.sol#L15)
The [OFTTransportAdapterWithStore contract](https://github.com/across-protocol/contracts/blob/c5d7541037d19053ce2106583b1b711037483038/contracts/libraries/OFTTransportAdapterWithStore.sol#L8)
Consider adding a NatSpec comment containing a security contact above each contract definition. Using the @custom:security-contact convention is recommended as it has been adopted by the [OpenZeppelin Wizard](https://wizard.openzeppelin.com/) and the [ethereum-lists](https://github.com/ethereum-lists/contracts#tracking-new-deployments).