### PR TITLE
fix: Format constants file on pre commit hook

### DIFF
--- a/scripts/preCommitHook.sh
+++ b/scripts/preCommitHook.sh
@@ -32,7 +32,7 @@ fi
 
 echo "Running generate-constants-json on staged files ..."
 
-yarn generate-constants-json
+yarn generate-constants-json && yarn prettier --write script/utils/constants.json
 GENERATE_CONSTANTS_JSON_EXIT=$?
 if [ $GENERATE_CONSTANTS_JSON_EXIT -ne 0 ]; then
     echo "generate-constants-json encountered an error. Aborting the hook."


### PR DESCRIPTION
When constants.json is generated the ending new line is stripped, this should fix it