### PR TITLE
fix(svm): use native svm inputs for sponsored cctp bridge

### DIFF
--- a/programs/sponsored-cctp-src-periphery/src/error.rs
+++ b/programs/sponsored-cctp-src-periphery/src/error.rs
@@ -28,19 +28,4 @@ pub enum SvmError {
     QuoteDeadlineNotPassed,
     #[msg("New signer unchanged")]
     SignerUnchanged,
-    #[msg("Invalid quote data length")]
-    InvalidQuoteDataLength,
-}
-
-// EVM decoding errors.
-#[error_code]
-pub enum DataDecodingError {
-    #[msg("Cannot decode to u32")]
-    CannotDecodeToU32,
-    #[msg("Cannot decode to u64")]
-    CannotDecodeToU64,
-    #[msg("Cannot decode to i64")]
-    CannotDecodeToI64,
-    #[msg("Cannot decode bytes")]
-    CannotDecodeBytes,
 }

--- a/programs/sponsored-cctp-src-periphery/src/event.rs
+++ b/programs/sponsored-cctp-src-periphery/src/event.rs
@@ -17,11 +17,11 @@ pub struct SponsoredDepositForBurn {
     pub quote_nonce: Vec<u8>, // Nonce is bytes32 random value, but it is more readable in logs expressed as encoded data blob.
     pub origin_sender: Pubkey,
     pub final_recipient: Pubkey,
-    pub quote_deadline: i64,
+    pub quote_deadline: u64,
     pub max_bps_to_sponsor: u64,
     pub max_user_slippage_bps: u64,
     pub final_token: Pubkey,
-    pub signature: Vec<u8>,
+    pub signature: Vec<u8>, // Signature is fixed 65 bytes, but it is more readable in logs expressed as encoded data blob.
 }
 
 #[event]

--- a/programs/sponsored-cctp-src-periphery/src/lib.rs
+++ b/programs/sponsored-cctp-src-periphery/src/lib.rs
@@ -31,7 +31,7 @@ declare_program!(token_messenger_minter_v2);
 /// # Across Sponsored CCTP Source Periphery
 ///
 /// Source chain periphery program for users to interact with to start a sponsored or a non-sponsored flow that allows
-/// custom Accross-supported flows on destination chain. Uses Circle's CCTPv2 as an underlying bridge
+/// custom Across-supported flows on destination chain. Uses Circle's CCTPv2 as an underlying bridge
 
 #[program]
 pub mod sponsored_cctp_src_periphery {

--- a/programs/sponsored-cctp-src-periphery/src/state.rs
+++ b/programs/sponsored-cctp-src-periphery/src/state.rs
@@ -5,11 +5,11 @@ use anchor_lang::prelude::*;
 pub struct State {
     pub source_domain: u32, // Immutable CCTP domain for the chain this program is deployed on (e.g. 5 for Solana).
     pub signer: Pubkey,     // The authorized signer for sponsored CCTP quotes.
-    pub current_time: i64,  // Only used in testable mode, else set to 0 on mainnet.
+    pub current_time: u64,  // Only used in testable mode, else set to 0 on mainnet.
 }
 
 #[account]
 #[derive(InitSpace)]
 pub struct UsedNonce {
-    pub quote_deadline: i64, // Quote deadline is used to determine when it is safe to close the nonce account.
+    pub quote_deadline: u64, // Quote deadline is used to determine when it is safe to close the nonce account.
 }

--- a/programs/sponsored-cctp-src-periphery/src/utils/signer.rs
+++ b/programs/sponsored-cctp-src-periphery/src/utils/signer.rs
@@ -11,12 +11,8 @@ pub const QUOTE_SIGNATURE_LENGTH: usize = 65;
 /// Utility function to recover the quote signer EVM address.
 /// Based on CCTP's `recover_attester` function in
 /// https://github.com/circlefin/solana-cctp-contracts/blob/03f7dec786eb9affa68688954f62917edeed2e35/programs/v2/message-transmitter-v2/src/state.rs
-fn recover_signer(quote_hash: &[u8; 32], quote_signature: &[u8]) -> Result<Pubkey> {
-    // secp256k1_recover doesn't validate input parameters lengths, so check the signature. No need to check hash as it
-    // is fixed size array.
-    if quote_signature.len() != QUOTE_SIGNATURE_LENGTH {
-        return err!(CommonError::InvalidSignature);
-    }
+fn recover_signer(quote_hash: &[u8; 32], quote_signature: &[u8; QUOTE_SIGNATURE_LENGTH]) -> Result<Pubkey> {
+    // No need to validate the length of inputs as they are fixed-size arrays compared to CCTP's implementation.
 
     // Extract and validate recovery id from the signature.
     let ethereum_recovery_id = quote_signature[QUOTE_SIGNATURE_LENGTH - 1];
@@ -48,9 +44,9 @@ fn recover_signer(quote_hash: &[u8; 32], quote_signature: &[u8]) -> Result<Pubke
 pub fn validate_signature(
     expected_signer: Pubkey,
     quote: &SponsoredCCTPQuote,
-    quote_signature: &Vec<u8>,
+    quote_signature: &[u8; QUOTE_SIGNATURE_LENGTH],
 ) -> Result<()> {
-    let recovered_signer = recover_signer(&quote.evm_typed_hash()?, quote_signature)?;
+    let recovered_signer = recover_signer(&quote.evm_typed_hash(), quote_signature)?;
     if recovered_signer != expected_signer {
         return err!(CommonError::InvalidSignature);
     }

--- a/programs/sponsored-cctp-src-periphery/src/utils/sponsored_cctp_quote.rs
+++ b/programs/sponsored-cctp-src-periphery/src/utils/sponsored_cctp_quote.rs
@@ -1,105 +1,30 @@
 use anchor_lang::{prelude::*, solana_program::keccak};
 
-use crate::error::{DataDecodingError, SvmError};
-
-// Macro to define the SponsoredCCTPQuote fields as an enum with associated constants for ordinal, start, end, count,
-// and minimum total bytes.
-macro_rules! define_quote_fields {
-    ($($V:ident),+ $(,)?) => {
-        #[derive(Copy, Clone)]
-        pub enum SponsoredCCTPQuoteFields { $($V),+ }
-
-        impl SponsoredCCTPQuoteFields {
-            pub const fn ordinal(self) -> usize { self as usize }
-
-            pub const fn start(self) -> usize { self.ordinal() * Self::WORD_SIZE }
-
-            pub const fn end(self) -> usize {
-                self.start() + Self::WORD_SIZE
-            }
-
-            pub const WORD_SIZE: usize = 32;
-
-            pub const COUNT: usize = [$(SponsoredCCTPQuoteFields::$V),+].len();
-
-            pub const MIN_TOTAL_BYTES: usize = Self::COUNT * Self::WORD_SIZE;
-        }
-    };
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub struct SponsoredCCTPQuote {
+    pub source_domain: u32,
+    pub destination_domain: u32,
+    pub mint_recipient: Pubkey,
+    pub amount: u64,
+    pub burn_token: Pubkey,
+    pub destination_caller: Pubkey,
+    pub max_fee: u64,
+    pub min_finality_threshold: u32,
+    pub nonce: [u8; 32],
+    pub deadline: u64,
+    pub max_bps_to_sponsor: u64,
+    pub max_user_slippage_bps: u64,
+    pub final_recipient: Pubkey,
+    pub final_token: Pubkey,
+    pub execution_mode: u8,
+    pub action_data: Vec<u8>,
 }
 
-// Define the SponsoredCCTPQuote fields using the macro. Each field corresponds to a 32-byte word in the ABI encoded
-// SponsoredCCTPQuote struct, except for the last actionData field which is variable length bytes and would be encoded
-// to the multiple of 32 bytes (minimum is 64 bytes for the offset and length) on EVM.
-define_quote_fields!(
-    SourceDomain,
-    DestinationDomain,
-    MintRecipient,
-    Amount,
-    BurnToken,
-    DestinationCaller,
-    MaxFee,
-    MinFinalityThreshold,
-    Nonce,
-    Deadline,
-    MaxBpsToSponsor,
-    MaxUserSlippageBps,
-    FinalRecipient,
-    FinalToken,
-    ExecutionMode,
-    ActionDataOffset,
-    ActionDataLength
-);
-
-// Compile-time guarantees that below fields passed in hookData are contiguous, ordered and actionData is the last.
-const _: () = {
-    assert!((SponsoredCCTPQuoteFields::Deadline as usize) == (SponsoredCCTPQuoteFields::Nonce as usize) + 1);
-    assert!((SponsoredCCTPQuoteFields::MaxBpsToSponsor as usize) == (SponsoredCCTPQuoteFields::Deadline as usize) + 1);
-    assert!(
-        (SponsoredCCTPQuoteFields::MaxUserSlippageBps as usize)
-            == (SponsoredCCTPQuoteFields::MaxBpsToSponsor as usize) + 1
-    );
-    assert!(
-        (SponsoredCCTPQuoteFields::FinalRecipient as usize)
-            == (SponsoredCCTPQuoteFields::MaxUserSlippageBps as usize) + 1
-    );
-    assert!((SponsoredCCTPQuoteFields::FinalToken as usize) == (SponsoredCCTPQuoteFields::FinalRecipient as usize) + 1);
-    assert!((SponsoredCCTPQuoteFields::ExecutionMode as usize) == (SponsoredCCTPQuoteFields::FinalToken as usize) + 1);
-    assert!(
-        (SponsoredCCTPQuoteFields::ActionDataOffset as usize) == (SponsoredCCTPQuoteFields::ExecutionMode as usize) + 1
-    );
-    assert!(
-        (SponsoredCCTPQuoteFields::ActionDataLength as usize)
-            == (SponsoredCCTPQuoteFields::ActionDataOffset as usize) + 1
-    );
-    assert!((SponsoredCCTPQuoteFields::ActionDataLength as usize) == SponsoredCCTPQuoteFields::COUNT - 1);
-};
-
-pub const MIN_QUOTE_DATA_LENGTH: usize = SponsoredCCTPQuoteFields::MIN_TOTAL_BYTES;
-
-pub const HOOK_DATA_START: usize = SponsoredCCTPQuoteFields::Nonce.start();
-
-pub const NONCE_START: usize = SponsoredCCTPQuoteFields::Nonce.start();
-pub const NONCE_END: usize = SponsoredCCTPQuoteFields::Nonce.end();
-
-pub struct SponsoredCCTPQuote<'a> {
-    data: &'a [u8],
-}
-
-impl<'a> SponsoredCCTPQuote<'a> {
-    pub fn new(quote_bytes: &'a [u8]) -> Result<Self> {
-        // Encoded quote data must be at least MIN_QUOTE_DATA_LENGTH bytes long and must be a multiple of 32 bytes.
-        let quote_bytes_len = quote_bytes.len();
-        if quote_bytes_len < MIN_QUOTE_DATA_LENGTH || quote_bytes_len % SponsoredCCTPQuoteFields::WORD_SIZE != 0 {
-            return err!(SvmError::InvalidQuoteDataLength);
-        }
-
-        Ok(Self { data: quote_bytes })
-    }
-
+impl SponsoredCCTPQuote {
     /// EVM-compatible typed hash used for signature verification.
     ///
     /// Mirrors the Solidity implementation:
-    /// - The full quote hash is split into **two parts** to avoid the EVM stack too deep” issue in the contract.
+    /// - The full quote hash is split into two parts to avoid the EVM stack too deep issue in the contract.
     /// - The dynamic `actionData` is hashed separately (`keccak256(actionData)`) and that 32-byte digest is included as
     ///   the last field of `hash2`.
     /// - Finally, `typedDataHash = keccak256(abi.encode(hash1, hash2))`.
@@ -107,8 +32,8 @@ impl<'a> SponsoredCCTPQuote<'a> {
     /// Rust implementation detail:
     /// - We use `keccak::hashv(&[...])` to hash the bytewise concatenation of slices without building intermediate
     ///   buffers (no memcopy).
-    pub fn evm_typed_hash(&self) -> Result<[u8; 32]> {
-        Ok(keccak::hashv(&[&self.hash1(), &self.hash2()?]).to_bytes())
+    pub fn evm_typed_hash(&self) -> [u8; 32] {
+        keccak::hashv(&[&self.hash1(), &self.hash2()]).to_bytes()
     }
 
     /// `hash1` (EVM: first part) = keccak256(abi.encode(sourceDomain, destinationDomain, mintRecipient, amount,
@@ -117,171 +42,96 @@ impl<'a> SponsoredCCTPQuote<'a> {
     /// These are all static ABI fields, so `abi.encode(...)` is exactly the concatenation of their 32-byte words
     /// already present in the head.
     fn hash1(&self) -> [u8; 32] {
-        let start = SponsoredCCTPQuoteFields::SourceDomain.start();
-        let end = SponsoredCCTPQuoteFields::MinFinalityThreshold.end();
+        // Encode the first 8 static quote data fields.
+        let mut encoded = Vec::with_capacity(8 * 32);
 
-        // Safe: start and end are derived from SponsoredCCTPQuoteFields, so this should always be in-bounds.
-        keccak::hash(&self.data[start..end]).to_bytes()
+        Self::encode_u32(&mut encoded, self.source_domain);
+        Self::encode_u32(&mut encoded, self.destination_domain);
+        Self::encode_pubkey(&mut encoded, &self.mint_recipient);
+        Self::encode_u64(&mut encoded, self.amount);
+        Self::encode_pubkey(&mut encoded, &self.burn_token);
+        Self::encode_pubkey(&mut encoded, &self.destination_caller);
+        Self::encode_u64(&mut encoded, self.max_fee);
+        Self::encode_u32(&mut encoded, self.min_finality_threshold);
+
+        keccak::hash(&encoded).to_bytes()
     }
 
     /// `hash2` (EVM: second part) = keccak256(abi.encode(nonce, deadline, maxBpsToSponsor, maxUserSlippageBps,
     ///   finalRecipient, finalToken, executionMode, keccak256(actionData)))
     ///
-    /// We hash the static words (`Nonce..ExecutionMode`) directly from the head with appended `keccak(actionData)` as a
+    /// We hash the static words (`nonce..executionMode`) directly from the head with appended `keccak(actionData)` as a
     /// `bytes32` (static) value.
-    fn hash2(&self) -> Result<[u8; 32]> {
-        let start = SponsoredCCTPQuoteFields::Nonce.start();
-        let end = SponsoredCCTPQuoteFields::ExecutionMode.end();
+    fn hash2(&self) -> [u8; 32] {
+        // Encode the following 7 static quote data fields + action_data hash.
+        let mut encoded = Vec::with_capacity(8 * 32);
 
-        // Safe: start and end are derived from SponsoredCCTPQuoteFields, so this should always be in-bounds.
-        Ok(keccak::hashv(&[&self.data[start..end], &self.action_data_hash()?]).to_bytes())
+        Self::encode_bytes32(&mut encoded, &self.nonce);
+        Self::encode_u64(&mut encoded, self.deadline);
+        Self::encode_u64(&mut encoded, self.max_bps_to_sponsor);
+        Self::encode_u64(&mut encoded, self.max_user_slippage_bps);
+        Self::encode_pubkey(&mut encoded, &self.final_recipient);
+        Self::encode_pubkey(&mut encoded, &self.final_token);
+        Self::encode_u8(&mut encoded, self.execution_mode);
+        Self::encode_bytes32(&mut encoded, &keccak::hash(&self.action_data).to_bytes());
+
+        keccak::hash(&encoded).to_bytes()
     }
 
-    /// `keccak256(actionData)` — hashes only the dynamic bytes content (not ABI-encoded), matching the Solidity side's
-    /// `keccak256(quote.actionData)`.
-    fn action_data_hash(&self) -> Result<[u8; 32]> {
-        // actionData bytes start immediately after its length word.
-        let start = SponsoredCCTPQuoteFields::ActionDataLength.end();
-        let length = self.get_action_data_len_checked()?;
+    pub fn encode_hook_data(&self) -> Vec<u8> {
+        // ABI encoded hookData on EVM holds 7 static 32-byte words followed by the actionData offset that points to the
+        // length-prefixed actionData bytes. The actionData bytes are padded to 32-byte word length.
+        let action_data_offset = 8 * 32;
+        let min_hook_data_len = action_data_offset + 32;
+        let mut hook_data = Vec::with_capacity(min_hook_data_len);
 
-        // Safe: get_action_data_len_checked() ensures that the actionData bytes are within bounds.
-        Ok(keccak::hash(&self.data[start..start + length]).to_bytes())
+        Self::encode_bytes32(&mut hook_data, &self.nonce);
+        Self::encode_u64(&mut hook_data, self.deadline);
+        Self::encode_u64(&mut hook_data, self.max_bps_to_sponsor);
+        Self::encode_u64(&mut hook_data, self.max_user_slippage_bps);
+        Self::encode_pubkey(&mut hook_data, &self.final_recipient);
+        Self::encode_pubkey(&mut hook_data, &self.final_token);
+        Self::encode_u8(&mut hook_data, self.execution_mode);
+        Self::encode_bytes(&mut hook_data, &self.action_data, action_data_offset as u64);
+
+        hook_data
     }
 
-    pub fn source_domain(&self) -> Result<u32> {
-        Self::decode_to_u32(self.get_field_word(SponsoredCCTPQuoteFields::SourceDomain))
+    fn pad32_left(output: &mut Vec<u8>, input: &[u8]) {
+        let pad_len = (32usize).saturating_sub(input.len());
+        output.extend_from_slice(&[0u8; 32][..pad_len]);
+        output.extend_from_slice(input);
     }
 
-    pub fn destination_domain(&self) -> Result<u32> {
-        Self::decode_to_u32(self.get_field_word(SponsoredCCTPQuoteFields::DestinationDomain))
+    fn encode_u8(output: &mut Vec<u8>, input: u8) {
+        Self::pad32_left(output, &[input]);
     }
 
-    pub fn mint_recipient(&self) -> Result<Pubkey> {
-        Self::decode_to_pubkey(self.get_field_word(SponsoredCCTPQuoteFields::MintRecipient))
+    fn encode_u32(output: &mut Vec<u8>, input: u32) {
+        Self::pad32_left(output, &input.to_be_bytes());
     }
 
-    pub fn amount(&self) -> Result<u64> {
-        Self::decode_to_u64(self.get_field_word(SponsoredCCTPQuoteFields::Amount))
+    fn encode_u64(output: &mut Vec<u8>, input: u64) {
+        Self::pad32_left(output, &input.to_be_bytes());
     }
 
-    pub fn burn_token(&self) -> Result<Pubkey> {
-        Self::decode_to_pubkey(self.get_field_word(SponsoredCCTPQuoteFields::BurnToken))
+    fn encode_bytes32(output: &mut Vec<u8>, input: &[u8; 32]) {
+        output.extend_from_slice(input);
     }
 
-    pub fn destination_caller(&self) -> Result<Pubkey> {
-        Self::decode_to_pubkey(self.get_field_word(SponsoredCCTPQuoteFields::DestinationCaller))
+    fn encode_pubkey(output: &mut Vec<u8>, input: &Pubkey) {
+        output.extend_from_slice(input.as_ref());
     }
 
-    pub fn max_fee(&self) -> Result<u64> {
-        Self::decode_to_u64(self.get_field_word(SponsoredCCTPQuoteFields::MaxFee))
-    }
+    fn encode_bytes(output: &mut Vec<u8>, input: &[u8], offset: u64) {
+        Self::encode_u64(output, offset);
+        Self::encode_u64(output, input.len() as u64);
+        output.extend_from_slice(input);
 
-    pub fn min_finality_threshold(&self) -> Result<u32> {
-        Self::decode_to_u32(self.get_field_word(SponsoredCCTPQuoteFields::MinFinalityThreshold))
-    }
-
-    pub fn nonce(&self) -> Result<[u8; 32]> {
-        Self::decode_to_bytes32(self.get_field_word(SponsoredCCTPQuoteFields::Nonce))
-    }
-
-    pub fn deadline(&self) -> Result<i64> {
-        Self::decode_to_i64(self.get_field_word(SponsoredCCTPQuoteFields::Deadline))
-    }
-
-    pub fn max_bps_to_sponsor(&self) -> Result<u64> {
-        Self::decode_to_u64(self.get_field_word(SponsoredCCTPQuoteFields::MaxBpsToSponsor))
-    }
-
-    pub fn max_user_slippage_bps(&self) -> Result<u64> {
-        Self::decode_to_u64(self.get_field_word(SponsoredCCTPQuoteFields::MaxUserSlippageBps))
-    }
-
-    pub fn final_recipient(&self) -> Result<Pubkey> {
-        Self::decode_to_pubkey(self.get_field_word(SponsoredCCTPQuoteFields::FinalRecipient))
-    }
-
-    pub fn final_token(&self) -> Result<Pubkey> {
-        Self::decode_to_pubkey(self.get_field_word(SponsoredCCTPQuoteFields::FinalToken))
-    }
-
-    pub fn hook_data(&self) -> Result<Vec<u8>> {
-        // Safe: HOOK_DATA_START is derived from SponsoredCCTPQuoteFields, so this should always be in-bounds.
-        let mut hook_data = self.data[HOOK_DATA_START..].to_vec();
-
-        self.get_action_data_len_checked()?; // We only need the check, not the length here.
-
-        // Patch the actionData offset relative to the HOOK_DATA_START.
-        let hook_data_action_data_offset =
-            (SponsoredCCTPQuoteFields::ActionDataLength.start() - HOOK_DATA_START) as u64;
-        let offset_start = SponsoredCCTPQuoteFields::ActionDataOffset.start() - HOOK_DATA_START;
-        hook_data[offset_start + 24..offset_start + 32].copy_from_slice(&hook_data_action_data_offset.to_be_bytes());
-
-        Ok(hook_data)
-    }
-
-    fn get_action_data_len_checked(&self) -> Result<usize> {
-        // Verify the actionData bytes offset points to its length field.
-        let quote_action_data_offset =
-            Self::decode_to_u64(self.get_field_word(SponsoredCCTPQuoteFields::ActionDataOffset))?;
-        if quote_action_data_offset != (SponsoredCCTPQuoteFields::ActionDataLength.start() as u64) {
-            return err!(DataDecodingError::CannotDecodeBytes);
+        // Pad to 32 byte word length.
+        let remainder = input.len() % 32;
+        if remainder != 0 {
+            output.extend_from_slice(&[0u8; 32][..32 - remainder]);
         }
-
-        // Verify the encoded quote data has sufficient length to hold the actionData bytes (constructor only checks the
-        // minimum length to hold empty actionData bytes).
-        let action_data_length =
-            Self::decode_to_u64(self.get_field_word(SponsoredCCTPQuoteFields::ActionDataLength))? as usize;
-        if action_data_length > self.data.len() - MIN_QUOTE_DATA_LENGTH {
-            return err!(DataDecodingError::CannotDecodeBytes);
-        }
-
-        Ok(action_data_length)
-    }
-
-    fn get_field_word(&self, field: SponsoredCCTPQuoteFields) -> &[u8; 32] {
-        let start = field.start();
-        let end = field.end();
-        // Safe: start and end are derived from SponsoredCCTPQuoteFields, so this should always be in-bounds.
-        let data_slice = &self.data[start..end];
-        // Safe: data_slice is exactly 32 bytes long, so we can convert it to [u8; 32].
-        <&[u8; 32]>::try_from(data_slice).unwrap()
-    }
-
-    fn decode_to_u32(data: &[u8; 32]) -> Result<u32> {
-        if data[..28].iter().any(|&b| b != 0) {
-            return err!(DataDecodingError::CannotDecodeToU32);
-        }
-        // Safe: data[28..] is exactly 4 bytes long, so we can convert it to [u8; 4].
-        Ok(u32::from_be_bytes(data[28..].try_into().unwrap()))
-    }
-
-    fn decode_to_u64(data: &[u8; 32]) -> Result<u64> {
-        if data[..24].iter().any(|&b| b != 0) {
-            return err!(DataDecodingError::CannotDecodeToU64);
-        }
-        // Safe: data[24..] is exactly 8 bytes long, so we can convert it to [u8; 8].
-        Ok(u64::from_be_bytes(data[24..].try_into().unwrap()))
-    }
-
-    fn decode_to_i64(data: &[u8; 32]) -> Result<i64> {
-        if data[..24].iter().any(|&b| b != 0) {
-            return err!(DataDecodingError::CannotDecodeToI64);
-        }
-        // Safe: data[24..] is exactly 8 bytes long, so we can convert it to [u8; 8].
-        let v_u64 = u64::from_be_bytes(data[24..].try_into().unwrap());
-        match i64::try_from(v_u64) {
-            Ok(v_i64) => Ok(v_i64),
-            Err(_) => err!(DataDecodingError::CannotDecodeToI64),
-        }
-    }
-
-    fn decode_to_pubkey(data: &[u8; 32]) -> Result<Pubkey> {
-        // Wrap in Result just to have consistency with decoding other field types that might error.
-        Ok(Pubkey::from(*data))
-    }
-
-    fn decode_to_bytes32(data: &[u8; 32]) -> Result<[u8; 32]> {
-        // Wrap in Result just to have consistency with decoding other field types that might error.
-        Ok(*data)
     }
 }

--- a/programs/sponsored-cctp-src-periphery/src/utils/testable_utils.rs
+++ b/programs/sponsored-cctp-src-periphery/src/utils/testable_utils.rs
@@ -12,7 +12,7 @@ pub struct SetCurrentTime<'info> {
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct SetCurrentTimeParams {
-    pub new_time: i64,
+    pub new_time: u64,
 }
 
 pub fn set_current_time(ctx: Context<SetCurrentTime>, _params: SetCurrentTimeParams) -> Result<()> {
@@ -33,16 +33,16 @@ pub fn set_current_time(ctx: Context<SetCurrentTime>, _params: SetCurrentTimePar
 pub fn initialize_current_time(_state: &mut State) -> Result<()> {
     #[cfg(feature = "test")]
     {
-        _state.current_time = Clock::get()?.unix_timestamp;
+        _state.current_time = u64::try_from(Clock::get()?.unix_timestamp)?;
     }
 
     Ok(())
 }
 
-pub fn get_current_time(_state: &State) -> Result<i64> {
+pub fn get_current_time(_state: &State) -> Result<u64> {
     #[cfg(not(feature = "test"))]
     {
-        Ok(Clock::get()?.unix_timestamp)
+        Ok(u64::try_from(Clock::get()?.unix_timestamp)?)
     }
 
     #[cfg(feature = "test")]

--- a/test/svm/SponsoredCctpSrc.common.ts
+++ b/test/svm/SponsoredCctpSrc.common.ts
@@ -1,10 +1,10 @@
 import * as anchor from "@coral-xyz/anchor";
 import { BN, Program } from "@coral-xyz/anchor";
 import { PublicKey } from "@solana/web3.js";
-import { randomBytes } from "crypto";
 import { ethers } from "ethers";
 import { evmAddressToPublicKey } from "../../src/svm/web3-v1";
 import { SponsoredCctpSrcPeriphery } from "../../target/types/sponsored_cctp_src_periphery";
+import { SponsoredCCTPQuote, SponsoredCCTPQuoteSVM } from "./SponsoredCctpSrc.types";
 
 export const provider = anchor.AnchorProvider.env();
 export const program = anchor.workspace.SponsoredCctpSrcPeriphery as Program<SponsoredCctpSrcPeriphery>;

--- a/test/svm/SponsoredCctpSrc.types.ts
+++ b/test/svm/SponsoredCctpSrc.types.ts
@@ -1,4 +1,6 @@
 import { ethers } from "ethers";
+import type { BN } from "@coral-xyz/anchor";
+import { PublicKey } from "@solana/web3.js";
 
 export interface SponsoredCCTPQuote {
   sourceDomain: number; // uint32
@@ -17,6 +19,25 @@ export interface SponsoredCCTPQuote {
   finalToken: string; // bytes32
   executionMode: number; // uint8
   actionData: ethers.BytesLike; // bytes
+}
+
+export interface SponsoredCCTPQuoteSVM {
+  sourceDomain: number; // u32
+  destinationDomain: number; // u32
+  mintRecipient: PublicKey; // Pubkey
+  amount: BN; // u64
+  burnToken: PublicKey; // Pubkey
+  destinationCaller: PublicKey; // Pubkey
+  maxFee: BN; // u64
+  minFinalityThreshold: number; // u32
+  nonce: number[]; // [u8; 32]
+  deadline: BN; // u64
+  maxBpsToSponsor: BN; // u64
+  maxUserSlippageBps: BN; // u64
+  finalRecipient: PublicKey; // Pubkey
+  finalToken: PublicKey; // Pubkey
+  executionMode: number; // u8
+  actionData: Buffer; // Vec<u8>
 }
 
 export interface HookData {


### PR DESCRIPTION
Using Solana native input types allows increasing `actionData` length in sponsored CCTP bridge.