### PR TITLE
Fix typo: recieve -> receive in comments

### DIFF
--- a/contracts/chain-adapters/CrossDomainEnabled.sol
+++ b/contracts/chain-adapters/CrossDomainEnabled.sol
@@ -12,7 +12,7 @@ import { ICrossDomainMessenger } from "@eth-optimism/contracts/libraries/bridge/
  * immutable for use in contracts like the Optimism_Adapter which use delegateCall().
  */
 contract CrossDomainEnabled {
-    // Messenger contract used to send and recieve messages from the other domain.
+    // Messenger contract used to send and receive messages from the other domain.
     address public immutable MESSENGER;
 
     /**

--- a/contracts/chain-adapters/ZkStack_Adapter.sol
+++ b/contracts/chain-adapters/ZkStack_Adapter.sol
@@ -73,7 +73,7 @@ contract ZkStack_Adapter is AdapterInterface, CircleCCTPAdapter {
      * @param _cctpTokenMessenger address of the CCTP token messenger contract for the configured network.
      * @param _recipientCircleDomainId Circle domain ID for the destination network.
      * @param _l1Weth WETH address on L1.
-     * @param _l2RefundAddress address that recieves excess gas refunds on L2.
+     * @param _l2RefundAddress address that receives excess gas refunds on L2.
      * @param _l2GasLimit The maximum amount of gas this contract is willing to pay to execute a transaction on L2.
      * @param _l1GasToL2GasPerPubDataLimit The exchange rate of l1 gas to l2 gas.
      * @param _maxTxGasprice The maximum effective gas price any transaction sent to this adapter may have.

--- a/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol
+++ b/contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol
@@ -94,7 +94,7 @@ contract ZkStack_CustomGasToken_Adapter is AdapterInterface, CircleCCTPAdapter {
      * @param _cctpTokenMessenger address of the CCTP token messenger contract for the configured network.
      * @param _recipientCircleDomainId Circle domain ID for the destination network.
      * @param _l1Weth WETH address on L1.
-     * @param _l2RefundAddress address that recieves excess gas refunds on L2.
+     * @param _l2RefundAddress address that receives excess gas refunds on L2.
      * @param _customGasTokenFunder Contract on L1 which funds bridge fees with amounts in the custom gas token.
      * @param _l2GasLimit The maximum amount of gas this contract is willing to pay to execute a transaction on L2.
      * @param _l1GasToL2GasPerPubDataLimit The exchange rate of l1 gas to l2 gas.

--- a/contracts/handlers/MulticallHandler.sol
+++ b/contracts/handlers/MulticallHandler.sol
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts-v4/security/ReentrancyGuard.sol";
 /**
  * @title Across Multicall contract that allows a user to specify a series of calls that should be made by the handler
  * via the message field in the deposit.
- * @dev This contract makes the calls blindly. The contract will send any remaining tokens The caller should ensure that the tokens recieved by the handler are completely consumed.
+ * @dev This contract makes the calls blindly. The contract will send any remaining tokens. The caller should ensure that the tokens received by the handler are completely consumed.
  */
 contract MulticallHandler is AcrossMessageHandler, ReentrancyGuard {
     using SafeERC20 for IERC20;

--- a/contracts/libraries/HyperCoreLib.sol
+++ b/contracts/libraries/HyperCoreLib.sol
@@ -420,7 +420,7 @@ library HyperCoreLib {
 
     /**
      * @notice Converts a maximum EVM amount to send into an EVM amount to send to avoid loss to dust,
-     * @notice and the corresponding amount that will be recieved on Core.
+     * @notice and the corresponding amount that will be received on Core.
      * @param maximumEVMSendAmount The maximum amount to send on HyperEVM
      * @param decimalDiff The decimal difference of evmDecimals - coreDecimals
      * @return amountEVMToSend The amount to send on HyperEVM


### PR DESCRIPTION
## Summary
- Fixed spelling of "recieve" to "receive" in 5 files
- Corrected "recieved" to "received" in MulticallHandler.sol and HyperCoreLib.sol
- Corrected "recieves" to "receives" in ZkStack adapters
- Also fixed a missing period in MulticallHandler.sol comment

## Files Changed
- `contracts/chain-adapters/CrossDomainEnabled.sol`
- `contracts/handlers/MulticallHandler.sol`
- `contracts/libraries/HyperCoreLib.sol`
- `contracts/chain-adapters/ZkStack_Adapter.sol`
- `contracts/chain-adapters/ZkStack_CustomGasToken_Adapter.sol`

## Test plan
- [ ] Verify the changes are documentation/comment-only and do not affect contract logic