### PR TITLE
feat(HypercoreDepositHandler): Allow different types of messages passed to handleAcrossV3Message

### DIFF
--- a/contracts/handlers/HyperliquidDepositHandler.sol
+++ b/contracts/handlers/HyperliquidDepositHandler.sol
@@ -124,7 +124,7 @@ contract HyperliquidDepositHandler is AcrossMessageHandler, ReentrancyGuard, Own
         if (message[0] == 0) {
             address user = abi.decode(message[1:], (address));
             _depositToHypercore(token, amount, user, false);
-        } else if (message[0] == bytes1("1")) {
+        } else if (message[0] == bytes1(0x01)) {
             (address user, bytes memory signature) = abi.decode(message[1:], (address, bytes));
             _verifySignature(user, signature);
             _depositToHypercore(token, amount, user, true);


### PR DESCRIPTION
Read first byte to determine how to decode `message`:
- type 1: message = abi.encode(user)
- type 2: message = abi.encode(user, signature)

type 2 messages can be used to activate new accounts, type 1 cannot