### PR TITLE
docs: add SpokePool contract overview above constructor

### DIFF
--- a/contracts/spoke-pools/SpokePool.sol
+++ b/contracts/spoke-pools/SpokePool.sol
@@ -213,6 +213,17 @@ abstract contract SpokePool is
     /// @notice Thrown when the native fee sent by the caller is insufficient to cover the OFT transfer.
     error OFTFeeUnderpaid();
 
+    // SpokePool is the per-chain endpoint of Across's hub-and-spoke intents system. An instance is deployed on every
+    // supported chain and serves both origin- and destination-chain roles for cross-chain transfers:
+    //   - On the origin chain it accepts depositor funds (locking them in the contract) and emits FundsDeposited
+    //     events that relayers observe to fulfill the transfer.
+    //   - On the destination chain it lets relayers call fillRelay() to front the recipient's tokens.
+    //   - It stores root bundles relayed from HubPool on L1 and executes their leaves: relayer refunds (repaying
+    //     relayers from contract reserves) and slow fills (the protocol's fallback when no relayer fills in time).
+    //   - Locked origin-chain tokens are later bridged back to HubPool on L1 via the canonical bridge.
+    // This base contract is abstract and UUPS-upgradeable. Chain-specific variants (e.g. Arbitrum_SpokePool,
+    // Optimism_SpokePool) override cross-chain admin verification and any bridge-specific logic. Admin actions
+    // originate on HubPool (L1) and are relayed in via the appropriate chain adapter.
     /**
      * @notice Construct the SpokePool. Normally, logic contracts used in upgradeable proxies shouldn't
      * have constructors since the following code will be executed within the logic contract's state, not the

--- a/contracts/spoke-pools/SpokePool.sol
+++ b/contracts/spoke-pools/SpokePool.sol
@@ -215,8 +215,11 @@ abstract contract SpokePool is
 
     // SpokePool is the per-chain endpoint of Across's hub-and-spoke intents system. An instance is deployed on every
     // supported chain and serves both origin- and destination-chain roles for cross-chain transfers:
-    //   - On the origin chain it accepts depositor funds (locking them in the contract) and emits FundsDeposited
-    //     events that relayers observe to fulfill the transfer.
+    //   - L2 deposit flow: a depositor calls deposit() / depositV3() (or unsafeDeposit()) on the origin SpokePool,
+    //     specifying input/output tokens, amounts, destination chain, recipient, exclusivity, quote timestamp, and
+    //     fill deadline. The contract pulls and locks the input tokens (wrapping native ETH if sent), assigns a
+    //     unique deposit ID, and emits FundsDeposited for relayers to observe. Native-token deposits are auto-wrapped
+    //     into the chain's wrappedNativeToken before being locked.
     //   - On the destination chain it lets relayers call fillRelay() to front the recipient's tokens.
     //   - It stores root bundles relayed from HubPool on L1 and executes their leaves: relayer refunds (repaying
     //     relayers from contract reserves) and slow fills (the protocol's fallback when no relayer fills in time).


### PR DESCRIPTION
## Summary
- Adds an inline comment block above `SpokePool`'s constructor summarizing what the contract does: it is the per-chain endpoint of Across's hub-and-spoke intents system, handling origin deposits, destination fills, root bundle leaf execution (relayer refunds + slow fills), and bridging locked tokens back to HubPool on L1.
- Notes that the contract is abstract and UUPS-upgradeable, with chain-specific variants (e.g. `Arbitrum_SpokePool`, `Optimism_SpokePool`) overriding cross-chain admin verification and bridge-specific logic.

## Test plan
- [ ] No code change — comment-only edit; existing `yarn build-evm-foundry` / `yarn test-evm-foundry` should pass unchanged.

_Requested by @MattRosenUMA in Slack._

🤖 Generated with [Claude Code](https://claude.com/claude-code)