### PR TITLE
fix: Address L01

### DIFF
--- a/contracts/external/libraries/BytesLib.sol
+++ b/contracts/external/libraries/BytesLib.sol
@@ -37,23 +37,6 @@ library BytesLib {
     }
 
     /**
-     * @notice Reads a uint8 from the low-order byte of a 32-byte word at a given word offset (for abi.encode data)
-     * @param _bytes The bytes array to convert
-     * @param _wordOffset The start index of the 32-byte word containing the uint8
-     * @return result The uint8 result
-     */
-    function toUint8FromWord(bytes memory _bytes, uint256 _wordOffset) internal pure returns (uint8 result) {
-        if (_bytes.length < _wordOffset + 32) {
-            revert OutOfBounds();
-        }
-
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            result := mload(add(add(_bytes, 0x20), _wordOffset))
-        }
-    }
-
-    /**
      * @notice Reads a uint16 from a bytes array at a given start index (for tightly packed data)
      * @notice Reads a uint16 from a bytes array at a given start index
      * @param _bytes The bytes array to convert
@@ -72,23 +55,6 @@ library BytesLib {
     }
 
     /**
-     * @notice Reads a uint16 from the low-order bytes of a 32-byte word at a given word offset (for abi.encode data)
-     * @param _bytes The bytes array to convert
-     * @param _wordOffset The start index of the 32-byte word containing the uint16
-     * @return result The uint16 result
-     */
-    function toUint16FromWord(bytes memory _bytes, uint256 _wordOffset) internal pure returns (uint16 result) {
-        if (_bytes.length < _wordOffset + 32) {
-            revert OutOfBounds();
-        }
-
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            result := mload(add(add(_bytes, 0x20), _wordOffset))
-        }
-    }
-
-    /**
      * @notice Reads a uint32 from a bytes array at a given start index (for tightly packed data)
      * @notice Reads a uint32 from a bytes array at a given start index
      * @param _bytes The bytes array to convert
@@ -103,23 +69,6 @@ library BytesLib {
         // solhint-disable-next-line no-inline-assembly
         assembly {
             result := mload(add(add(_bytes, 0x4), _start))
-        }
-    }
-
-    /**
-     * @notice Reads a uint32 from the low-order bytes of a 32-byte word at a given word offset (for abi.encode data)
-     * @param _bytes The bytes array to convert
-     * @param _wordOffset The start index of the 32-byte word containing the uint32
-     * @return result The uint32 result
-     */
-    function toUint32FromWord(bytes memory _bytes, uint256 _wordOffset) internal pure returns (uint32 result) {
-        if (_bytes.length < _wordOffset + 32) {
-            revert OutOfBounds();
-        }
-
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            result := mload(add(add(_bytes, 0x20), _wordOffset))
         }
     }
 

--- a/contracts/periphery/mintburn/sponsored-oft/ComposeMsgCodec.sol
+++ b/contracts/periphery/mintburn/sponsored-oft/ComposeMsgCodec.sol
@@ -68,15 +68,15 @@ library ComposeMsgCodec {
     }
 
     function _getDestinationDex(bytes memory data) internal pure returns (uint32 v) {
-        return BytesLib.toUint32FromWord(data, DESTINATION_DEX_OFFSET);
+        return uint32(BytesLib.toUint256(data, DESTINATION_DEX_OFFSET));
     }
 
     function _getAccountCreationMode(bytes memory data) internal pure returns (uint8 v) {
-        return BytesLib.toUint8FromWord(data, ACCOUNT_CREATION_MODE_OFFSET);
+        return uint8(BytesLib.toUint256(data, ACCOUNT_CREATION_MODE_OFFSET));
     }
 
     function _getExecutionMode(bytes memory data) internal pure returns (uint8 v) {
-        return BytesLib.toUint8FromWord(data, EXECUTION_MODE_OFFSET);
+        return uint8(BytesLib.toUint256(data, EXECUTION_MODE_OFFSET));
     }
 
     function _getActionData(bytes memory data) internal pure returns (bytes memory v) {


### PR DESCRIPTION
# L-01: Using BytesLib for ABI-Encoded Data


The codebase uses [the BytesLib library](https://github.com/across-protocol/contracts/blob/c4dd51e67d505e79eb048ae546c32ad13d05b498/contracts/external/libraries/BytesLib.sol) to read uint8, uint16, and uint32 values from arbitrary byte offsets. However, BytesLib was designed for tightly packed data (i.e. created through abi.encodePacked), while most messages in the codebase are encoded using abi.encode.

To compensate, decoding functions such as [_getAccountCreationMode](https://github.com/across-protocol/contracts/blob/c4dd51e67d505e79eb048ae546c32ad13d05b498/contracts/periphery/mintburn/sponsored-oft/ComposeMsgCodec.sol#L75) rely on calling BytesLib with magic offsets that account for the 0 byte paddings. This makes the logic harder to follow and increases the risk of future decoding errors if message layouts change.

To improve readability and reduce maintenance risk, consider calling the BytesLib library with solely the offset to the 32-byte word that the target value should be extracted from, and updating BytesLib to extract the relevant low-order bytes from that word.


## Summary of the fix                                                                                                                                                  
                                                                                                                                                             
In `ComposeMsgCodec.sol`:

- Updated _getDestinationDex() to use uint32(BytesLib.toUint256(data, DESTINATION_DEX_OFFSET))
- Updated _getAccountCreationMode() to use uint8(BytesLib.toUint256(data, ACCOUNT_CREATION_MODE_OFFSET))
- Updated _getExecutionMode() to use uint8(BytesLib.toUint256(data, EXECUTION_MODE_OFFSET))
                                                             
                                                                                              