### PR TITLE
Updated actions/setup-node from @V3 to @v4

### DIFF
--- a/.github/actions/setup-node-if-needed/action.yml
+++ b/.github/actions/setup-node-if-needed/action.yml
@@ -22,7 +22,7 @@ runs:
         fi
     - name: Setup Node.js
       if: steps.check-node.outputs.installed == 'false'
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: "${{ inputs.node_version }}"
     - name: Resolve actual Node version


### PR DESCRIPTION
Updated actions/setup-node from @V3 to @v4
This is the only file in the repository that was still using the old version (v3). Updating it ensures consistency and up-to-date security across all workflows.
https://github.com/actions/setup-node/releases/tag/v4.4.0