### PR TITLE
Fix typo: addres -> address in NatSpec comments

### DIFF
--- a/contracts/chain-adapters/Blast_RescueAdapter.sol
+++ b/contracts/chain-adapters/Blast_RescueAdapter.sol
@@ -31,7 +31,7 @@ contract Blast_RescueAdapter is AdapterInterface {
 
     /**
      * @notice Rescues the tokens from the calling contract.
-     * @param message The encoded address of the ERC20 to send to the rescue addres.
+     * @param message The encoded address of the ERC20 to send to the rescue address.
      */
     function relayMessage(address, bytes memory message) external payable override {
         (uint256 requestId, uint256 hintId) = abi.decode(message, (uint256, uint256));

--- a/contracts/chain-adapters/Ethereum_RescueAdapter.sol
+++ b/contracts/chain-adapters/Ethereum_RescueAdapter.sol
@@ -26,7 +26,7 @@ contract Ethereum_RescueAdapter is AdapterInterface {
 
     /**
      * @notice Rescues the tokens from the calling contract.
-     * @param message The encoded address of the ERC20 to send to the rescue addres.
+     * @param message The encoded address of the ERC20 to send to the rescue address.
      */
     function relayMessage(address, bytes memory message) external payable override {
         IERC20 tokenAddress = IERC20(abi.decode(message, (address)));


### PR DESCRIPTION
## Summary
- Fixed spelling of "addres" to "address" in NatSpec documentation comments in 2 rescue adapter files

## Files Changed
- `contracts/chain-adapters/Blast_RescueAdapter.sol`
- `contracts/chain-adapters/Ethereum_RescueAdapter.sol`

## Test plan
- [ ] Verify the changes are documentation/comment-only and do not affect contract logic