### PR TITLE
feat: add swapsProcessed return values to finalizePendingsSwaps

### DIFF
--- a/contracts/periphery/mintburn/HyperCoreFlowExecutor.sol
+++ b/contracts/periphery/mintburn/HyperCoreFlowExecutor.sol
@@ -703,7 +703,7 @@ contract HyperCoreFlowExecutor is AccessControl {
     /// @notice Finalizes pending queue of swaps for `finalToken` if a corresponding SwapHandler has enough balance
     function finalizePendingSwaps(
         address finalToken,
-        uint256 maxToProcess
+        uint256 maxSwapCountToFinalize
     ) external returns (uint256 finalizedSwapsCount, uint256 finalizedSwapsAmount, uint256 totalPendingSwapsRemaining) {
         FinalTokenInfo memory finalTokenInfo = _getExistingFinalTokenInfo(finalToken);
         CoreTokenInfo memory coreTokenInfo = coreTokenInfos[finalToken];
@@ -713,12 +713,12 @@ contract HyperCoreFlowExecutor is AccessControl {
         uint256 head = pendingQueueHead[finalToken];
         bytes32[] storage queue = pendingQueue[finalToken];
         if (head >= queue.length) return (0, 0, 0);
-        if (maxToProcess == 0) return (0, 0, queue.length - head);
+        if (maxSwapCountToFinalize == 0) return (0, 0, queue.length - head);
 
         // Note: `availableCore` is the SwapHandler's Core balance for `finalToken`, which monotonically increases
         uint64 availableCore = HyperCoreLib.spotBalance(address(finalTokenInfo.swapHandler), coreTokenInfo.coreIndex);
 
-        while (head < queue.length && finalizedSwapsCount < maxToProcess) {
+        while (head < queue.length && finalizedSwapsCount < maxSwapCountToFinalize) {
             bytes32 nonce = queue[head];
 
             PendingSwap storage pendingSwap = pendingSwaps[nonce];


### PR DESCRIPTION
Adds `swapsProcessed` and `totalSwapsProcessed` as return vars to `finalizePendingSwaps` 