### PR TITLE
[N-11] Unused Errors Due To Deprecated Logic

### DIFF
--- a/contracts/interfaces/SpokePoolInterface.sol
+++ b/contracts/interfaces/SpokePoolInterface.sol
@@ -56,8 +56,6 @@ interface SpokePoolInterface {
 
     error NotEOA();
     error InvalidDepositorSignature();
-    error InvalidRelayerFeePct();
-    error MaxTransferSizeExceeded();
     error InvalidCrossDomainAdmin();
     error InvalidWithdrawalRecipient();
     error DepositsArePaused();


### PR DESCRIPTION
After the removal of the _deposit function from the SpokePool contract, the InvalidRelayerFeePct and MaxTransferSizeExceeded errors are no longer in use.

Consider removing the unused errors.