### PR TITLE
Fix typo: Accross -> Across and LayzerZero -> LayerZero

### DIFF
--- a/contracts/periphery/mintburn/sponsored-oft/SponsoredOFTSrcPeriphery.sol
+++ b/contracts/periphery/mintburn/sponsored-oft/SponsoredOFTSrcPeriphery.sol
@@ -16,7 +16,7 @@ import { IERC20Metadata } from "@openzeppelin/contracts-v4/token/ERC20/extension
 import { SafeERC20 } from "@openzeppelin/contracts-v4/token/ERC20/utils/SafeERC20.sol";
 
 /// @notice Source chain periphery contract for users to interact with to start a sponsored or a non-sponsored flow
-/// that allows custom Accross-supported flows on destination chain. Uses LayzerZero's OFT as an underlying bridge
+/// that allows custom Across-supported flows on destination chain. Uses LayerZero's OFT as an underlying bridge
 contract SponsoredOFTSrcPeriphery is Ownable, OFTCoreMath {
     using AddressToBytes32 for address;
     using MinimalLZOptions for bytes;

--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -479,7 +479,7 @@ pub mod svm_spoke {
     /// refund. In the happy path, (a) should be used. (b) should only be used if there is a relayer within the bundle
     /// who can't receive the transfer for some reason, such as failed token transfers due to blacklisting. Executing
     /// relayer refunds requires the caller to create a LUT and load the execution params into it. This is needed to
-    /// fit the data in a single instruction. The exact structure and validation of the leaf is defined in the Accross
+    /// fit the data in a single instruction. The exact structure and validation of the leaf is defined in the Across
     /// UMIP: https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-179.md
     ///
     /// instruction_params Parameters:


### PR DESCRIPTION
## Summary
- Fixed spelling of the protocol name "Accross" to "Across" in 2 files
- Also fixed "LayzerZero" to "LayerZero" in SponsoredOFTSrcPeriphery.sol

## Files Changed
- `contracts/periphery/mintburn/sponsored-oft/SponsoredOFTSrcPeriphery.sol` (Solidity)
- `programs/svm-spoke/src/lib.rs` (Rust)

## Test plan
- [ ] Verify the changes are comment-only and do not affect contract/program logic