### PR TITLE
fix: M-02

### DIFF
--- a/contracts/handlers/HyperliquidDepositHandler.sol
+++ b/contracts/handlers/HyperliquidDepositHandler.sol
@@ -258,10 +258,10 @@ contract HyperliquidDepositHandler is AcrossMessageHandler, ReentrancyGuard, Own
 
             if (mode == AccountActivationMode.FromDonationBox) {
                 totalEvmAmount += coreTokenInfo.accountActivationFeeEVM;
-            } else {
-                (, uint64 depositCore) = HyperCoreLib.maximumEVMSendAmountToAmounts(evmAmount, decimalDiff);
-                if (depositCore <= coreTokenInfo.accountActivationFeeCore) revert InsufficientEvmAmountForActivation();
             }
+
+            (, uint64 depositCore) = HyperCoreLib.maximumEVMSendAmountToAmounts(totalEvmAmount, decimalDiff);
+            if (depositCore <= coreTokenInfo.accountActivationFeeCore) revert InsufficientEvmAmountForActivation();
         }
 
         // Check bridge safety before making any state changes or withdrawals


### PR DESCRIPTION
## Account Activation DoS via Dust Deposit in FromDonationBox Mode

The [HyperliquidDepositHandler._depositToHypercore](https://github.com/across-protocol/contracts/blob/d3bc16ecaecb84b71c80b826be1b93d0cd973ddc/contracts/handlers/HyperliquidDepositHandler.sol#L240) function incorrectly handles small user deposits when [mode == FromDonationBox](https://github.com/across-protocol/contracts/blob/d3bc16ecaecb84b71c80b826be1b93d0cd973ddc/contracts/handlers/HyperliquidDepositHandler.sol#L262) and tokens have positive decimalDiff (i.e., Core has more decimals than EVM). When a user provides a tiny evmAmount, the donation box adds activationFeeEvm to form [totalEvmAmount](https://github.com/across-protocol/contracts/blob/d3bc16ecaecb84b71c80b826be1b93d0cd973ddc/contracts/handlers/HyperliquidDepositHandler.sol#L264), but during the [transfer](https://github.com/across-protocol/contracts/blob/d3bc16ecaecb84b71c80b826be1b93d0cd973ddc/contracts/handlers/HyperliquidDepositHandler.sol#L272), maximumEVMSendAmountToAmounts rounds down during decimal conversion. If the resulting _amountCoreToReceive equals accountActivationFeeCore, the [condition](https://github.com/across-protocol/contracts/blob/d3bc16ecaecb84b71c80b826be1b93d0cd973ddc/contracts/libraries/HyperCoreLib.sol#L120) in transferERC20EVMToCore fails (_amountCoreToReceive > accountActivationFeeCore is false), preventing any Core transfer. Consequently, the user's Hypercore account remains unactivated and receives zero tokens, yet accountsActivated[user] = true is [already set](https://github.com/across-protocol/contracts/blob/d3bc16ecaecb84b71c80b826be1b93d0cd973ddc/contracts/handlers/HyperliquidDepositHandler.sol#L257), permanently blocking future sponsored activations for that address and wasting donation box funds. This issue does not affect FromUserFunds mode, which validates [depositCore > accountActivationFeeCore](https://github.com/across-protocol/contracts/blob/d3bc16ecaecb84b71c80b826be1b93d0cd973ddc/contracts/handlers/HyperliquidDepositHandler.sol#L268). Consider adding a similar validation in the FromDonationBox mode to ensure _amountCoreToReceive > accountActivationFeeCore after combining the user's deposit with the sponsored fee, or revert the transaction before marking the account as activated.

## Fix
Check min transfer amount for both types of account activation modes.