### PR TITLE
Fix typo: overriden -> overridden in comments

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1461,7 +1461,7 @@ abstract contract SpokePool is
         // executing the leaf.
     }
 
-    // Should be overriden by implementing contract depending on how L2 handles sending tokens to L1.
+    // Should be overridden by implementing contract depending on how L2 handles sending tokens to L1.
     function _bridgeTokensToHubPool(uint256 amountToReturn, address l2TokenAddress) internal virtual;
 
     function _setClaimedLeaf(uint32 rootBundleId, uint32 leafId) internal {

--- a/contracts/Succinct_SpokePool.sol
+++ b/contracts/Succinct_SpokePool.sol
@@ -114,7 +114,7 @@ contract Succinct_SpokePool is SpokePool, ITelepathyHandler {
     }
 
     function _bridgeTokensToHubPool(uint256, address) internal override {
-        // This method is a no-op. If the chain intends to include bridging functionality, this must be overriden.
+        // This method is a no-op. If the chain intends to include bridging functionality, this must be overridden.
         // If not, leaving this unimplemented means this method may be triggered, but the result will be that no
         // balance is transferred.
     }

--- a/contracts/chain-adapters/Succinct_Adapter.sol
+++ b/contracts/chain-adapters/Succinct_Adapter.sol
@@ -46,6 +46,6 @@ contract Succinct_Adapter is AdapterInterface {
         address
     ) external payable override {
         // This method is intentionally left as a no-op.
-        // If the adapter is intended to be able to relay tokens, this method should be overriden.
+        // If the adapter is intended to be able to relay tokens, this method should be overridden.
     }
 }


### PR DESCRIPTION
## Summary
- Fixed spelling of "overriden" to "overridden" (correct past participle) in 3 files

## Files Changed
- `contracts/Succinct_SpokePool.sol`
- `contracts/SpokePool.sol`
- `contracts/chain-adapters/Succinct_Adapter.sol`

## Test plan
- [ ] Verify the changes are comment-only and do not affect contract logic