### PR TITLE
fix: correct spelling in comments and scripts

### DIFF
--- a/programs/svm-spoke/src/lib.rs
+++ b/programs/svm-spoke/src/lib.rs
@@ -613,7 +613,7 @@ pub mod svm_spoke {
     /// Initializes a claim account for a relayer refund.
     ///
     /// This function sets up a claim account for a relayer to claim their refund at a later time and should only be
-    /// used in the un-happy path where a bundle cant not be executed due to a recipient in the bundle having a blocked
+    /// used in the un-happy path where a bundle cannot be executed due to a recipient in the bundle having a blocked
     /// or uninitialized claim ATA. The refund address becomes the "owner" of the claim_account.
     ///
     /// ### Required Accounts:

--- a/scripts/svm/executeRebalanceToHubPool.ts
+++ b/scripts/svm/executeRebalanceToHubPool.ts
@@ -464,7 +464,7 @@ async function executeRelayerRefundLeaf(
     .accounts({ signer: signer.publicKey, instructionParams: instructionParams })
     .rpc();
   console.log(`Close instruction params transaction sent: ${closeInstructionParamsTx}`);
-  // Note we cant close the lookup table account as it needs to be both deactivated and expired at to do this.
+  // Note we can't close the lookup table account as it needs to be both deactivated and expired at to do this.
 }
 
 // Run the executeRebalanceToHubPool function

--- a/scripts/svm/simpleFakeRelayerRepayment.ts
+++ b/scripts/svm/simpleFakeRelayerRepayment.ts
@@ -318,7 +318,7 @@ async function testBundleLogic(): Promise<void> {
     .accounts({ signer: signer.publicKey, instructionParams: instructionParams })
     .rpc();
   console.log(`Close instruction params transaction sent: ${closeInstructionParamsTx}`);
-  // Note we cant close the lookup table account as it needs to be both deactivated and expired at to do this.
+  // Note we can't close the lookup table account as it needs to be both deactivated and expired at to do this.
 
   // Check that the relayers got back the amount you were expecting
   const relayerBalances = [];


### PR DESCRIPTION
## Description
Fixed spelling errors in comments and script files.

⚠️ **Note:** Comment-only changes. No functional code modified.

## Changes
- Fix 'cant not' → 'cannot'
- Fix 'cant' → 'can't'

## Files Modified
- programs/svm-spoke/src/lib.rs
- scripts/svm/simpleFakeRelayerRepayment.ts
- scripts/svm/executeRebalanceToHubPool.ts

## Impact
- Comment clarity improvement only
- No functional changes to Across Protocol bridge logic