### PR TITLE
improve: export `deployments`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/DeploymentUtils.ts
+++ b/src/DeploymentUtils.ts
@@ -1,11 +1,13 @@
 import * as deployments_ from "../deployments/deployments.json";
 
-interface DeploymentExport {
-  [chainId: string]: { [contractName: string]: { address: string; blockNumber: number } };
-}
-const deployments: DeploymentExport = deployments_ as any;
+/** Mapping: chainId -> contractName -> { address, blockNumber }. */
+export type Deployments = Record<string, Record<string, { address: string; blockNumber: number }>>;
 
-// Returns the deployed address of any contract on any network.
+export const deployments: Readonly<Deployments> = deployments_ as Deployments;
+
+/**
+ * Returns the deployed address of any contract on any network.
+ */
 export function getDeployedAddress(
   contractName: string,
   networkId: number | string,
@@ -19,7 +21,26 @@ export function getDeployedAddress(
   return address;
 }
 
-// Returns the deployment block number of any contract on any network.
+/**
+ * Returns all active deployments for a given contract name across all chains.
+ * Each result contains chainId, address, and blockNumber.
+ */
+export function getAllDeployedAddresses(
+  contractName: string
+): Array<{ chainId: number; address: string; blockNumber: number }> {
+  const results: Array<{ chainId: number; address: string; blockNumber: number }> = [];
+  Object.keys(deployments).forEach((_chainId) => {
+    const info = deployments[_chainId]?.[contractName];
+    if (info?.address) {
+      results.push({ chainId: Number(_chainId), address: info.address, blockNumber: info.blockNumber });
+    }
+  });
+  return results;
+}
+
+/**
+ * Returns the deployment block number of any contract on any network.
+ */
 export function getDeployedBlockNumber(contractName: string, networkId: number): number {
   try {
     return deployments[networkId.toString()][contractName].blockNumber;
@@ -28,7 +49,9 @@ export function getDeployedBlockNumber(contractName: string, networkId: number):
   }
 }
 
-// Returns the chainId and contract name for a given contract address.
+/**
+ * Returns the chainId and contract name for a given contract address.
+ */
 export function getContractInfoFromAddress(contractAddress: string): { chainId: Number; contractName: string } {
   const returnValue: { chainId: number; contractName: string }[] = [];
 

--- a/src/DeploymentUtils.ts
+++ b/src/DeploymentUtils.ts
@@ -3,7 +3,7 @@ import * as deployments_ from "../deployments/deployments.json";
 /** Mapping: chainId -> contractName -> { address, blockNumber }. */
 export type Deployments = Record<string, Record<string, { address: string; blockNumber: number }>>;
 
-export const deployments: Readonly<Deployments> = deployments_ as Deployments;
+export const DEPLOYMENTS: Readonly<Deployments> = deployments_ as Deployments;
 
 /**
  * Returns the deployed address of any contract on any network.
@@ -13,7 +13,7 @@ export function getDeployedAddress(
   networkId: number | string,
   throwOnError = true
 ): string | undefined {
-  const address = deployments[networkId.toString()]?.[contractName]?.address;
+  const address = DEPLOYMENTS[networkId.toString()]?.[contractName]?.address;
   if (!address && throwOnError) {
     throw new Error(`Contract ${contractName} not found on ${networkId} in deployments.json`);
   }
@@ -29,8 +29,8 @@ export function getAllDeployedAddresses(
   contractName: string
 ): Array<{ chainId: number; address: string; blockNumber: number }> {
   const results: Array<{ chainId: number; address: string; blockNumber: number }> = [];
-  Object.keys(deployments).forEach((_chainId) => {
-    const info = deployments[_chainId]?.[contractName];
+  Object.keys(DEPLOYMENTS).forEach((_chainId) => {
+    const info = DEPLOYMENTS[_chainId]?.[contractName];
     if (info?.address) {
       results.push({ chainId: Number(_chainId), address: info.address, blockNumber: info.blockNumber });
     }
@@ -43,7 +43,7 @@ export function getAllDeployedAddresses(
  */
 export function getDeployedBlockNumber(contractName: string, networkId: number): number {
   try {
-    return deployments[networkId.toString()][contractName].blockNumber;
+    return DEPLOYMENTS[networkId.toString()][contractName].blockNumber;
   } catch (_) {
     throw new Error(`Contract ${contractName} not found on ${networkId} in deployments.json`);
   }
@@ -55,9 +55,9 @@ export function getDeployedBlockNumber(contractName: string, networkId: number):
 export function getContractInfoFromAddress(contractAddress: string): { chainId: Number; contractName: string } {
   const returnValue: { chainId: number; contractName: string }[] = [];
 
-  Object.keys(deployments).forEach((_chainId) =>
-    Object.keys(deployments[_chainId]).forEach((_contractName) => {
-      if (deployments[_chainId][_contractName].address === contractAddress)
+  Object.keys(DEPLOYMENTS).forEach((_chainId) =>
+    Object.keys(DEPLOYMENTS[_chainId]).forEach((_contractName) => {
+      if (DEPLOYMENTS[_chainId][_contractName].address === contractAddress)
         returnValue.push({ chainId: Number(_chainId), contractName: _contractName });
     })
   );


### PR DESCRIPTION
With exported `deployments`, consumers of this repo have flexibility to add their own utility fns over it