### PR TITLE
feat(svm): disallow deposits with output token set to 0x0

### DIFF
--- a/programs/svm-spoke/src/error.rs
+++ b/programs/svm-spoke/src/error.rs
@@ -33,6 +33,8 @@ pub enum CommonError {
     InsufficientSpokePoolBalanceToExecuteLeaf,
     #[msg("Invalid exclusive relayer!")]
     InvalidExclusiveRelayer,
+    #[msg("Invalid output token!")]
+    InvalidOutputToken,
 }
 
 // SVM specific errors.

--- a/programs/svm-spoke/src/instructions/deposit.rs
+++ b/programs/svm-spoke/src/instructions/deposit.rs
@@ -95,6 +95,10 @@ pub fn _deposit(
     let state = &mut ctx.accounts.state;
     let current_time = get_current_time(state)?;
 
+    if output_token == Pubkey::default() {
+        return err!(CommonError::InvalidOutputToken);
+    }
+
     if current_time.checked_sub(quote_timestamp).unwrap_or(u32::MAX) > state.deposit_quote_time_buffer {
         return err!(CommonError::InvalidQuoteTimestamp);
     }

--- a/test/svm/SvmSpoke.Deposit.ts
+++ b/test/svm/SvmSpoke.Deposit.ts
@@ -774,6 +774,17 @@ describe("svm_spoke.deposit", () => {
     assertSE(vaultAccount.amount, depositData.inputAmount, "Vault balance should equal the deposited amount");
   });
 
+  it("Output token cannot be zero address", async () => {
+    const invalidDepositData = { ...depositData, outputToken: new PublicKey("11111111111111111111111111111111") };
+
+    try {
+      await approvedDeposit(invalidDepositData);
+      assert.fail("Should not be able to process deposit with zero output token address");
+    } catch (err: any) {
+      assert.include(err.toString(), "Error Code: InvalidOutputToken", "Expected InvalidOutputToken error");
+    }
+  });
+
   describe("codama client and solana kit", () => {
     it("Deposit with with solana kit and codama client", async () => {
       // typescript is not happy with the depositData object


### PR DESCRIPTION
Implements the same logic for SVM as #1031 on EVM to disallow deposits with zero output token