### PR TITLE
feat: Use deployed-addresses as source of truth

### DIFF
--- a/broadcast/deployed-addresses.json
+++ b/broadcast/deployed-addresses.json
@@ -5,208 +5,173 @@
       "contracts": {
         "AcrossConfigStore": {
           "address": "0x3B03509645713718B78951126E0A6de6f10043f5",
-          "transaction_hash": "Unknown",
           "block_number": 14717196
         },
         "AcrossMerkleDistributor": {
           "address": "0xE50b2cEAC4f60E840Ae513924033E753e2366487",
-          "transaction_hash": "Unknown",
           "block_number": 15976846
         },
         "AdapterStore": {
           "address": "0x42df4D71f35ffBD28ae217d52E83C1DA0007D63b",
-          "transaction_hash": "Unknown",
           "block_number": 23086526
         },
         "Arbitrum_Adapter": {
           "address": "0xc0b6d2f794cc787c71f2ca5cecd57102c32379b3",
-          "transaction_hash": "0xedc397bdc758e28f61e8b35ddab220911ccfe605ddd3649d13223dc12bc137ef",
-          "block_number": 23498485
+          "block_number": 23498485,
+          "transaction_hash": "0xedc397bdc758e28f61e8b35ddab220911ccfe605ddd3649d13223dc12bc137ef"
         },
         "Arbitrum_RescueAdapter": {
           "address": "0xC6fA0a4EBd802c01157d6E7fB1bbd2ae196ae375",
-          "transaction_hash": "Unknown",
           "block_number": 16233939
         },
         "Arbitrum_SendTokensAdapter": {
           "address": "0xC06A68DF12376271817FcEBfb45Be996B0e1593E",
-          "transaction_hash": "Unknown",
           "block_number": 16691987
         },
         "Boba_Adapter": {
           "address": "0x33B0Ec794c15D6Cc705818E70d4CaCe7bCfB5Af3",
-          "transaction_hash": "Unknown",
           "block_number": 14716798
         },
         "Ethereum_Adapter": {
           "address": "0x527E872a5c3f0C7c24Fe33F2593cFB890a285084",
-          "transaction_hash": "Unknown",
           "block_number": 14704381
         },
         "SpokePool": {
           "address": "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5",
-          "transaction_hash": "Unknown",
           "block_number": 17117454
         },
         "HubPool": {
           "address": "0xc186fA914353c44b2E33eBE05f21846F1048bEda",
-          "transaction_hash": "Unknown",
           "block_number": 14819537
         },
         "HubPoolStore": {
           "address": "0x1Ace3BbD69b63063F859514Eca29C9BDd8310E61",
-          "transaction_hash": "Unknown",
           "block_number": 22368469
         },
         "LpTokenFactory": {
           "address": "0x7dB69eb9F52eD773E9b03f5068A1ea0275b2fD9d",
-          "transaction_hash": "Unknown",
           "block_number": 14704307
         },
         "Optimism_Adapter": {
           "address": "0x3562e309c6c79626e5f0cf746fb5bf4f6b8eebe5",
-          "transaction_hash": "0x2d4b2fc5de201b2cf2a4f369c458e86d7577e18ef3850b9d90061fea3d8a6b8f",
-          "block_number": 23498500
+          "block_number": 23498500,
+          "transaction_hash": "0x2d4b2fc5de201b2cf2a4f369c458e86d7577e18ef3850b9d90061fea3d8a6b8f"
         },
         "PolygonTokenBridger": {
           "address": "0x0330E9b4D0325cCfF515E81DFbc7754F2a02ac57",
-          "transaction_hash": "Unknown",
           "block_number": 14819539
         },
         "Polygon_Adapter": {
           "address": "0x537abe038c223066b50312474409924487d2e655",
-          "transaction_hash": "0x8eb57df471fea74d5a69f59abbafb38d1f7c116f24b29b47a8251ee6bc6c9d75",
-          "block_number": 23498649
+          "block_number": 23498649,
+          "transaction_hash": "0x8eb57df471fea74d5a69f59abbafb38d1f7c116f24b29b47a8251ee6bc6c9d75"
         },
         "ZkSync_Adapter": {
           "address": "0xA374585E6062517Ee367ee5044946A6fBe17724f",
-          "transaction_hash": "Unknown",
           "block_number": 22167105
         },
         "Base_Adapter": {
           "address": "0x799bdc55d91864b14b2ed63a34def5d502aa897f",
-          "transaction_hash": "0xf9845ddc7ebcf5e00b6ee2073dfb8cf50a774161e1f4562cd5c11a5016f4bb64",
-          "block_number": 23498763
+          "block_number": 23498763,
+          "transaction_hash": "0xf9845ddc7ebcf5e00b6ee2073dfb8cf50a774161e1f4562cd5c11a5016f4bb64"
         },
         "Linea_Adapter": {
           "address": "0x5A44A32c13e2C43416bFDE5dDF5DCb3880c42787",
-          "transaction_hash": "Unknown",
           "block_number": 22169879
         },
         "BondToken": {
           "address": "0xee1dc6bcf1ee967a350e9ac6caaaa236109002ea",
-          "transaction_hash": "Unknown",
           "block_number": 17980554
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 22420136
         },
         "Mode_Adapter": {
           "address": "0xf1B59868697f3925b72889ede818B9E7ba0316d0",
-          "transaction_hash": "Unknown",
           "block_number": 19914094
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 22967417
         },
         "Lisk_Adapter": {
           "address": "0xF039AdCC74936F90fE175e8b3FE0FdC8b8E0c73b",
-          "transaction_hash": "Unknown",
           "block_number": 22474211
         },
         "Universal_Adapter_56": {
           "address": "0x6f1C9d3bcDF51316E7b515a62C02F601500b084b",
-          "transaction_hash": "Unknown",
           "block_number": 23251254
         },
         "Universal_Adapter_999": {
           "address": "0x0ec70777Ac388774041dD5A1778Cdf3AF3134D2B",
-          "transaction_hash": "Unknown",
           "block_number": 23371516
         },
         "Universal_Adapter_9745": {
           "address": "0xb47fD69FE25878F4E43aAF2F9ad7D0A3A0B22363",
-          "transaction_hash": "Unknown",
           "block_number": 23419367
         },
         "Blast_Adapter": {
           "address": "0xF2bEf5E905AAE0295003ab14872F811E914EdD81",
-          "transaction_hash": "Unknown",
           "block_number": 20221494
         },
         "Scroll_Adapter": {
           "address": "0x2DA799c2223c6ffB595e578903AE6b95839160d8",
-          "transaction_hash": "Unknown",
           "block_number": 22325451
         },
         "Blast_DaiRetriever": {
           "address": "0x98Dd57048d7d5337e92D9102743528ea4Fea64aB",
-          "transaction_hash": "Unknown",
           "block_number": 20378862
         },
         "Blast_RescueAdapter": {
           "address": "0xE5Dea263511F5caC27b15cBd58Ff103F4Ce90957",
-          "transaction_hash": "Unknown",
           "block_number": 20378872
         },
         "Redstone_Adapter": {
           "address": "0x188F8C95B7cfB7993B53a4F643efa687916f73fA",
-          "transaction_hash": "Unknown",
           "block_number": 20432774
         },
         "Zora_Adapter": {
           "address": "0x024f2fc31cbdd8de17194b1892c834f98ef5169b",
-          "transaction_hash": "Unknown",
           "block_number": 20512287
         },
         "WorldChain_Adapter": {
           "address": "0xA8399e221a583A57F54Abb5bA22f31b5D6C09f32",
-          "transaction_hash": "Unknown",
           "block_number": 20963234
         },
         "AlephZero_Adapter": {
           "address": "0x6F4083304C2cA99B077ACE06a5DcF670615915Af",
-          "transaction_hash": "Unknown",
           "block_number": 21131132
         },
         "Ink_Adapter": {
           "address": "0x7e90a40c7519b041a7df6498fbf5662e8cfc61d2",
-          "transaction_hash": "Unknown",
           "block_number": 21438590
         },
         "Cher_Adapter": {
           "address": "0x0c9d064523177dBB55CFE52b9D0c485FBFc35FD2",
-          "transaction_hash": "Unknown",
           "block_number": 21597341
         },
         "Lens_Adapter": {
           "address": "0x5e0B7e20a77BDf11812837D30F1326068Bcf24Cf",
-          "transaction_hash": "Unknown",
           "block_number": 22382942
         },
         "DoctorWho_Adapter": {
           "address": "0x8956efa31572e1d7ed5c8e36772f214a57dfa0d1",
-          "transaction_hash": "0x67979fe35fe433222cc4f1b7966084c65e4cd2dcecc6e0e3a7cd9970d0c77b75",
-          "block_number": 23498783
+          "block_number": 23498783,
+          "transaction_hash": "0x67979fe35fe433222cc4f1b7966084c65e4cd2dcecc6e0e3a7cd9970d0c77b75"
         },
         "Solana_Adapter": {
           "address": "0x9F788694934fD2Ed34D5340B9a76EB34f2bFD7B3",
-          "transaction_hash": "Unknown",
           "block_number": 22595936
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 22789839
         },
         "PermissionSplitterProxy": {
           "address": "0x0Bf07B2e415F02711fFBB32491f8ec9e5489B2e7",
-          "transaction_hash": "0xa2a7b2c6812fb8ae34539fb04cd5f2a9112da1c7f6ffce0ddcf1fee7e43acf48",
-          "block_number": 19084679
+          "block_number": 19084679,
+          "transaction_hash": "0xa2a7b2c6812fb8ae34539fb04cd5f2a9112da1c7f6ffce0ddcf1fee7e43acf48"
         }
       }
     },
@@ -215,43 +180,36 @@
       "contracts": {
         "SpokePool": {
           "address": "0x6f26Bf09B1C792e3228e5467807a900A503c0281",
-          "transaction_hash": "Unknown",
           "block_number": 93903076
         },
         "1inch_SwapAndBridge": {
           "address": "0x3E7448657409278C9d6E192b92F2b69B234FCc42",
-          "transaction_hash": "Unknown",
           "block_number": 120044846
         },
         "UniswapV3_SwapAndBridge": {
           "address": "0x6f4A733c7889f038D77D4f540182Dda17423CcbF",
-          "transaction_hash": "Unknown",
           "block_number": 120044742
         },
         "AcrossMerkleDistributor": {
           "address": "0xc8b31410340d57417bE62672f6B53dfB9de30aC2",
-          "transaction_hash": "Unknown",
           "block_number": 114652330
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 135440379
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 138622548
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 137675818
         },
         "Optimism_SpokePool": {
           "address": "0x21352b3495a6ee1bd2921bdb0a876fadc3a9245e",
-          "transaction_hash": "0xc2df23c0f90b79bb4d0cdc77984bce181b2a9e5f50216b21ce62c7e6608d206f",
-          "block_number": 141955483
+          "block_number": 141955483,
+          "transaction_hash": "0xc2df23c0f90b79bb4d0cdc77984bce181b2a9e5f50216b21ce62c7e6608d206f"
         }
       }
     },
@@ -260,27 +218,22 @@
       "contracts": {
         "SpokePool": {
           "address": "0x4e8E101924eDE233C13e2D8622DC8aED2872d505",
-          "transaction_hash": "Unknown",
           "block_number": 48762335
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 49157612
         },
         "MulticallHandler": {
           "address": "0xAC537C12fE8f544D712d71ED4376a502EEa944d7",
-          "transaction_hash": "Unknown",
           "block_number": 48762440
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 52135703
         },
         "Helios": {
           "address": "0xE58480CA74f1A819faFd777BEDED4E2D5629943d",
-          "transaction_hash": "Unknown",
           "block_number": 59344945
         }
       }
@@ -290,28 +243,24 @@
       "contracts": {
         "SpokePool": {
           "address": "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
-          "transaction_hash": "Unknown",
           "block_number": 7915488
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 15730595
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 22350961
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 20205357
         },
         "DoctorWho_SpokePool": {
           "address": "0x1d82bfdb412415b3ed2514d5eb33574a3c94a72a",
-          "transaction_hash": "0xd11b50621ee864671a6b953ec0f921577089bcf2b796fbed147aad67122daa90",
-          "block_number": 28765348
+          "block_number": 28765348,
+          "transaction_hash": "0xd11b50621ee864671a6b953ec0f921577089bcf2b796fbed147aad67122daa90"
         }
       }
     },
@@ -320,58 +269,48 @@
       "contracts": {
         "MintableERC1155": {
           "address": "0xA15a90E7936A2F8B70E181E955760860D133e56B",
-          "transaction_hash": "Unknown",
           "block_number": 40600414
         },
         "PolygonTokenBridger": {
           "address": "0x0330E9b4D0325cCfF515E81DFbc7754F2a02ac57",
-          "transaction_hash": "Unknown",
           "block_number": 28604258
         },
         "SpokePool": {
           "address": "0x9295ee1d8C5b022Be115A2AD3c30C72E34e7F096",
-          "transaction_hash": "Unknown",
           "block_number": 41908657
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 71155996
         },
         "1inch_UniversalSwapAndBridge": {
           "address": "0xf9735e425a36d22636ef4cb75c7a6c63378290ca",
-          "transaction_hash": "Unknown",
           "block_number": 56529707
         },
         "1inch_SwapAndBridge": {
           "address": "0xaBa0F11D55C5dDC52cD0Cb2cd052B621d45159d5",
-          "transaction_hash": "Unknown",
           "block_number": 56675429
         },
         "UniswapV3_UniversalSwapAndBridge": {
           "address": "0xc2dcb88873e00c9d401de2cbba4c6a28f8a6e2c2",
-          "transaction_hash": "Unknown",
           "block_number": 56529578
         },
         "UniswapV3_SwapAndBridge": {
           "address": "0x9220fa27ae680e4e8d9733932128fa73362e0393",
-          "transaction_hash": "Unknown",
           "block_number": 56675837
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 74229464
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 73247089
         },
         "Polygon_SpokePool": {
           "address": "0x8f7b21ff11006f0520b06074d36e39b6cd83cf29",
-          "transaction_hash": "0x92801b64851c27c614e68b66dc26ab6831c1f2b95f3f805bd8646d1747105685",
-          "block_number": 77338915
+          "block_number": 77338915,
+          "transaction_hash": "0x92801b64851c27c614e68b66dc26ab6831c1f2b95f3f805bd8646d1747105685"
         }
       }
     },
@@ -380,22 +319,18 @@
       "contracts": {
         "SpokePool": {
           "address": "0xb234cA484866c811d0e6D3318866F583781ED045",
-          "transaction_hash": "Unknown",
           "block_number": 4197027
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 4419395
         },
         "MulticallHandler": {
           "address": "0x1Ed0D59019a52870337b51DEe8190486a8663037",
-          "transaction_hash": "Unknown",
           "block_number": 3458452
         },
         "SpokePoolPeriphery": {
           "address": "0x8A8cA9c4112c67b7Dae7dF7E89EA45D592362107",
-          "transaction_hash": "Unknown",
           "block_number": 2884429
         }
       }
@@ -405,7 +340,6 @@
       "contracts": {
         "SpokePool": {
           "address": "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58",
-          "transaction_hash": "Unknown",
           "block_number": 619993
         }
       }
@@ -415,22 +349,18 @@
       "contracts": {
         "SpokePool": {
           "address": "0xE0B015E54d54fc84a6cB9B666099c46adE9335FF",
-          "transaction_hash": "Unknown",
           "block_number": 10352565
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 64765628
         },
         "MulticallHandler": {
           "address": "0x68d3806E57148D6c6793C78EbDDbc272fE605dbf",
-          "transaction_hash": "Unknown",
           "block_number": 63168917
         },
         "SpokePoolPeriphery": {
           "address": "0x672b9ba0CE73b69b5F940362F0ee36AAA3F02986",
-          "transaction_hash": "Unknown",
           "block_number": 62189304
         }
       }
@@ -440,22 +370,18 @@
       "contracts": {
         "SpokePool": {
           "address": "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
-          "transaction_hash": "Unknown",
           "block_number": 4524742
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 13571842
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 16881850
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 15809528
         }
       }
@@ -465,28 +391,24 @@
       "contracts": {
         "SpokePool": {
           "address": "0x13fDac9F9b4777705db45291bbFF3c972c6d1d97",
-          "transaction_hash": "Unknown",
           "block_number": 5512122
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 17147100
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 20457079
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 16783149
         },
         "Redstone_SpokePool": {
           "address": "0x78d8cb7284b14c123a2e81a3246494e8dad873e4",
-          "transaction_hash": "0xa57c46d87a2f441460948eee80f1301db9881360e82158d1dae50e73f3d32166",
-          "block_number": 21978768
+          "block_number": 21978768,
+          "transaction_hash": "0xa57c46d87a2f441460948eee80f1301db9881360e82158d1dae50e73f3d32166"
         }
       }
     },
@@ -495,12 +417,10 @@
       "contracts": {
         "SpokePool": {
           "address": "0xbd886FC0725Cc459b55BbFEb3E4278610331f83b",
-          "transaction_hash": "Unknown",
           "block_number": 13999465
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 32616082
         }
       }
@@ -510,27 +430,22 @@
       "contracts": {
         "SpokePool": {
           "address": "0x35E63eA3eb0fb7A3bc543C71FB66412e1F6B0E04",
-          "transaction_hash": "Unknown",
           "block_number": 13937805
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 14459886
         },
         "Helios": {
           "address": "0xd08baaE74D6d2eAb1F3320B2E1a53eeb391ce8e5",
-          "transaction_hash": "Unknown",
           "block_number": 13934816
         },
         "MulticallHandler": {
           "address": "0x5E7840E06fAcCb6d1c3b5F5E0d1d3d07F2829bba",
-          "transaction_hash": "Unknown",
           "block_number": 13992522
         },
         "SpokePoolPeriphery": {
           "address": "0xF1BF00D947267Da5cC63f8c8A60568c59FA31bCb",
-          "transaction_hash": "Unknown",
           "block_number": 15142204
         }
       }
@@ -540,22 +455,18 @@
       "contracts": {
         "SpokePool": {
           "address": "0x9552a0a6624A23B848060AE5901659CDDa1f83f8",
-          "transaction_hash": "Unknown",
           "block_number": 2602337
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 15875239
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 19185347
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 18113085
         }
       }
@@ -565,12 +476,10 @@
       "contracts": {
         "SpokePool": {
           "address": "0x6999526e507Cc3b03b180BbE05E1Ff938259A874",
-          "transaction_hash": "Unknown",
           "block_number": 12593713
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 26247751
         }
       }
@@ -580,28 +489,24 @@
       "contracts": {
         "SpokePool": {
           "address": "0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96",
-          "transaction_hash": "Unknown",
           "block_number": 1709997
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 6672118
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 9982275
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 8910059
         },
         "Cher_SpokePool": {
           "address": "0x48e687205d3962c43891b8cde5a4fe75fa6c8d7a",
-          "transaction_hash": "0x5e126b5845bf4425d053febf06089e7c02411ee3edf7df6ffa888bc530d85c7f",
-          "block_number": 11504355
+          "block_number": 11504355,
+          "transaction_hash": "0x5e126b5845bf4425d053febf06089e7c02411ee3edf7df6ffa888bc530d85c7f"
         }
       }
     },
@@ -610,12 +515,10 @@
       "contracts": {
         "SpokePool": {
           "address": "0xeF684C38F94F48775959ECf2012D7E864ffb9dd4",
-          "transaction_hash": "Unknown",
           "block_number": 7267988
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 23893534
         }
       }
@@ -625,33 +528,28 @@
       "contracts": {
         "SpokePool": {
           "address": "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
-          "transaction_hash": "Unknown",
           "block_number": 2164878
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 29844942
         },
         "1inch_SwapAndBridge": {
           "address": "0x7CFaBF2eA327009B39f40078011B0Fb714b65926",
-          "transaction_hash": "Unknown",
           "block_number": 14450808
         },
         "UniswapV3_SwapAndBridge": {
           "address": "0xbcfbCE9D92A516e3e7b0762AE218B4194adE34b4",
-          "transaction_hash": "Unknown",
           "block_number": 14450714
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 33154505
         },
         "Base_SpokePool": {
           "address": "0x2eb5def5cf9635f9d926788a26d424287a045b92",
-          "transaction_hash": "0x6ec337bdf00c331fabbfb0e98862aa2b766c613b6d6002c44b53668b7240989c",
-          "block_number": 36361964
+          "block_number": 36361964,
+          "transaction_hash": "0x6ec337bdf00c331fabbfb0e98862aa2b766c613b6d6002c44b53668b7240989c"
         }
       }
     },
@@ -660,27 +558,22 @@
       "contracts": {
         "Helios": {
           "address": "0x7e63a5f1a8f0b4d0934b2f2327daed3f6bb2ee75",
-          "transaction_hash": "Unknown",
           "block_number": 1552582
         },
         "SpokePool": {
           "address": "0x50039fAEfebef707cFD94D6d462fE6D10B39207a",
-          "transaction_hash": "Unknown",
           "block_number": 1710028
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 1619568
         },
         "SpokePoolPeriphery": {
           "address": "0xF1BF00D947267Da5cC63f8c8A60568c59FA31bCb",
-          "transaction_hash": "Unknown",
           "block_number": 1628438
         },
         "MulticallHandler": {
           "address": "0x5E7840E06fAcCb6d1c3b5F5E0d1d3d07F2829bba",
-          "transaction_hash": "Unknown",
           "block_number": 1619956
         }
       }
@@ -690,28 +583,24 @@
       "contracts": {
         "SpokePool": {
           "address": "0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96",
-          "transaction_hash": "Unknown",
           "block_number": 8043187
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 23155816
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 26465760
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 25393939
         },
         "Mode_SpokePool": {
           "address": "0xc49226858478de8757e425661b1b5297102330d7",
-          "transaction_hash": "0x0c14a2fadf82090979edd310e414ba7c7da3558ef1283ad2ec762f0093b5839b",
-          "block_number": 27988148
+          "block_number": 27988148,
+          "transaction_hash": "0x0c14a2fadf82090979edd310e414ba7c7da3558ef1283ad2ec762f0093b5839b"
         }
       }
     },
@@ -720,12 +609,10 @@
       "contracts": {
         "SpokePool": {
           "address": "0x6A0a7f39530923911832Dd60667CE5da5449967B",
-          "transaction_hash": "Unknown",
           "block_number": 156275
         },
         "MulticallHandler": {
           "address": "0x02D2B95F631E0CF6c203E77f827381B0885F7822",
-          "transaction_hash": "Unknown",
           "block_number": 145561
         }
       }
@@ -735,38 +622,32 @@
       "contracts": {
         "SpokePool": {
           "address": "0xe35e9842fceaCA96570B734083f4a58e8F7C5f2A",
-          "transaction_hash": "Unknown",
           "block_number": 83868041
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 333624754
         },
         "1inch_SwapAndBridge": {
           "address": "0xC456398D5eE3B93828252e48beDEDbc39e03368E",
-          "transaction_hash": "Unknown",
           "block_number": 211175795
         },
         "UniswapV3_SwapAndBridge": {
           "address": "0xF633b72A4C2Fb73b77A379bf72864A825aD35b6D",
-          "transaction_hash": "Unknown",
           "block_number": 211175481
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 360020909
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 351421618
         },
         "Arbitrum_SpokePool": {
           "address": "0x33d52d76d617126648067401c106923e4a34dbe1",
-          "transaction_hash": "0x3a645809d7a2d2a0176afc87f8e565419f94547c9b1521b537b6f233c3bb412c",
-          "block_number": 385694983
+          "block_number": 385694983,
+          "transaction_hash": "0x3a645809d7a2d2a0176afc87f8e565419f94547c9b1521b537b6f233c3bb412c"
         }
       }
     },
@@ -775,28 +656,24 @@
       "contracts": {
         "SpokePool": {
           "address": "0xeF684C38F94F48775959ECf2012D7E864ffb9dd4",
-          "transaction_hash": "Unknown",
           "block_number": 1139240
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 12980498
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 19600021
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 17456376
         },
         "Ink_SpokePool": {
           "address": "0x5be04e53b465c6fd89ecff3d36ddf666d198e31a",
-          "transaction_hash": "0x4be0cb8bd16c8541998b7fb4fe7fb93fb453af9edf96dcdef7c2b48f5f134667",
-          "block_number": 22643750
+          "block_number": 22643750,
+          "transaction_hash": "0x4be0cb8bd16c8541998b7fb4fe7fb93fb453af9edf96dcdef7c2b48f5f134667"
         }
       }
     },
@@ -805,22 +682,18 @@
       "contracts": {
         "SpokePool": {
           "address": "0x7E63A5f1a8F0B4d0934B2f2327DAED3F6bb2ee75",
-          "transaction_hash": "Unknown",
           "block_number": 2721169
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 18705781
         },
         "MulticallHandler": {
           "address": "0xdF1C940487574EEfa79989a79a4936A0F979cDa2",
-          "transaction_hash": "Unknown",
           "block_number": 21108879
         },
         "SpokePoolPeriphery": {
           "address": "0xE0BCff426509723B18D6b2f0D8F4602d143bE3e0",
-          "transaction_hash": "Unknown",
           "block_number": 20348650
         }
       }
@@ -830,17 +703,14 @@
       "contracts": {
         "PolygonTokenBridger": {
           "address": "0x4e3737679081c4D3029D88cA560918094f2e0284",
-          "transaction_hash": "Unknown",
           "block_number": 7529773
         },
         "SpokePool": {
           "address": "0xd08baaE74D6d2eAb1F3320B2E1a53eeb391ce8e5",
-          "transaction_hash": "Unknown",
           "block_number": 7529960
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 24181411
         }
       }
@@ -850,28 +720,24 @@
       "contracts": {
         "SpokePool": {
           "address": "0x2D509190Ed0172ba588407D4c2df918F955Cc6E1",
-          "transaction_hash": "Unknown",
           "block_number": 5574280
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 18834642
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 22144286
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 21071991
         },
         "Blast_SpokePool": {
           "address": "0xfcb6f77112951e1995d37542b519fe0a85a1aa77",
-          "transaction_hash": "0x36ddae4eb4e86aab7bcead1e4e18dab4ac19b2e6facdcbc363df0b2f37e2eea0",
-          "block_number": 23665884
+          "block_number": 23665884,
+          "transaction_hash": "0x36ddae4eb4e86aab7bcead1e4e18dab4ac19b2e6facdcbc363df0b2f37e2eea0"
         }
       }
     },
@@ -880,17 +746,14 @@
       "contracts": {
         "SpokePool": {
           "address": "0x82B564983aE7274c86695917BBf8C99ECb6F0F8F",
-          "transaction_hash": "Unknown",
           "block_number": 6082004
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 28665844
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 32080834
         }
       }
@@ -900,17 +763,14 @@
       "contracts": {
         "SpokePool": {
           "address": "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
-          "transaction_hash": "Unknown",
           "block_number": 2929205
         },
         "SpokePoolVerifier": {
           "address": "0x630b76C7cA96164a5aCbC1105f8BA8B739C82570",
-          "transaction_hash": "Unknown",
           "block_number": 3160019
         },
         "MulticallHandler": {
           "address": "0xAC537C12fE8f544D712d71ED4376a502EEa944d7",
-          "transaction_hash": "Unknown",
           "block_number": 3179705
         }
       }
@@ -920,12 +780,10 @@
       "contracts": {
         "SpokePool": {
           "address": "0x7E63A5f1a8F0B4d0934B2f2327DAED3F6bb2ee75",
-          "transaction_hash": "Unknown",
           "block_number": 12411026
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 175845768
         }
       }
@@ -935,28 +793,24 @@
       "contracts": {
         "SpokePool": {
           "address": "0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96",
-          "transaction_hash": "Unknown",
           "block_number": 7489705
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 15223712
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 17441646
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 16783149
         },
         "Scroll_SpokePool": {
           "address": "0x9fda59848900a9c93b7dd9341312a292df8fcdc8",
-          "transaction_hash": "0xe052d93c759370f20c1c3b0212a149a7207c0ea31bb2967e5cf3753f497d736e",
-          "block_number": 20085960
+          "block_number": 20085960,
+          "transaction_hash": "0xe052d93c759370f20c1c3b0212a149a7207c0ea31bb2967e5cf3753f497d736e"
         }
       }
     },
@@ -965,12 +819,10 @@
       "contracts": {
         "SpokePool": {
           "address": "0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96",
-          "transaction_hash": "Unknown",
           "block_number": 15393172
         },
         "MulticallHandler": {
           "address": "0xAC537C12fE8f544D712d71ED4376a502EEa944d7",
-          "transaction_hash": "Unknown",
           "block_number": 15392366
         }
       }
@@ -980,28 +832,24 @@
       "contracts": {
         "SpokePool": {
           "address": "0x13fDac9F9b4777705db45291bbFF3c972c6d1d97",
-          "transaction_hash": "Unknown",
           "block_number": 18382867
         },
         "SpokePoolVerifier": {
           "address": "0x3Fb9cED51E968594C87963a371Ed90c39519f65A",
-          "transaction_hash": "Unknown",
           "block_number": 29892606
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 33202799
         },
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
-          "transaction_hash": "Unknown",
           "block_number": 32130332
         },
         "Zora_SpokePool": {
           "address": "0x40ad479382ad2a5c3061487a5094a677b00f6cb0",
-          "transaction_hash": "0x095f04a9587bad2fabfa5f0a40bb1e2b3481ad5a8904b33a9abd8ac4e0332deb",
-          "block_number": 34724058
+          "block_number": 34724058,
+          "transaction_hash": "0x095f04a9587bad2fabfa5f0a40bb1e2b3481ad5a8904b33a9abd8ac4e0332deb"
         }
       }
     },
@@ -1010,62 +858,50 @@
       "contracts": {
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 8810926
         },
         "AcrossConfigStore": {
           "address": "0xB3De1e212B49e68f4a68b5993f31f63946FCA2a6",
-          "transaction_hash": "Unknown",
           "block_number": 4968255
         },
         "LPTokenFactory": {
           "address": "0xFB87Ac52Bac7ccF497b6053610A9c59B87a0cE7D",
-          "transaction_hash": "Unknown",
           "block_number": 4911834
         },
         "HubPool": {
           "address": "0x14224e63716aface30c9a417e0542281869f7d9e",
-          "transaction_hash": "Unknown",
           "block_number": 4911835
         },
         "SpokePool": {
           "address": "0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662",
-          "transaction_hash": "Unknown",
           "block_number": 5288470
         },
         "PolygonTokenBridger": {
           "address": "0x4e3737679081c4D3029D88cA560918094f2e0284",
-          "transaction_hash": "Unknown",
           "block_number": 5984560
         },
         "Polygon_Adapter": {
           "address": "0x540029039E493b1B843653f93C3064A956931747",
-          "transaction_hash": "Unknown",
           "block_number": 5984591
         },
         "Lisk_Adapter": {
           "address": "0x13a8B1D6443016424e2b8Bac40dD884Ee679AFc4",
-          "transaction_hash": "Unknown",
           "block_number": 6226289
         },
         "Lens_Adapter": {
           "address": "0x8fac6F764ae0b4F632FE2E6c938ED5637E629ff2",
-          "transaction_hash": "Unknown",
           "block_number": 7448085
         },
         "Blast_Adapter": {
           "address": "0x09500Ffd743e01B4146a4BA795231Ca7Ca37819f",
-          "transaction_hash": "Unknown",
           "block_number": 6233857
         },
         "DoctorWho_Adapter": {
           "address": "0x2b482aFb675e1F231521d5E56770ce4aac592246",
-          "transaction_hash": "Unknown",
           "block_number": 7698546
         },
         "Solana_Adapter": {
           "address": "0x9b2c2f3fD98cF8468715Be31155cc053C56f822A",
-          "transaction_hash": "Unknown",
           "block_number": 8409722
         }
       }
@@ -1075,12 +911,10 @@
       "contracts": {
         "SpokePool": {
           "address": "0x4e8E101924eDE233C13e2D8622DC8aED2872d505",
-          "transaction_hash": "Unknown",
           "block_number": 7762656
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 138622548
         }
       }
@@ -1090,12 +924,10 @@
       "contracts": {
         "SpokePool": {
           "address": "0x5545092553Cf5Bf786e87a87192E902D50D8f022",
-          "transaction_hash": "Unknown",
           "block_number": 7634204
         },
         "MulticallHandler": {
           "address": "0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E",
-          "transaction_hash": "Unknown",
           "block_number": 24206664
         }
       }
@@ -1105,32 +937,26 @@
       "contracts": {
         "SvmSpoke": {
           "address": "JAZWcGrpSWNPTBj8QtJ9UyQqhJCDhG9GJkDeMf5NQBiq",
-          "transaction_hash": "Unknown",
           "block_number": 356313770
         },
         "MulticallHandler": {
           "address": "Fk1RpqsfeWt8KnFCTW9NQVdVxYvxuqjGn6iPB9wrmM8h",
-          "transaction_hash": "Unknown",
           "block_number": 356321050
         },
         "MessageTransmitter": {
           "address": "CCTPmbSD7gX1bxKPAmg77w8oFzNFpaQiQUWD43TKaecd",
-          "transaction_hash": "Unknown",
           "block_number": 339604856
         },
         "TokenMessengerMinter": {
           "address": "CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3",
-          "transaction_hash": "Unknown",
           "block_number": 277864039
         },
         "MessageTransmitterV2": {
           "address": "CCTPV2Sm4AdWt5296sk4P66VBZ7bEhcARwFaaS9YPbeC",
-          "transaction_hash": "Unknown",
           "block_number": 383716739
         },
         "TokenMessengerMinterV2": {
           "address": "CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe",
-          "transaction_hash": "Unknown",
           "block_number": 383709630
         }
       }
@@ -1140,32 +966,26 @@
       "contracts": {
         "SvmSpoke": {
           "address": "DLv3NggMiSaef97YCkew5xKUHDh13tVGZ7tydt3ZeAru",
-          "transaction_hash": "Unknown",
           "block_number": 349354195
         },
         "MulticallHandler": {
           "address": "HaQe51FWtnmaEcuYEfPA7MRCXKrtqptat4oJdJ8zV5Be",
-          "transaction_hash": "Unknown",
           "block_number": 349358090
         },
         "MessageTransmitter": {
           "address": "CCTPmbSD7gX1bxKPAmg77w8oFzNFpaQiQUWD43TKaecd",
-          "transaction_hash": "Unknown",
           "block_number": 312515728
         },
         "TokenMessengerMinter": {
           "address": "CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3",
-          "transaction_hash": "Unknown",
           "block_number": 262177984
         },
         "MessageTransmitterV2": {
           "address": "CCTPV2Sm4AdWt5296sk4P66VBZ7bEhcARwFaaS9YPbeC",
-          "transaction_hash": "Unknown",
           "block_number": 343321624
         },
         "TokenMessengerMinterV2": {
           "address": "CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe",
-          "transaction_hash": "Unknown",
           "block_number": 343322709
         }
       }

--- a/broadcast/deployed-addresses.md
+++ b/broadcast/deployed-addresses.md
@@ -9,241 +9,201 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### AcrossConfigStore
 
 - **AcrossConfigStore**: `0x3B03509645713718B78951126E0A6de6f10043f5`
-  - Transaction Hash: `Unknown`
   - Block Number: `14717196`
 
 #### AcrossMerkleDistributor
 
 - **AcrossMerkleDistributor**: `0xE50b2cEAC4f60E840Ae513924033E753e2366487`
-  - Transaction Hash: `Unknown`
   - Block Number: `15976846`
 
 #### AdapterStore
 
 - **AdapterStore**: `0x42df4D71f35ffBD28ae217d52E83C1DA0007D63b`
-  - Transaction Hash: `Unknown`
   - Block Number: `23086526`
 
 #### Arbitrum_Adapter
 
 - **Arbitrum_Adapter**: `0x5eC9844936875E27eBF22172f4d92E107D35B57C`
-  - Transaction Hash: `Unknown`
   - Block Number: `23086601`
 
 #### Arbitrum_RescueAdapter
 
 - **Arbitrum_RescueAdapter**: `0xC6fA0a4EBd802c01157d6E7fB1bbd2ae196ae375`
-  - Transaction Hash: `Unknown`
   - Block Number: `16233939`
 
 #### Arbitrum_SendTokensAdapter
 
 - **Arbitrum_SendTokensAdapter**: `0xC06A68DF12376271817FcEBfb45Be996B0e1593E`
-  - Transaction Hash: `Unknown`
   - Block Number: `16691987`
 
 #### Boba_Adapter
 
 - **Boba_Adapter**: `0x33B0Ec794c15D6Cc705818E70d4CaCe7bCfB5Af3`
-  - Transaction Hash: `Unknown`
   - Block Number: `14716798`
 
 #### Ethereum_Adapter
 
 - **Ethereum_Adapter**: `0x527E872a5c3f0C7c24Fe33F2593cFB890a285084`
-  - Transaction Hash: `Unknown`
   - Block Number: `14704381`
 
 #### SpokePool
 
 - **SpokePool**: `0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5`
-  - Transaction Hash: `Unknown`
   - Block Number: `17117454`
 
 #### HubPool
 
 - **HubPool**: `0xc186fA914353c44b2E33eBE05f21846F1048bEda`
-  - Transaction Hash: `Unknown`
   - Block Number: `14819537`
 
 #### HubPoolStore
 
 - **HubPoolStore**: `0x1Ace3BbD69b63063F859514Eca29C9BDd8310E61`
-  - Transaction Hash: `Unknown`
   - Block Number: `22368469`
 
 #### LpTokenFactory
 
 - **LpTokenFactory**: `0x7dB69eb9F52eD773E9b03f5068A1ea0275b2fD9d`
-  - Transaction Hash: `Unknown`
   - Block Number: `14704307`
 
 #### Optimism_Adapter
 
 - **Optimism_Adapter**: `0xE1e74B3D6A8E2A479B62958D4E4E6eEaea5B612b`
-  - Transaction Hash: `Unknown`
   - Block Number: `19915034`
 
 #### PolygonTokenBridger
 
 - **PolygonTokenBridger**: `0x0330E9b4D0325cCfF515E81DFbc7754F2a02ac57`
-  - Transaction Hash: `Unknown`
   - Block Number: `14819539`
 
 #### Polygon_Adapter
 
 - **Polygon_Adapter**: `0xF71F1e20F75820b484F8A0959C2D9E5cdd89c9F0`
-  - Transaction Hash: `Unknown`
   - Block Number: `23227800`
 
 #### ZkSync_Adapter
 
 - **ZkSync_Adapter**: `0xA374585E6062517Ee367ee5044946A6fBe17724f`
-  - Transaction Hash: `Unknown`
   - Block Number: `22167105`
 
 #### Base_Adapter
 
 - **Base_Adapter**: `0xE1421233BF7158A19f89F17c9735F9cbd3D9529c`
-  - Transaction Hash: `Unknown`
   - Block Number: `19915087`
 
 #### Linea_Adapter
 
 - **Linea_Adapter**: `0x5A44A32c13e2C43416bFDE5dDF5DCb3880c42787`
-  - Transaction Hash: `Unknown`
   - Block Number: `22169879`
 
 #### BondToken
 
 - **BondToken**: `0xee1dc6bcf1ee967a350e9ac6caaaa236109002ea`
-  - Transaction Hash: `Unknown`
   - Block Number: `17980554`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `22420136`
 
 #### Mode_Adapter
 
 - **Mode_Adapter**: `0xf1B59868697f3925b72889ede818B9E7ba0316d0`
-  - Transaction Hash: `Unknown`
   - Block Number: `19914094`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `22967417`
 
 #### Lisk_Adapter
 
 - **Lisk_Adapter**: `0xF039AdCC74936F90fE175e8b3FE0FdC8b8E0c73b`
-  - Transaction Hash: `Unknown`
   - Block Number: `22474211`
 
 #### Universal_Adapter_56
 
 - **Universal_Adapter_56**: `0x6f1C9d3bcDF51316E7b515a62C02F601500b084b`
-  - Transaction Hash: `Unknown`
   - Block Number: `23251254`
 
 #### Universal_Adapter_999
 
 - **Universal_Adapter_999**: `0x0ec70777Ac388774041dD5A1778Cdf3AF3134D2B`
-  - Transaction Hash: `Unknown`
   - Block Number: `23371516`
 
 #### Universal_Adapter_9745
 
 - **Universal_Adapter_9745**: `0xb47fD69FE25878F4E43aAF2F9ad7D0A3A0B22363`
-  - Transaction Hash: `Unknown`
   - Block Number: `23419367`
 
 #### Blast_Adapter
 
 - **Blast_Adapter**: `0xF2bEf5E905AAE0295003ab14872F811E914EdD81`
-  - Transaction Hash: `Unknown`
   - Block Number: `20221494`
 
 #### Scroll_Adapter
 
 - **Scroll_Adapter**: `0x2DA799c2223c6ffB595e578903AE6b95839160d8`
-  - Transaction Hash: `Unknown`
   - Block Number: `22325451`
 
 #### Blast_DaiRetriever
 
 - **Blast_DaiRetriever**: `0x98Dd57048d7d5337e92D9102743528ea4Fea64aB`
-  - Transaction Hash: `Unknown`
   - Block Number: `20378862`
 
 #### Blast_RescueAdapter
 
 - **Blast_RescueAdapter**: `0xE5Dea263511F5caC27b15cBd58Ff103F4Ce90957`
-  - Transaction Hash: `Unknown`
   - Block Number: `20378872`
 
 #### Redstone_Adapter
 
 - **Redstone_Adapter**: `0x188F8C95B7cfB7993B53a4F643efa687916f73fA`
-  - Transaction Hash: `Unknown`
   - Block Number: `20432774`
 
 #### Zora_Adapter
 
 - **Zora_Adapter**: `0x024f2fc31cbdd8de17194b1892c834f98ef5169b`
-  - Transaction Hash: `Unknown`
   - Block Number: `20512287`
 
 #### WorldChain_Adapter
 
 - **WorldChain_Adapter**: `0xA8399e221a583A57F54Abb5bA22f31b5D6C09f32`
-  - Transaction Hash: `Unknown`
   - Block Number: `20963234`
 
 #### AlephZero_Adapter
 
 - **AlephZero_Adapter**: `0x6F4083304C2cA99B077ACE06a5DcF670615915Af`
-  - Transaction Hash: `Unknown`
   - Block Number: `21131132`
 
 #### Ink_Adapter
 
 - **Ink_Adapter**: `0x7e90a40c7519b041a7df6498fbf5662e8cfc61d2`
-  - Transaction Hash: `Unknown`
   - Block Number: `21438590`
 
 #### Cher_Adapter
 
 - **Cher_Adapter**: `0x0c9d064523177dBB55CFE52b9D0c485FBFc35FD2`
-  - Transaction Hash: `Unknown`
   - Block Number: `21597341`
 
 #### Lens_Adapter
 
 - **Lens_Adapter**: `0x5e0B7e20a77BDf11812837D30F1326068Bcf24Cf`
-  - Transaction Hash: `Unknown`
   - Block Number: `22382942`
 
 #### DoctorWho_Adapter
 
 - **DoctorWho_Adapter**: `0xFADcC43096756e1527306FD92982FEbBe3c629Fa`
-  - Transaction Hash: `Unknown`
   - Block Number: `21773451`
 
 #### Solana_Adapter
 
 - **Solana_Adapter**: `0x9F788694934fD2Ed34D5340B9a76EB34f2bFD7B3`
-  - Transaction Hash: `Unknown`
   - Block Number: `22595936`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `22789839`
 
 #### Optimism_Adapter
@@ -287,43 +247,36 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x6f26Bf09B1C792e3228e5467807a900A503c0281`
-  - Transaction Hash: `Unknown`
   - Block Number: `93903076`
 
 #### 1inch_SwapAndBridge
 
 - **1inch_SwapAndBridge**: `0x3E7448657409278C9d6E192b92F2b69B234FCc42`
-  - Transaction Hash: `Unknown`
   - Block Number: `120044846`
 
 #### UniswapV3_SwapAndBridge
 
 - **UniswapV3_SwapAndBridge**: `0x6f4A733c7889f038D77D4f540182Dda17423CcbF`
-  - Transaction Hash: `Unknown`
   - Block Number: `120044742`
 
 #### AcrossMerkleDistributor
 
 - **AcrossMerkleDistributor**: `0xc8b31410340d57417bE62672f6B53dfB9de30aC2`
-  - Transaction Hash: `Unknown`
   - Block Number: `114652330`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `135440379`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `138622548`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `137675818`
 
 #### Optimism_SpokePool
@@ -337,31 +290,26 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x4e8E101924eDE233C13e2D8622DC8aED2872d505`
-  - Transaction Hash: `Unknown`
   - Block Number: `48762335`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `49157612`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0xAC537C12fE8f544D712d71ED4376a502EEa944d7`
-  - Transaction Hash: `Unknown`
   - Block Number: `48762440`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `52135703`
 
 #### Helios
 
 - **Helios**: `0xE58480CA74f1A819faFd777BEDED4E2D5629943d`
-  - Transaction Hash: `Unknown`
   - Block Number: `59344945`
 
 ### Unichain (Chain ID: 130)
@@ -369,25 +317,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64`
-  - Transaction Hash: `Unknown`
   - Block Number: `7915488`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `15730595`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `22350961`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `20205357`
 
 #### DoctorWho_SpokePool
@@ -401,61 +345,51 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### MintableERC1155
 
 - **MintableERC1155**: `0xA15a90E7936A2F8B70E181E955760860D133e56B`
-  - Transaction Hash: `Unknown`
   - Block Number: `40600414`
 
 #### PolygonTokenBridger
 
 - **PolygonTokenBridger**: `0x0330E9b4D0325cCfF515E81DFbc7754F2a02ac57`
-  - Transaction Hash: `Unknown`
   - Block Number: `28604258`
 
 #### SpokePool
 
 - **SpokePool**: `0x9295ee1d8C5b022Be115A2AD3c30C72E34e7F096`
-  - Transaction Hash: `Unknown`
   - Block Number: `41908657`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `71155996`
 
 #### 1inch_UniversalSwapAndBridge
 
 - **1inch_UniversalSwapAndBridge**: `0xf9735e425a36d22636ef4cb75c7a6c63378290ca`
-  - Transaction Hash: `Unknown`
   - Block Number: `56529707`
 
 #### 1inch_SwapAndBridge
 
 - **1inch_SwapAndBridge**: `0xaBa0F11D55C5dDC52cD0Cb2cd052B621d45159d5`
-  - Transaction Hash: `Unknown`
   - Block Number: `56675429`
 
 #### UniswapV3_UniversalSwapAndBridge
 
 - **UniswapV3_UniversalSwapAndBridge**: `0xc2dcb88873e00c9d401de2cbba4c6a28f8a6e2c2`
-  - Transaction Hash: `Unknown`
   - Block Number: `56529578`
 
 #### UniswapV3_SwapAndBridge
 
 - **UniswapV3_SwapAndBridge**: `0x9220fa27ae680e4e8d9733932128fa73362e0393`
-  - Transaction Hash: `Unknown`
   - Block Number: `56675837`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `74229464`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `73247089`
 
 #### Polygon_SpokePool
@@ -469,25 +403,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0xb234cA484866c811d0e6D3318866F583781ED045`
-  - Transaction Hash: `Unknown`
   - Block Number: `4197027`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `4419395`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x1Ed0D59019a52870337b51DEe8190486a8663037`
-  - Transaction Hash: `Unknown`
   - Block Number: `3458452`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x8A8cA9c4112c67b7Dae7dF7E89EA45D592362107`
-  - Transaction Hash: `Unknown`
   - Block Number: `2884429`
 
 ### Boba (Chain ID: 288)
@@ -495,7 +425,6 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58`
-  - Transaction Hash: `Unknown`
   - Block Number: `619993`
 
 ### zkSync (Chain ID: 324)
@@ -503,25 +432,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0xE0B015E54d54fc84a6cB9B666099c46adE9335FF`
-  - Transaction Hash: `Unknown`
   - Block Number: `10352565`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `64765628`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x68d3806E57148D6c6793C78EbDDbc272fE605dbf`
-  - Transaction Hash: `Unknown`
   - Block Number: `63168917`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x672b9ba0CE73b69b5F940362F0ee36AAA3F02986`
-  - Transaction Hash: `Unknown`
   - Block Number: `62189304`
 
 ### World Chain (Chain ID: 480)
@@ -529,25 +454,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64`
-  - Transaction Hash: `Unknown`
   - Block Number: `4524742`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `13571842`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `16881850`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `15809528`
 
 ### Redstone (Chain ID: 690)
@@ -555,25 +476,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x13fDac9F9b4777705db45291bbFF3c972c6d1d97`
-  - Transaction Hash: `Unknown`
   - Block Number: `5512122`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `17147100`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `20457079`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `16783149`
 
 #### Redstone_SpokePool
@@ -587,31 +504,26 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x35E63eA3eb0fb7A3bc543C71FB66412e1F6B0E04`
-  - Transaction Hash: `Unknown`
   - Block Number: `13937805`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `14459886`
 
 #### Helios
 
 - **Helios**: `0xd08baaE74D6d2eAb1F3320B2E1a53eeb391ce8e5`
-  - Transaction Hash: `Unknown`
   - Block Number: `13934816`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x5E7840E06fAcCb6d1c3b5F5E0d1d3d07F2829bba`
-  - Transaction Hash: `Unknown`
   - Block Number: `13992522`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0xF1BF00D947267Da5cC63f8c8A60568c59FA31bCb`
-  - Transaction Hash: `Unknown`
   - Block Number: `15142204`
 
 ### Lisk (Chain ID: 1135)
@@ -619,25 +531,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x9552a0a6624A23B848060AE5901659CDDa1f83f8`
-  - Transaction Hash: `Unknown`
   - Block Number: `2602337`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `15875239`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `19185347`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `18113085`
 
 ### Soneium (Chain ID: 1868)
@@ -645,25 +553,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96`
-  - Transaction Hash: `Unknown`
   - Block Number: `1709997`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `6672118`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `9982275`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `8910059`
 
 #### Cher_SpokePool
@@ -677,31 +581,26 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64`
-  - Transaction Hash: `Unknown`
   - Block Number: `2164878`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `29844942`
 
 #### 1inch_SwapAndBridge
 
 - **1inch_SwapAndBridge**: `0x7CFaBF2eA327009B39f40078011B0Fb714b65926`
-  - Transaction Hash: `Unknown`
   - Block Number: `14450808`
 
 #### UniswapV3_SwapAndBridge
 
 - **UniswapV3_SwapAndBridge**: `0xbcfbCE9D92A516e3e7b0762AE218B4194adE34b4`
-  - Transaction Hash: `Unknown`
   - Block Number: `14450714`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `33154505`
 
 #### Base_SpokePool
@@ -715,31 +614,26 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### Helios
 
 - **Helios**: `0x7e63a5f1a8f0b4d0934b2f2327daed3f6bb2ee75`
-  - Transaction Hash: `Unknown`
   - Block Number: `1552582`
 
 #### SpokePool
 
 - **SpokePool**: `0x50039fAEfebef707cFD94D6d462fE6D10B39207a`
-  - Transaction Hash: `Unknown`
   - Block Number: `1710028`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `1619568`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0xF1BF00D947267Da5cC63f8c8A60568c59FA31bCb`
-  - Transaction Hash: `Unknown`
   - Block Number: `1628438`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x5E7840E06fAcCb6d1c3b5F5E0d1d3d07F2829bba`
-  - Transaction Hash: `Unknown`
   - Block Number: `1619956`
 
 ### Mode (Chain ID: 34443)
@@ -747,25 +641,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96`
-  - Transaction Hash: `Unknown`
   - Block Number: `8043187`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `23155816`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `26465760`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `25393939`
 
 #### Mode_SpokePool
@@ -779,37 +669,31 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0xe35e9842fceaCA96570B734083f4a58e8F7C5f2A`
-  - Transaction Hash: `Unknown`
   - Block Number: `83868041`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `333624754`
 
 #### 1inch_SwapAndBridge
 
 - **1inch_SwapAndBridge**: `0xC456398D5eE3B93828252e48beDEDbc39e03368E`
-  - Transaction Hash: `Unknown`
   - Block Number: `211175795`
 
 #### UniswapV3_SwapAndBridge
 
 - **UniswapV3_SwapAndBridge**: `0xF633b72A4C2Fb73b77A379bf72864A825aD35b6D`
-  - Transaction Hash: `Unknown`
   - Block Number: `211175481`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `360020909`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `351421618`
 
 #### Arbitrum_SpokePool
@@ -823,25 +707,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0xeF684C38F94F48775959ECf2012D7E864ffb9dd4`
-  - Transaction Hash: `Unknown`
   - Block Number: `1139240`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `12980498`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `19600021`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `17456376`
 
 #### Ink_SpokePool
@@ -855,25 +735,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x7E63A5f1a8F0B4d0934B2f2327DAED3F6bb2ee75`
-  - Transaction Hash: `Unknown`
   - Block Number: `2721169`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `18705781`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0xdF1C940487574EEfa79989a79a4936A0F979cDa2`
-  - Transaction Hash: `Unknown`
   - Block Number: `21108879`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0xE0BCff426509723B18D6b2f0D8F4602d143bE3e0`
-  - Transaction Hash: `Unknown`
   - Block Number: `20348650`
 
 ### Blast (Chain ID: 81457)
@@ -881,25 +757,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x2D509190Ed0172ba588407D4c2df918F955Cc6E1`
-  - Transaction Hash: `Unknown`
   - Block Number: `5574280`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `18834642`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `22144286`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `21071991`
 
 #### Blast_SpokePool
@@ -913,25 +785,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96`
-  - Transaction Hash: `Unknown`
   - Block Number: `7489705`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `15223712`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `17441646`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `16783149`
 
 #### Scroll_SpokePool
@@ -945,25 +813,21 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x13fDac9F9b4777705db45291bbFF3c972c6d1d97`
-  - Transaction Hash: `Unknown`
   - Block Number: `18382867`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x3Fb9cED51E968594C87963a371Ed90c39519f65A`
-  - Transaction Hash: `Unknown`
   - Block Number: `29892606`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `33202799`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `32130332`
 
 #### Zora_SpokePool
@@ -977,37 +841,31 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SvmSpoke
 
 - **SvmSpoke**: `DLv3NggMiSaef97YCkew5xKUHDh13tVGZ7tydt3ZeAru`
-  - Transaction Hash: `Unknown`
   - Block Number: `349354195`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `HaQe51FWtnmaEcuYEfPA7MRCXKrtqptat4oJdJ8zV5Be`
-  - Transaction Hash: `Unknown`
   - Block Number: `349358090`
 
 #### MessageTransmitter
 
 - **MessageTransmitter**: `CCTPmbSD7gX1bxKPAmg77w8oFzNFpaQiQUWD43TKaecd`
-  - Transaction Hash: `Unknown`
   - Block Number: `312515728`
 
 #### TokenMessengerMinter
 
 - **TokenMessengerMinter**: `CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3`
-  - Transaction Hash: `Unknown`
   - Block Number: `262177984`
 
 #### MessageTransmitterV2
 
 - **MessageTransmitterV2**: `CCTPV2Sm4AdWt5296sk4P66VBZ7bEhcARwFaaS9YPbeC`
-  - Transaction Hash: `Unknown`
   - Block Number: `343321624`
 
 #### TokenMessengerMinterV2
 
 - **TokenMessengerMinterV2**: `CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe`
-  - Transaction Hash: `Unknown`
   - Block Number: `343322709`
 
 ## 🧪 Testnet Networks
@@ -1017,13 +875,11 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0xbd886FC0725Cc459b55BbFEb3E4278610331f83b`
-  - Transaction Hash: `Unknown`
   - Block Number: `13999465`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `32616082`
 
 ### Unichain Sepolia (Chain ID: 1301)
@@ -1031,13 +887,11 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x6999526e507Cc3b03b180BbE05E1Ff938259A874`
-  - Transaction Hash: `Unknown`
   - Block Number: `12593713`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `26247751`
 
 ### Lisk Sepolia (Chain ID: 4202)
@@ -1045,13 +899,11 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0xeF684C38F94F48775959ECf2012D7E864ffb9dd4`
-  - Transaction Hash: `Unknown`
   - Block Number: `7267988`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `23893534`
 
 ### Lens Sepolia (Chain ID: 37111)
@@ -1059,13 +911,11 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x6A0a7f39530923911832Dd60667CE5da5449967B`
-  - Transaction Hash: `Unknown`
   - Block Number: `156275`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x02D2B95F631E0CF6c203E77f827381B0885F7822`
-  - Transaction Hash: `Unknown`
   - Block Number: `145561`
 
 ### Polygon Amoy (Chain ID: 80002)
@@ -1073,19 +923,16 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### PolygonTokenBridger
 
 - **PolygonTokenBridger**: `0x4e3737679081c4D3029D88cA560918094f2e0284`
-  - Transaction Hash: `Unknown`
   - Block Number: `7529773`
 
 #### SpokePool
 
 - **SpokePool**: `0xd08baaE74D6d2eAb1F3320B2E1a53eeb391ce8e5`
-  - Transaction Hash: `Unknown`
   - Block Number: `7529960`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `24181411`
 
 ### Base Sepolia (Chain ID: 84532)
@@ -1093,19 +940,16 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x82B564983aE7274c86695917BBf8C99ECb6F0F8F`
-  - Transaction Hash: `Unknown`
   - Block Number: `6082004`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `28665844`
 
 #### SpokePoolPeriphery
 
 - **SpokePoolPeriphery**: `0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C`
-  - Transaction Hash: `Unknown`
   - Block Number: `32080834`
 
 ### Tatara (Chain ID: 129399)
@@ -1113,19 +957,16 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64`
-  - Transaction Hash: `Unknown`
   - Block Number: `2929205`
 
 #### SpokePoolVerifier
 
 - **SpokePoolVerifier**: `0x630b76C7cA96164a5aCbC1105f8BA8B739C82570`
-  - Transaction Hash: `Unknown`
   - Block Number: `3160019`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0xAC537C12fE8f544D712d71ED4376a502EEa944d7`
-  - Transaction Hash: `Unknown`
   - Block Number: `3179705`
 
 ### Arbitrum Sepolia (Chain ID: 421614)
@@ -1133,13 +974,11 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x7E63A5f1a8F0B4d0934B2f2327DAED3F6bb2ee75`
-  - Transaction Hash: `Unknown`
   - Block Number: `12411026`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `175845768`
 
 ### BOB Sepolia (Chain ID: 808813)
@@ -1147,13 +986,11 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96`
-  - Transaction Hash: `Unknown`
   - Block Number: `15393172`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0xAC537C12fE8f544D712d71ED4376a502EEa944d7`
-  - Transaction Hash: `Unknown`
   - Block Number: `15392366`
 
 ### Sepolia (Chain ID: 11155111)
@@ -1161,73 +998,61 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `8810926`
 
 #### AcrossConfigStore
 
 - **AcrossConfigStore**: `0xB3De1e212B49e68f4a68b5993f31f63946FCA2a6`
-  - Transaction Hash: `Unknown`
   - Block Number: `4968255`
 
 #### LPTokenFactory
 
 - **LPTokenFactory**: `0xFB87Ac52Bac7ccF497b6053610A9c59B87a0cE7D`
-  - Transaction Hash: `Unknown`
   - Block Number: `4911834`
 
 #### HubPool
 
 - **HubPool**: `0x14224e63716aface30c9a417e0542281869f7d9e`
-  - Transaction Hash: `Unknown`
   - Block Number: `4911835`
 
 #### SpokePool
 
 - **SpokePool**: `0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662`
-  - Transaction Hash: `Unknown`
   - Block Number: `5288470`
 
 #### PolygonTokenBridger
 
 - **PolygonTokenBridger**: `0x4e3737679081c4D3029D88cA560918094f2e0284`
-  - Transaction Hash: `Unknown`
   - Block Number: `5984560`
 
 #### Polygon_Adapter
 
 - **Polygon_Adapter**: `0x540029039E493b1B843653f93C3064A956931747`
-  - Transaction Hash: `Unknown`
   - Block Number: `5984591`
 
 #### Lisk_Adapter
 
 - **Lisk_Adapter**: `0x13a8B1D6443016424e2b8Bac40dD884Ee679AFc4`
-  - Transaction Hash: `Unknown`
   - Block Number: `6226289`
 
 #### Lens_Adapter
 
 - **Lens_Adapter**: `0x8fac6F764ae0b4F632FE2E6c938ED5637E629ff2`
-  - Transaction Hash: `Unknown`
   - Block Number: `7448085`
 
 #### Blast_Adapter
 
 - **Blast_Adapter**: `0x09500Ffd743e01B4146a4BA795231Ca7Ca37819f`
-  - Transaction Hash: `Unknown`
   - Block Number: `6233857`
 
 #### DoctorWho_Adapter
 
 - **DoctorWho_Adapter**: `0x2b482aFb675e1F231521d5E56770ce4aac592246`
-  - Transaction Hash: `Unknown`
   - Block Number: `7698546`
 
 #### Solana_Adapter
 
 - **Solana_Adapter**: `0x9b2c2f3fD98cF8468715Be31155cc053C56f822A`
-  - Transaction Hash: `Unknown`
   - Block Number: `8409722`
 
 ### Optimism Sepolia (Chain ID: 11155420)
@@ -1235,13 +1060,11 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x4e8E101924eDE233C13e2D8622DC8aED2872d505`
-  - Transaction Hash: `Unknown`
   - Block Number: `7762656`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `138622548`
 
 ### Blast Sepolia (Chain ID: 168587773)
@@ -1249,13 +1072,11 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SpokePool
 
 - **SpokePool**: `0x5545092553Cf5Bf786e87a87192E902D50D8f022`
-  - Transaction Hash: `Unknown`
   - Block Number: `7634204`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E`
-  - Transaction Hash: `Unknown`
   - Block Number: `24206664`
 
 ### Solana Devnet (Chain ID: 133268194659241)
@@ -1263,35 +1084,29 @@ This file contains the latest deployed smart contract addresses from the broadca
 #### SvmSpoke
 
 - **SvmSpoke**: `JAZWcGrpSWNPTBj8QtJ9UyQqhJCDhG9GJkDeMf5NQBiq`
-  - Transaction Hash: `Unknown`
   - Block Number: `356313770`
 
 #### MulticallHandler
 
 - **MulticallHandler**: `Fk1RpqsfeWt8KnFCTW9NQVdVxYvxuqjGn6iPB9wrmM8h`
-  - Transaction Hash: `Unknown`
   - Block Number: `356321050`
 
 #### MessageTransmitter
 
 - **MessageTransmitter**: `CCTPmbSD7gX1bxKPAmg77w8oFzNFpaQiQUWD43TKaecd`
-  - Transaction Hash: `Unknown`
   - Block Number: `339604856`
 
 #### TokenMessengerMinter
 
 - **TokenMessengerMinter**: `CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3`
-  - Transaction Hash: `Unknown`
   - Block Number: `277864039`
 
 #### MessageTransmitterV2
 
 - **MessageTransmitterV2**: `CCTPV2Sm4AdWt5296sk4P66VBZ7bEhcARwFaaS9YPbeC`
-  - Transaction Hash: `Unknown`
   - Block Number: `383716739`
 
 #### TokenMessengerMinterV2
 
 - **TokenMessengerMinterV2**: `CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe`
-  - Transaction Hash: `Unknown`
   - Block Number: `383709630`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts",
-  "version": "4.1.11",
+  "version": "4.1.12",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/script/utils/CONSTANTS_README.md
+++ b/script/utils/CONSTANTS_README.md
@@ -6,14 +6,14 @@ This document explains how to use the new constants management system that uses 
 
 The constants system consists of:
 
-1. **`constants.json`** - A structured JSON file containing all constants
-2. **`script/Constants.sol`** - The main constants contract with hardcoded values for compatibility
-3. **`script/ConstantsLoader.s.sol`** - A Foundry script demonstrating how to use `parseJson` functions
+1. **`generated/constants.json`** - A structured JSON file containing all constants
+2. **`script/utils/Constants.sol`** - The main constants contract that loads the constants from the JSON file
+3. **`script/utils/GenerateConstantsJson.ts`** - A TypeScript script that generates the `constants.json` file
 
 ## File Structure
 
 ```
-├── constants.json                    # All constants in JSON format
+├── generated/constants.json          # All constants in JSON format
 ├── script/utils/
 │   ├── Constants.sol                 # Main constants contract
 │   └── CONSTANTS_README.md           # This documentation
@@ -26,158 +26,26 @@ The constants system consists of:
 You can use Foundry's `vm.parseJson*` functions to read constants directly from the JSON file:
 
 ```solidity
-// Load chain IDs
-uint256 mainnetChainId = vm.parseJsonUint("constants.json", ".chainIds.MAINNET");
-uint256 arbitrumChainId = vm.parseJsonUint("constants.json", ".chainIds.ARBITRUM");
-
-// Load addresses
-address mainnetWeth = vm.parseJsonAddress("constants.json", ".wrappedNativeTokens.MAINNET");
-address arbitrumL2Router = vm.parseJsonAddress("constants.json", ".l2Addresses.ARBITRUM.l2GatewayRouter");
-
-// Load time constants
-uint256 quoteTimeBuffer = vm.parseJsonUint("constants.json", ".timeConstants.QUOTE_TIME_BUFFER");
+// Deploy script needs to inherit DeploymentUtils.sol
+uint256 cctpV2TokenMessenger = getL1Addresses(chainId).cctpV2TokenMessenger;
+address weth = getWETHAddress(chainId);
 ```
 
-### 2. Available JSON Paths
+### 2. Adding New Constants
 
-The `constants.json` file is organized into the following sections:
+To add a new constant, the `GenerateConstantsJson.ts` script needs to be updated to include the new constant.
 
-#### Chain IDs
-
-```json
-{
-  "chainIds": {
-    "MAINNET": 1,
-    "ARBITRUM": 42161,
-    "OPTIMISM": 10
-    // ... more chains
-  }
-}
+```typescript
+// Add the new constant to the GenerateConstantsJson.ts script
+const constants = {
+    PUBLIC_NETWORKS: convertChainFamiliesEnumString(),
+    ...
+    "newConstant": "newConstantValue",
+  };
 ```
 
-#### Wrapped Native Tokens
+Then, run the `GenerateConstantsJson.ts` script to generate the `constants.json` file.
 
-```json
-{
-  "wrappedNativeTokens": {
-    "MAINNET": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-    "ARBITRUM": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
-    // ... more tokens
-  }
-}
-```
-
-#### L2 Addresses
-
-```json
-{
-  "l2Addresses": {
-    "ARBITRUM": {
-      "l2GatewayRouter": "0x5288c571Fd7aD117beA99bF60FE0846C4E84F933",
-      "cctpTokenMessenger": "0x19330d10D9Cc8751218eaf51E8885D058642E08A",
-      "uniswapV3SwapRouter": "0xE592427A0AEce92De3Edee1F18E0157C05861564"
-    }
-  }
-}
-```
-
-#### L1 Addresses
-
-```json
-{
-  "l1Addresses": {
-    "MAINNET": {
-      "finder": "0x40f941E48A552bF496B154Af6bf55725f18D77c3",
-      "l1ArbitrumInbox": "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f"
-      // ... more addresses
-    }
-  }
-}
-```
-
-#### OP Stack Addresses
-
-```json
-{
-  "opStackAddresses": {
-    "MAINNET": {
-      "BASE": {
-        "L1CrossDomainMessenger": "0x866E82a600A1414e583f7F13623F1aC5d58b0Afa",
-        "L1StandardBridge": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35"
-      }
-    }
-  }
-}
-```
-
-#### Circle Domain IDs
-
-```json
-{
-  "circleDomainIds": {
-    "MAINNET": 0,
-    "ARBITRUM": 3,
-    "OPTIMISM": 2
-  }
-}
-```
-
-#### Time Constants
-
-```json
-{
-  "timeConstants": {
-    "QUOTE_TIME_BUFFER": 3600,
-    "FILL_DEADLINE_BUFFER": 21600
-  }
-}
-```
-
-### 3. Adding New Constants
-
-To add new constants:
-
-1. **Add to `constants.json`**:
-
-   ```json
-   {
-     "chainIds": {
-       "NEW_CHAIN": 12345
-     },
-     "wrappedNativeTokens": {
-       "NEW_CHAIN": "0x..."
-     }
-   }
-   ```
-
-2. **Add to `Constants.sol`** (for compatibility):
-
-   ```solidity
-   uint256 constant NEW_CHAIN = 12345;
-   WETH9Interface constant WRAPPED_NATIVE_TOKEN_NEW_CHAIN = WETH9Interface(0x...);
-   ```
-
-3. **Use in scripts**:
-   ```solidity
-   uint256 newChainId = vm.parseJsonUint("constants.json", ".chainIds.NEW_CHAIN");
-   address newChainWeth = vm.parseJsonAddress("constants.json", ".wrappedNativeTokens.NEW_CHAIN");
-   ```
-
-## Example Usage in Deployment Scripts
-
-```solidity
-contract MyDeploymentScript is Script {
-  function run() public {
-    // Load constants for the target chain
-    uint256 chainId = vm.parseJsonUint("constants.json", ".chainIds.MAINNET");
-    address weth = vm.parseJsonAddress("constants.json", ".wrappedNativeTokens.MAINNET");
-
-    // Load L1 addresses
-    address finder = vm.parseJsonAddress("constants.json", ".l1Addresses.MAINNET.finder");
-    address arbitrumInbox = vm.parseJsonAddress("constants.json", ".l1Addresses.MAINNET.l1ArbitrumInbox");
-
-    // Use constants in deployment
-    // ... deployment logic
-  }
-}
+```bash
+yarn generate-constants-json
 ```

--- a/script/utils/ExtractDeployedFoundryAddresses.ts
+++ b/script/utils/ExtractDeployedFoundryAddresses.ts
@@ -45,8 +45,8 @@ interface JsonOutput {
       contracts: {
         [contractName: string]: {
           address: string;
-          transaction_hash: string;
-          block_number: number | null;
+          transaction_hash?: string;
+          block_number?: number;
         };
       };
     };
@@ -341,7 +341,9 @@ function generateAddressesFile(broadcastFiles: BroadcastFile[], outputFile: stri
 
       for (const contract of contracts) {
         content.push(`- **${contract.contractName}**: \`${contract.contractAddress}\``);
-        content.push(`  - Transaction Hash: \`${contract.transactionHash}\``);
+        if (contract.transactionHash !== "Unknown") {
+          content.push(`  - Transaction Hash: \`${contract.transactionHash}\``);
+        }
         if (contract.blockNumber !== null) {
           content.push(`  - Block Number: \`${contract.blockNumber}\``);
         }
@@ -366,8 +368,8 @@ function generateAddressesFile(broadcastFiles: BroadcastFile[], outputFile: stri
         const contractName = contract.contractName;
         jsonOutput.chains[chainId].contracts[contractName] = {
           address: contract.contractAddress,
-          transaction_hash: contract.transactionHash,
-          block_number: contract.blockNumber,
+          ...(contract.blockNumber !== null && { block_number: contract.blockNumber }),
+          ...(contract.transactionHash !== "Unknown" && { transaction_hash: contract.transactionHash }),
         };
       }
     }

--- a/scripts/preCommitHook.sh
+++ b/scripts/preCommitHook.sh
@@ -31,8 +31,11 @@ if [ -n "$STAGED_RUST_FILES" ]; then
 fi
 
 echo "Running generate-constants-json on staged files ..."
-
 yarn generate-constants-json && yarn prettier --write generated/constants.json
+if git diff --name-only | grep -E 'generated/constants.json$' >/dev/null; then
+    echo "Generated constants have changed."
+    git add generated/constants.json
+fi
 GENERATE_CONSTANTS_JSON_EXIT=$?
 if [ $GENERATE_CONSTANTS_JSON_EXIT -ne 0 ]; then
     echo "generate-constants-json encountered an error. Aborting the hook."
@@ -40,10 +43,14 @@ if [ $GENERATE_CONSTANTS_JSON_EXIT -ne 0 ]; then
 fi
 
 echo "Running extract-addresses on staged files ..."
-
 yarn extract-addresses
 EXTRACT_ADDRESSES_EXIT=$?
 if [ $EXTRACT_ADDRESSES_EXIT -ne 0 ]; then
     echo "extract-addresses encountered an error. Aborting the hook."
     exit $EXTRACT_ADDRESSES_EXIT
+fi
+if git diff --name-only | grep -E 'broadcast/deployed-addresses\.(json|md)$' >/dev/null; then
+    echo "Broadcast or deployed addresses have changed."
+    git add broadcast/deployed-addresses.json
+    git add broadcast/deployed-addresses.md
 fi


### PR DESCRIPTION
Final changes to use `deployed-addresses.json` as source of truth and export it via `src/DeploymentUtils.ts` functions

This pr also remove `transaction_hash` field from `deployed-addresses` as its not being used and not present on old deployments

Closes https://linear.app/uma/issue/ACX-4541/deprecate-deploymentsjson-in-favour-of-deployed-addressesjson