### PR TITLE
fix: L-04 add EIP-712 to HyperLiquidDepositHandler

### DIFF
--- a/broadcast/deployed-addresses.json
+++ b/broadcast/deployed-addresses.json
@@ -554,6 +554,11 @@
         "SpokePoolPeriphery": {
           "address": "0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C",
           "block_number": 18113085
+        },
+        "Lisk_SpokePool": {
+          "address": "0xe58480ca74f1a819fafd777beded4e2d5629943d",
+          "block_number": 27152120,
+          "transaction_hash": "0x0129be4b65f57157e7cbd7a8b8688afed1293a3442620df4d1c85736d451b0fc"
         }
       }
     },
@@ -590,9 +595,9 @@
           "block_number": 8910059
         },
         "Cher_SpokePool": {
-          "address": "0x48e687205d3962c43891b8cde5a4fe75fa6c8d7a",
-          "block_number": 11504355,
-          "transaction_hash": "0x5e126b5845bf4425d053febf06089e7c02411ee3edf7df6ffa888bc530d85c7f"
+          "address": "0x1c8243198570658f818fc56538f2c837c2a32958",
+          "block_number": 17949038,
+          "transaction_hash": "0x7a3ca40368652c84c2ca47f5722df58e098efcb8af08427192d55ae0baf92e91"
         }
       }
     },

--- a/broadcast/deployed-addresses.md
+++ b/broadcast/deployed-addresses.md
@@ -177,6 +177,7 @@ This file contains the latest deployed smart contract addresses from the broadca
 
 | Contract Name      | Address                                                                                                                      |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| Lisk_SpokePool     | [0xE58480CA74f1A819faFd777BEDED4E2D5629943d](https://blockscout.lisk.com/address/0xE58480CA74f1A819faFd777BEDED4E2D5629943d) |
 | MulticallHandler   | [0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E](https://blockscout.lisk.com/address/0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E) |
 | SpokePool          | [0x9552a0a6624A23B848060AE5901659CDDa1f83f8](https://blockscout.lisk.com/address/0x9552a0a6624A23B848060AE5901659CDDa1f83f8) |
 | SpokePoolPeriphery | [0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C](https://blockscout.lisk.com/address/0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C) |
@@ -187,6 +188,7 @@ This file contains the latest deployed smart contract addresses from the broadca
 | Contract Name      | Address                                                                                                                         |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | Cher_SpokePool     | [0x48e687205D3962c43891b8Cde5A4Fe75FA6C8D7a](https://soneium.blockscout.com/address/0x48e687205D3962c43891b8Cde5A4Fe75FA6C8D7a) |
+| Cher_SpokePool     | [0x1c8243198570658f818FC56538f2c837C2a32958](https://soneium.blockscout.com/address/0x1c8243198570658f818FC56538f2c837C2a32958) |
 | MulticallHandler   | [0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E](https://soneium.blockscout.com/address/0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E) |
 | SpokePool          | [0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96](https://soneium.blockscout.com/address/0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96) |
 | SpokePoolPeriphery | [0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C](https://soneium.blockscout.com/address/0x89415a82d909a7238d69094C3Dd1dCC1aCbDa85C) |


### PR DESCRIPTION
> _verifySignature [authorizes](https://github.com/across-protocol/contracts/blob/d3bc16ecaecb84b71c80b826be1b93d0cd973ddc/contracts/handlers/HyperliquidDepositHandler.sol#L285-L289) donation-box-funded activation using ECDSA.recover(keccak256(abi.encode(user)), signature) without domain separation or an expiry. The signed message omits contract-specific data (e.g., contract address, chain ID) and time-bounding metadata, so the signature is a raw hash of user that can be replayed, in theory, wherever an identical hash is accepted. Lack of nonce or deadline further allows indefinite reuse.
> 
> In this current specific case of account activation sponsorship authorization, the scope is limited to one-time use and no other immediate cross-context replay is possible. Nonetheless, it is advised to future-proof signature authorization and adopt industry best practices.
> 
> Consider adopting EIP-712-style domain separation (including contract address, chain ID, and intent identifier), expanding the signed payload to cover the action being authorized, and adding an explicit expiry to limit signature lifetime.