### PR TITLE
[L-13] Function Selectors On Deprecated Functions Are Not Locked

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -342,6 +342,47 @@ abstract contract SpokePool is
         emit EmergencyDeletedRootBundle(rootBundleId);
     }
 
+    /**************************************
+     *      REMOVED DEPOSITOR FUNCTIONS   *
+     **************************************/
+
+    /**
+     * @dev REMOVED: This function has been removed and is now disallowed to prevent selector reuse.
+     * @notice This function was removed from the protocol. Calling it will revert.
+     * Function selector is preserved to prevent accidental reuse in future versions.
+     */
+    function depositDeprecated_5947912356(
+        address,
+        address,
+        uint256,
+        uint256,
+        int64,
+        uint32,
+        bytes memory,
+        uint256
+    ) public payable {
+        revert RemovedFunction();
+    }
+
+    /**
+     * @dev REMOVED: This function has been removed and is now disallowed to prevent selector reuse.
+     * @notice This function was removed from the protocol. Calling it will revert.
+     * Function selector is preserved to prevent accidental reuse in future versions.
+     */
+    function depositFor(
+        address,
+        address,
+        address,
+        uint256,
+        uint256,
+        int64,
+        uint32,
+        bytes memory,
+        uint256
+    ) public payable {
+        revert RemovedFunction();
+    }
+
     /********************************************
      *            DEPOSITOR FUNCTIONS           *
      ********************************************/

--- a/contracts/interfaces/SpokePoolInterface.sol
+++ b/contracts/interfaces/SpokePoolInterface.sol
@@ -46,6 +46,41 @@ interface SpokePoolInterface {
 
     function emergencyDeleteRootBundle(uint256 rootBundleId) external;
 
+    // REMOVED FUNCTIONS: These functions have been removed and are now disallowed.
+    // Function selectors are preserved to prevent accidental reuse in future versions.
+    // All calls to these functions will revert.
+
+    /**
+     * @dev REMOVED: This function has been removed and is now disallowed.
+     * @notice Calling this function will revert. Use deposit() or depositV3() instead.
+     */
+    function depositDeprecated_5947912356(
+        address recipient,
+        address originToken,
+        uint256 amount,
+        uint256 destinationChainId,
+        int64 relayerFeePct,
+        uint32 quoteTimestamp,
+        bytes memory message,
+        uint256 maxCount
+    ) external payable;
+
+    /**
+     * @dev REMOVED: This function has been removed and is now disallowed.
+     * @notice Calling this function will revert. Use deposit() or depositV3() instead.
+     */
+    function depositFor(
+        address depositor,
+        address recipient,
+        address originToken,
+        uint256 amount,
+        uint256 destinationChainId,
+        int64 relayerFeePct,
+        uint32 quoteTimestamp,
+        bytes memory message,
+        uint256 maxCount
+    ) external payable;
+
     function executeRelayerRefundLeaf(
         uint32 rootBundleId,
         SpokePoolInterface.RelayerRefundLeaf memory relayerRefundLeaf,

--- a/contracts/interfaces/V3SpokePoolInterface.sol
+++ b/contracts/interfaces/V3SpokePoolInterface.sol
@@ -328,6 +328,7 @@ interface V3SpokePoolInterface {
     error InvalidFillDeadline();
     error InvalidExclusiveRelayer();
     error InvalidOutputToken();
+    error RemovedFunction();
     error MsgValueDoesNotMatchInputAmount();
     error NotExclusiveRelayer();
     error NoSlowFillsInExclusivityWindow();


### PR DESCRIPTION
Pull request 1031 removes already announced deprecated functionalities, such as the depositDeprecated_5947912356 and depositFor functions, alongside their _deposit internal function.

However, as these entry points are removed, future versions of the codebase might introduce new functions that could have the same function selector as the removed ones. In such case, a protocol that might have used the deprecated functionalities could now call to the new ones with unexpected outcomes.

Similarly, if a fallback function is used in the future, depending on its implementation, it might take the calldata of protocols using the old deprecated functionalities with similar results.

In order to prevent the reuse of the deprecated function selectors, consider keeping the public functions' declaration, without their original definition, and reverting the calls to them.