### PR TITLE
fix: L-04

### DIFF
--- a/test/evm/hardhat/chain-specific-spokepools/ZkSync_SpokePool.ts
+++ b/test/evm/hardhat/chain-specific-spokepools/ZkSync_SpokePool.ts
@@ -202,6 +202,14 @@ describe("ZkSync Spoke Pool", function () {
     );
     expect(l2AssetRouter.withdraw).to.have.been.calledWith(expectedAssetId, expectedData);
   });
+  it("Reverts with InvalidTokenAddress when bridging a token without L1 mapping", async function () {
+    const { leaves, tree } = await constructSingleRelayerRefundTree(l2Dai, await zkSyncSpokePool.callStatic.chainId());
+    l2AssetRouter.l1TokenAddress.returns(ZERO_ADDRESS);
+    await zkSyncSpokePool.connect(crossDomainAlias).relayRootBundle(tree.getHexRoot(), mockTreeRoot);
+    await expect(
+      zkSyncSpokePool.connect(relayer).executeRelayerRefundLeaf(0, leaves[0], tree.getHexProof(leaves[0]))
+    ).to.be.revertedWith("InvalidTokenAddress");
+  });
   it("Bridge tokens to hub pool correctly calls the Standard L2 Bridge for zkSync Bridged USDC.e", async function () {
     // Redeploy the SpokePool with usdc address -> 0x0
     const usdcAddress = ZERO_ADDRESS;


### PR DESCRIPTION
## Potential Early Revert On Unsupported L2 assets


ZkSync_SpokePool._bridgeTokensToHubPool always derives [an assetId](https://github.com/across-protocol/contracts/blob/d3bc16ecaecb84b71c80b826be1b93d0cd973ddc/contracts/ZkSync_SpokePool.sol#L188-L190) and calls the asset router even when the L2 token has no L1 mapping. For instance, a user deposits an Era-native token that is not registered in the router; _getAssetId hashes address(0) and the subsequent l2AssetRouter.withdraw reverts for un-recognised assetId.

Consider adding an explicit guard in [_getAssetId](https://github.com/across-protocol/contracts/blob/d3bc16ecaecb84b71c80b826be1b93d0cd973ddc/contracts/ZkSync_SpokePool.sol#L196) to revert with a clear error when l1TokenAddress == address(0), avoiding the router call and clarifying unsupported assets in the docstring.

## Fix

Add zero address check in `_getAssetId`