### PR TITLE
[M-06] Inconsistent Use of the __gap Variable

### DIFF
--- a/contracts/Arbitrum_SpokePool.sol
+++ b/contracts/Arbitrum_SpokePool.sol
@@ -121,6 +121,8 @@ contract Arbitrum_SpokePool is SpokePool, CircleCCTPAdapter {
 
     // Reserve storage slots for future versions of this base contract to add state variables without
     // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
-    // are added. This is at bottom of contract to make sure it's always at the end of storage.
+    // are added, so that the total number of slots taken by this contract remains constant. Per-contract
+    // storage layout information  can be found in storage-layouts/
+    // This is at bottom of contract to make sure it's always at the end of storage.
     uint256[1000] private __gap;
 }

--- a/contracts/Ovm_SpokePool.sol
+++ b/contracts/Ovm_SpokePool.sol
@@ -218,6 +218,8 @@ contract Ovm_SpokePool is SpokePool, CircleCCTPAdapter {
 
     // Reserve storage slots for future versions of this base contract to add state variables without
     // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
-    // are added. This is at bottom of contract to make sure its always at the end of storage.
+    // are added, so that the total number of slots taken by this contract remains constant. Per-contract
+    // storage layout information  can be found in storage-layouts/
+    // This is at bottom of contract to make sure it's always at the end of storage.
     uint256[999] private __gap;
 }

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1759,6 +1759,8 @@ abstract contract SpokePool is
 
     // Reserve storage slots for future versions of this base contract to add state variables without
     // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
-    // are added. This is at bottom of contract to make sure it's always at the end of storage.
+    // are added, so that the total number of slots taken by this contract remains constant. Per-contract
+    // storage layout information  can be found in storage-layouts/
+    // This is at bottom of contract to make sure it's always at the end of storage.
     uint256[997] private __gap;
 }

--- a/contracts/ZkSync_SpokePool.sol
+++ b/contracts/ZkSync_SpokePool.sol
@@ -180,6 +180,8 @@ contract ZkSync_SpokePool is SpokePool, CircleCCTPAdapter {
 
     // Reserve storage slots for future versions of this base contract to add state variables without
     // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
-    // are added. This is at bottom of contract to make sure its always at the end of storage.
+    // are added, so that the total number of slots taken by this contract remains constant. Per-contract
+    // storage layout information  can be found in storage-layouts/
+    // This is at bottom of contract to make sure it's always at the end of storage.
     uint256[999] private __gap;
 }

--- a/contracts/chain-adapters/ForwarderBase.sol
+++ b/contracts/chain-adapters/ForwarderBase.sol
@@ -214,6 +214,8 @@ abstract contract ForwarderBase is UUPSUpgradeable, ForwarderInterface, MultiCal
 
     // Reserve storage slots for future versions of this base contract to add state variables without
     // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
-    // are added. This is at bottom of contract to make sure it's always at the end of storage.
+    // are added, so that the total number of slots taken by this contract remains constant. Per-contract
+    // storage layout information  can be found in storage-layouts/
+    // This is at bottom of contract to make sure it's always at the end of storage.
     uint256[1000] private __gap;
 }

--- a/contracts/chain-adapters/l2/WithdrawalHelperBase.sol
+++ b/contracts/chain-adapters/l2/WithdrawalHelperBase.sol
@@ -129,6 +129,8 @@ abstract contract WithdrawalHelperBase is CircleCCTPAdapter, MultiCaller, UUPSUp
 
     // Reserve storage slots for future versions of this base contract to add state variables without
     // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
-    // are added. This is at bottom of contract to make sure it's always at the end of storage.
+    // are added, so that the total number of slots taken by this contract remains constant. Per-contract
+    // storage layout information  can be found in storage-layouts/
+    // This is at bottom of contract to make sure it's always at the end of storage.
     uint256[1000] private __gap;
 }

--- a/contracts/upgradeable/EIP712CrossChainUpgradeable.sol
+++ b/contracts/upgradeable/EIP712CrossChainUpgradeable.sol
@@ -81,6 +81,8 @@ abstract contract EIP712CrossChainUpgradeable is Initializable {
 
     // Reserve storage slots for future versions of this base contract to add state variables without
     // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
-    // are added. This is at bottom of contract to make sure it's always at the end of storage.
+    // are added, so that the total number of slots taken by this contract remains constant. Per-contract
+    // storage layout information  can be found in storage-layouts/
+    // This is at bottom of contract to make sure it's always at the end of storage.
     uint256[1000] private __gap;
 }

--- a/contracts/upgradeable/MultiCallerUpgradeable.sol
+++ b/contracts/upgradeable/MultiCallerUpgradeable.sol
@@ -73,6 +73,8 @@ contract MultiCallerUpgradeable {
 
     // Reserve storage slots for future versions of this base contract to add state variables without
     // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
-    // are added. This is at bottom of contract to make sure its always at the end of storage.
+    // are added, so that the total number of slots taken by this contract remains constant. Per-contract
+    // storage layout information  can be found in storage-layouts/
+    // This is at bottom of contract to make sure it's always at the end of storage.
     uint256[1000] private __gap;
 }


### PR DESCRIPTION
Adjusted `__gap` comment to give more context