### PR TITLE
default exclusivityDeadline to 0 if undefined

### DIFF
--- a/scripts/svm/simpleFill.ts
+++ b/scripts/svm/simpleFill.ts
@@ -55,7 +55,7 @@ async function fillRelay(): Promise<void> {
   const originChainId = new BN(resolvedArgv.originChainId);
   const depositId = intToU8Array32(new BN(resolvedArgv.depositId));
   const fillDeadline = resolvedArgv.fillDeadline || Math.floor(Date.now() / 1000) + 60; // Current time + 1 minute
-  const exclusivityDeadline = resolvedArgv.exclusivityDeadline || Math.floor(Date.now() / 1000) + 30; // Current time + 30 seconds
+  const exclusivityDeadline = resolvedArgv.exclusivityDeadline ?? 0; // default to 0
   const message = Buffer.from("");
   const seed = new BN(resolvedArgv.seed);
 


### PR DESCRIPTION
Currently behavior:
If the caller of the `simpleFill` script supplies an `exclusivityDeadline` or 0, the script sets this number to `current time + buffer`.
This is likely not what the caller wants. If caller supplies 0, which is often the case in production, keep 0.

