### PR TITLE
fix: Limit order finalization call

### DIFF
--- a/contracts/periphery/mintburn/HyperCoreFlowExecutor.sol
+++ b/contracts/periphery/mintburn/HyperCoreFlowExecutor.sol
@@ -667,7 +667,11 @@ contract HyperCoreFlowExecutor is AccessControl, Lockable {
             finalCoreTokenInfo.tokenInfo.evmExtraWeiDecimals
         );
 
-        HyperCoreLib.transferERC20CoreToCore(finalCoreTokenInfo.coreIndex, swap.finalRecipient, totalToSend);
+        finalTokenInfos[swap.finalToken].swapHandler.transferFundsToUserOnCore(
+            finalCoreTokenInfo.coreIndex,
+            swap.finalRecipient,
+            totalToSend
+        );
         emit SwapFlowFinalized(quoteNonce, swap.finalRecipient, swap.finalToken, totalToSend, additionalToSendEVM);
     }
 


### PR DESCRIPTION
During the finalization of limit orders, funds are on the swap handler on the Core side. So we need to send the funds to user on from the swap handler instead of the periphery 