### PR TITLE
[N-01] fix: comment on encoding in slow fill

### DIFF
--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -717,6 +717,9 @@ pub mod svm_spoke {
     /// - proof: Inclusion proof for this leaf in slow relay root in root bundle.
     /// Note: slow_fill_leaf, _root_bundle_id, and proof are optional parameters. If None for any of these is passed,
     /// the caller must load them via the instruction_params account.
+    /// Note: When verifying the slow fill leaf, the relay data is hashed using AnchorSerialize::serialize that encodes
+    /// output token amounts to little-endian format while input token amount preserves its big-endian encoding as it
+    /// is passed as [u8; 32] array.
     pub fn execute_slow_relay_leaf<'info>(
         ctx: Context<'_, '_, '_, 'info, ExecuteSlowRelayLeaf<'info>>,
         _relay_hash: [u8; 32],


### PR DESCRIPTION
Audit identified following issue:

> The [slow fill leaf](https://github.com/across-protocol/contracts/blob/9dbc340fed4b17f3797c2250f2d34e0df476e4d1/programs/svm-spoke/src/instructions/slow_fill.rs#L228) is computed from the `SlowFill` struct which includes [relay data](https://github.com/across-protocol/contracts/blob/9dbc340fed4b17f3797c2250f2d34e0df476e4d1/programs/svm-spoke/src/instructions/slow_fill.rs#L110) for the
corresponding fill. The leaf is then verified for inclusion in the Merkle tree with [slow relay root](https://github.com/across-protocol/contracts/blob/9dbc340fed4b17f3797c2250f2d34e0df476e4d1/programs/svm-spoke/src/instructions/slow_fill.rs#L227)
that is computed off-chain. However, the way that the relay data should be provided may be
unclear to the slow fill executor due to the way that data is serialized before hashing. The
[hashing function](https://github.com/across-protocol/contracts/blob/9dbc340fed4b17f3797c2250f2d34e0df476e4d1/programs/svm-spoke/src/instructions/slow_fill.rs#L227) uses [`AnchorSerialize::serialize`](https://github.com/across-protocol/contracts/blob/9dbc340fed4b17f3797c2250f2d34e0df476e4d1/programs/svm-spoke/src/instructions/slow_fill.rs#L123) to process the relay data before
performing computation, and this function changes integer types to little-endian format in the
resulting serialized bytes. This process may be unclear to the slow fill relayer when providing
the data, resulting in a leaf that does not belong to the tree with the corresponding root.
>
> Consider adding further documentation within the code to clarify the exact format that data
should be provided to avoid confusion and failed slow fill attempts.

This addresses the issue by adding note to `execute_slow_relay_leaf` function on the numerical encoding of token amounts when verifying the slow fill leaf.