### PR TITLE
fix(package): Migrate unnecessary depends to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.95",
     "@coral-xyz/anchor": "^0.31.1",
-    "@defi-wonderland/smock": "^2.3.4",
     "@eth-optimism/contracts": "^0.5.40",
     "@ethersproject/abstract-provider": "5.7.0",
     "@ethersproject/abstract-signer": "5.7.0",
@@ -77,13 +76,13 @@
     "@uma/contracts-node": "^0.4.17",
     "axios": "^1.7.4",
     "bs58": "^6.0.0",
-    "prettier-plugin-rust": "^0.1.9",
     "yargs": "^17.7.2",
     "zksync-web3": "^0.14.3"
   },
   "devDependencies": {
     "@codama/nodes-from-anchor": "^1.2.0",
     "@codama/renderers-js": "^1.2.14",
+    "@defi-wonderland/smock": "^2.3.4",
     "@matterlabs/hardhat-zksync-deploy": "^0.6.3",
     "@matterlabs/hardhat-zksync-solc": "^1.4.0",
     "@matterlabs/hardhat-zksync-upgradable": "^0.1.0",
@@ -123,6 +122,7 @@
     "mocha": "^9.0.3",
     "multiformats": "9.9.0",
     "prettier": "^2.8.8",
+    "prettier-plugin-rust": "^0.1.9",
     "prettier-plugin-solidity": "^1.4.1",
     "pretty-quick": "^2.0.1",
     "solhint": "^3.6.2",


### PR DESCRIPTION
Marking smock as a full dependency causes version coupling issues in downstream repositories.