### PR TITLE
feat: account creation changes for `HyperliquidDepositHandler`

### DIFF
--- a/contracts/handlers/HyperliquidDepositHandler.sol
+++ b/contracts/handlers/HyperliquidDepositHandler.sol
@@ -54,6 +54,7 @@ contract HyperliquidDepositHandler is AcrossMessageHandler, ReentrancyGuard, Own
     error NotSpokePool();
     error AccountAlreadyActivated();
     error CannotActivateAccount();
+    error UnknownAccountActivationMode();
 
     enum AccountActivationMode {
         None, // 0: No activation expected/needed (revert if user doesn't exist)
@@ -136,6 +137,8 @@ contract HyperliquidDepositHandler is AcrossMessageHandler, ReentrancyGuard, Own
             (address user, bytes memory signature) = abi.decode(message[1:], (address, bytes));
             _verifySignature(user, signature);
             _depositToHypercore(token, amount, user, mode);
+        } else {
+            revert UnknownAccountActivationMode();
         }
     }
 


### PR DESCRIPTION
https://github.com/across-protocol/contracts/pull/1223, but migrated on top of the ongoing audit

Introduces three new account creation modes for the `HyperliquidDepositHandler`, best described by this enum:

```
    enum AccountActivationMode {
        None, // 0: No activation expected/needed (revert if user doesn't exist)
        FromUserFunds, // 1: Activate from user's deposit if needed (no signature required)
        FromDonationBox // 2: Activate from DonationBox if needed (signature required)
    }
```