### PR TITLE
fix: [L-01] Changes to view Function Visibility Not Backwards Compatible

### DIFF
--- a/contracts/SpokePoolPeriphery.sol
+++ b/contracts/SpokePoolPeriphery.sol
@@ -151,7 +151,7 @@ contract SpokePoolPeriphery is SpokePoolPeripheryInterface, ReentrancyGuard, Mul
     SwapProxy public immutable swapProxy;
 
     // Mapping from user address to their current nonce
-    mapping(address => uint256) private permitNonces;
+    mapping(address => uint256) private _permitNonces;
 
     // Witness identifiers for the bridge and swap functions. Used to ensure collisions can't happen.
     bytes32 public constant BRIDGE_AND_SWAP_WITNESS_IDENTIFIER = keccak256("BridgeAndSwapWitness");
@@ -602,8 +602,8 @@ contract SpokePoolPeriphery is SpokePoolPeripheryInterface, ReentrancyGuard, Mul
      * @return The next nonce for the user.
      * @dev Nonce starts at 1 to avoid 0 (which triggers regular deposit) and ensure uniqueness.
      */
-    function permitNonce(address user) external view returns (uint256) {
-        return permitNonces[user] + 1;
+    function permitNonces(address user) external view returns (uint256) {
+        return _permitNonces[user] + 1;
     }
 
     /**
@@ -632,7 +632,7 @@ contract SpokePoolPeriphery is SpokePoolPeripheryInterface, ReentrancyGuard, Mul
      */
     function _validateAndIncrementNonce(address user, uint256 providedNonce) private {
         // Pre-increment nonce so it can never be 0.
-        if (++permitNonces[user] != providedNonce) {
+        if (++_permitNonces[user] != providedNonce) {
             revert InvalidNonce();
         }
     }

--- a/contracts/interfaces/SpokePoolPeripheryInterface.sol
+++ b/contracts/interfaces/SpokePoolPeripheryInterface.sol
@@ -154,7 +154,7 @@ interface SpokePoolPeripheryInterface {
      * Caller can specify their slippage tolerance for the swap and Across deposit params.
      * @dev If the swapToken does not implement `permit` to the specifications of EIP-2612, the permit call result will be ignored and the function will continue.
      * @dev If the swapToken in swapData does not implement `permit` to the specifications of EIP-2612, this function will fail.
-     * @dev The nonce for the swapAndDepositData signature must be retrieved from permitNonce(signatureOwner).
+     * @dev The nonce for the swapAndDepositData signature must be retrieved from permitNonces(signatureOwner).
      * @dev Design Decision: We use separate nonce tracking for permit-based functions versus
      * receiveWithAuthorization-based functions, which creates a theoretical replay attack that we think is
      * incredibly unlikely because this would require:
@@ -216,7 +216,7 @@ interface SpokePoolPeripheryInterface {
      * @notice Deposits an EIP-2612 token Across input token into the Spoke Pool contract.
      * @dev If the token does not implement `permit` to the specifications of EIP-2612, the permit call result will be ignored and the function will continue.
      * @dev If `acrossInputToken` does not implement `permit` to the specifications of EIP-2612, this function will fail.
-     * @dev The nonce for the depositData signature must be retrieved from permitNonce(signatureOwner).
+     * @dev The nonce for the depositData signature must be retrieved from permitNonces(signatureOwner).
      * @dev Design Decision: We use separate nonce tracking for permit-based functions versus
      * receiveWithAuthorization-based functions, which creates a theoretical replay attack that we think is
      * incredibly unlikely because this would require:
@@ -277,5 +277,5 @@ interface SpokePoolPeripheryInterface {
      * @param user The user whose nonce to return.
      * @return The current permit nonce for the user.
      */
-    function permitNonce(address user) external view returns (uint256);
+    function permitNonces(address user) external view returns (uint256);
 }

--- a/test/evm/foundry/local/SpokePoolPeriphery.t.sol
+++ b/test/evm/foundry/local/SpokePoolPeriphery.t.sol
@@ -633,7 +633,7 @@ contract SpokePoolPeripheryTest is Test {
             depositAmount,
             depositor,
             true,
-            spokePoolPeriphery.permitNonce(depositor)
+            spokePoolPeriphery.permitNonces(depositor)
         );
 
         bytes32 nonce = 0;
@@ -708,7 +708,7 @@ contract SpokePoolPeripheryTest is Test {
         mockWETH.deposit{ value: depositAmount }();
         mockWETH.transfer(address(dex), depositAmount);
 
-        uint256 validNonce = spokePoolPeriphery.permitNonce(depositor);
+        uint256 validNonce = spokePoolPeriphery.permitNonces(depositor);
 
         SpokePoolPeripheryInterface.SwapAndDepositData memory swapAndDepositData = _defaultSwapAndDepositData(
             address(mockERC20),
@@ -1415,7 +1415,7 @@ contract SpokePoolPeripheryTest is Test {
             depositAmount,
             depositor,
             true,
-            spokePoolPeriphery.permitNonce(depositor)
+            spokePoolPeriphery.permitNonces(depositor)
         );
 
         bytes32 nonce = 0;
@@ -1566,12 +1566,12 @@ contract SpokePoolPeripheryTest is Test {
                 }),
                 inputAmount: _amount,
                 spokePool: address(ethereumSpokePool),
-                nonce: spokePoolPeriphery.permitNonce(_depositor)
+                nonce: spokePoolPeriphery.permitNonces(_depositor)
             });
     }
 
     function testNonceInitiallyZero() public {
-        assertEq(spokePoolPeriphery.permitNonce(depositor), 1);
+        assertEq(spokePoolPeriphery.permitNonces(depositor), 1);
     }
 
     function testNonceIncrementsAfterDepositWithPermit() public {
@@ -1584,7 +1584,7 @@ contract SpokePoolPeripheryTest is Test {
         );
 
         // Check initial nonce
-        uint256 initialNonce = spokePoolPeriphery.permitNonce(depositor);
+        uint256 initialNonce = spokePoolPeriphery.permitNonces(depositor);
 
         bytes32 nonce = 0;
 
@@ -1613,7 +1613,7 @@ contract SpokePoolPeripheryTest is Test {
         spokePoolPeriphery.depositWithPermit(depositor, depositData, block.timestamp, signature, depositDataSignature);
 
         // Check that nonce was incremented
-        assertEq(spokePoolPeriphery.permitNonce(depositor), initialNonce + 1);
+        assertEq(spokePoolPeriphery.permitNonces(depositor), initialNonce + 1);
     }
 
     function testDepositWithPermitInvalidNonce() public {
@@ -1787,7 +1787,7 @@ contract SpokePoolPeripheryTest is Test {
             depositAmount,
             depositor,
             true,
-            spokePoolPeriphery.permitNonce(depositor) // Use proper nonce (will be 1 initially)
+            spokePoolPeriphery.permitNonces(depositor) // Use proper nonce (will be 1 initially)
         );
 
         bytes32 nonce = 0;


### PR DESCRIPTION
In the reviewed pull request, the visibility of the SpokePoolPeriphery contract's [permitNonces](https://github.com/across-protocol/contracts/blob/148d64338d3a83bbf27da20958d9394a7e2bc140/contracts/SpokePoolPeriphery.sol#L154) state variable has been changed from public to private. This is done because after the changes in the handling of nonces, the nonce returned from the permitNonces state variable will now only show the previous nonce and not the next valid nonce for a given user. A new getter function named [permitNonce](https://github.com/across-protocol/contracts/blob/148d64338d3a83bbf27da20958d9394a7e2bc140/contracts/SpokePoolPeriphery.sol#L605-L607) has been implemented for this purpose. The issue is that this change is not backwards compatible and will break existing integrations that rely on the previously public permitNonces variable to obtain the next valid nonce.

Consider changing the name of the newly added permitNonce function to permitNonces. This will retain backwards compatibility with no impact on integrators.