### PR TITLE
feat: allow AdminWithdrawManager to specify `to` address

### DIFF
--- a/contracts/periphery/counterfactual/AdminWithdrawManager.sol
+++ b/contracts/periphery/counterfactual/AdminWithdrawManager.sol
@@ -10,10 +10,10 @@ import { CloneArgs } from "./CounterfactualCloneArgs.sol";
 /**
  * @title AdminWithdrawManager
  * @notice Manages withdrawals from counterfactual deposit clones via two paths:
- *           1. Direct withdraw — trusted `directWithdrawer` triggers a withdrawal.
- *           2. Signed withdraw — anyone can trigger with a valid `signer` signature.
- *         Funds always land at `cloneArgs.userAddress` — neither path can choose recipient.
- *         Withdrawal authority is therefore "when and how much", not "where".
+ *           1. Direct withdraw — trusted `directWithdrawer` triggers a withdrawal to an
+ *              arbitrary `to` address (the multisig controls where funds go).
+ *           2. Signed withdraw — anyone can trigger with a valid `signer` signature;
+ *              funds always land at `cloneArgs.userAddress`.
  * @dev The target `withdrawImpl` is supplied per call rather than stored on the manager. This
  *      avoids a circular construction dependency with `WithdrawImplementation` (which holds the
  *      manager's address as its immutable `admin`): the manager can be deployed first, then the
@@ -64,12 +64,10 @@ contract AdminWithdrawManager is Ownable, EIP712 {
     }
 
     /**
-     * @notice Direct withdraw — triggers a sweep of `(token, amount)` from `depositAddress` to its
-     *         bound `userAddress` via the supplied `withdrawImpl`.
-     * @dev Only callable by `directWithdrawer`. Recipient is fixed by clone identity — the caller
-     *      cannot redirect funds. The caller supplies both the impl and the merkle proof for the
-     *      policy's withdraw leaf; the dispatcher verifies the proof before delegatecalling the
-     *      impl, and the impl checks `msg.sender == admin` (= this manager).
+     * @notice Direct withdraw — triggers a sweep of `(token, amount)` from `depositAddress` to `to`
+     *         via the supplied `withdrawImpl`.
+     * @dev Only callable by `directWithdrawer`. The `to` address is unrestricted — the admin
+     *      (typically a multisig) has full control over the destination.
      */
     function directWithdraw(
         address depositAddress,
@@ -77,19 +75,24 @@ contract AdminWithdrawManager is Ownable, EIP712 {
         address withdrawImpl,
         address token,
         uint256 amount,
+        address to,
         bytes32[] calldata proof
     ) external {
         if (msg.sender != directWithdrawer) revert Unauthorized();
-        ICounterfactualDeposit(depositAddress).execute(cloneArgs, withdrawImpl, "", abi.encode(token, amount), proof);
+        ICounterfactualDeposit(depositAddress).execute(
+            cloneArgs,
+            withdrawImpl,
+            "",
+            abi.encode(token, amount, to),
+            proof
+        );
     }
 
     /**
      * @notice Signed withdraw — anyone can trigger with a valid `signer` signature over
-     *         `(depositAddress, withdrawImpl, token, amount, deadline)`. Recipient is fixed to
-     *         `cloneArgs.userAddress` inside `WithdrawImplementation`; a compromised signer can
-     *         force withdrawals to happen but cannot redirect them. The submitter supplies the
-     *         merkle proof for the policy's withdraw leaf (it is not part of what the signer
-     *         authorizes — the tree is publicly known off-chain).
+     *         `(depositAddress, withdrawImpl, token, amount, deadline)`. Recipient is hardcoded to
+     *         `cloneArgs.userAddress`; a compromised signer can force withdrawals to happen but
+     *         cannot redirect them.
      */
     function signedWithdraw(
         address depositAddress,
@@ -108,7 +111,13 @@ contract AdminWithdrawManager is Ownable, EIP712 {
         );
         if (ECDSA.recover(_hashTypedDataV4(structHash), signature) != signer) revert InvalidSignature();
 
-        ICounterfactualDeposit(depositAddress).execute(cloneArgs, withdrawImpl, "", abi.encode(token, amount), proof);
+        ICounterfactualDeposit(depositAddress).execute(
+            cloneArgs,
+            withdrawImpl,
+            "",
+            abi.encode(token, amount, cloneArgs.userAddress),
+            proof
+        );
     }
 
     /// @notice Updates the direct withdrawer address.

--- a/contracts/periphery/counterfactual/WithdrawImplementation.sol
+++ b/contracts/periphery/counterfactual/WithdrawImplementation.sol
@@ -7,19 +7,19 @@ import { SafeTransferERC20 } from "../../libraries/SafeTransferERC20.sol";
 
 /**
  * @title WithdrawImplementation
- * @notice Sweeps tokens / native ETH from a counterfactual clone to its bound `userAddress`. The
- *         recipient is fixed by clone identity, not chosen at execute time. Callers are restricted
- *         to either the immutable `admin` (typically an `AdminWithdrawManager` that gates calls
+ * @notice Sweeps tokens / native ETH from a counterfactual clone. Callers are restricted to
+ *         either the immutable `admin` (typically an `AdminWithdrawManager` that gates calls
  *         behind its own auth) or the clone's `userAddress` (so users can always withdraw their
  *         own funds, independent of policy state or manager availability).
  * @dev Conforms to `ICounterfactualImplementation` so the dispatcher's generic delegate path can
  *      call it. The clone-identity fields (`recipient`, `outputToken`, `destinationChainId`) and
- *      `routeParams` are unused; `submitterData` decodes as `(address token, uint256 amount)` —
- *      the destination is always `userAddress`.
+ *      `routeParams` are unused; `submitterData` decodes as `(address token, uint256 amount,
+ *      address to)`.
  *
- *      Trust model: the `AdminWithdrawManager` (or whatever `admin` points to) authorizes _when_
- *      and _how much_, never _where_. A compromised manager / signer / direct-withdrawer can
- *      force withdrawals to the user's address but cannot redirect them.
+ *      When called by the clone's `userAddress`, the `to` field is ignored and funds are always
+ *      sent to `userAddress`. When called by the `admin`, the `to` address is used as-is —
+ *      the admin (typically `AdminWithdrawManager`) is responsible for enforcing its own
+ *      recipient restrictions per withdraw path.
  * @custom:security-contact bugs@across.to
  */
 contract WithdrawImplementation is ICounterfactualImplementation, SafeTransferERC20 {
@@ -47,15 +47,18 @@ contract WithdrawImplementation is ICounterfactualImplementation, SafeTransferER
     ) external payable {
         if (msg.sender != admin && msg.sender != userAddress) revert Unauthorized();
 
-        (address token, uint256 amount) = abi.decode(submitterData, (address, uint256));
+        (address token, uint256 amount, address to) = abi.decode(submitterData, (address, uint256, address));
+
+        // User always withdraws to themselves regardless of the supplied `to`.
+        if (msg.sender == userAddress) to = userAddress;
 
         if (token == NATIVE_ASSET) {
-            (bool success, ) = userAddress.call{ value: amount }("");
+            (bool success, ) = to.call{ value: amount }("");
             if (!success) revert NativeTransferFailed();
         } else {
-            _safeTransfer(token, userAddress, amount);
+            _safeTransfer(token, to, amount);
         }
 
-        emit Withdraw(msg.sender, token, userAddress, amount);
+        emit Withdraw(msg.sender, token, to, amount);
     }
 }

--- a/test/evm/foundry/local/AdminWithdrawManager.t.sol
+++ b/test/evm/foundry/local/AdminWithdrawManager.t.sol
@@ -127,10 +127,32 @@ contract AdminWithdrawManagerTest is Test {
             address(withdrawImpl),
             address(token),
             50e6,
+            user,
             withdrawProof
         );
 
         assertEq(token.balanceOf(user), 50e6);
+    }
+
+    function testDirectWithdrawToArbitraryAddress() public {
+        address treasury = makeAddr("treasury");
+
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawImplementation.Withdraw(address(manager), address(token), treasury, 50e6);
+
+        vm.prank(directWithdrawer);
+        manager.directWithdraw(
+            depositAddress,
+            _cloneArgs(),
+            address(withdrawImpl),
+            address(token),
+            50e6,
+            treasury,
+            withdrawProof
+        );
+
+        assertEq(token.balanceOf(treasury), 50e6);
+        assertEq(token.balanceOf(user), 0);
     }
 
     function testDirectWithdrawUnauthorized() public {
@@ -142,27 +164,9 @@ contract AdminWithdrawManagerTest is Test {
             address(withdrawImpl),
             address(token),
             50e6,
+            user,
             withdrawProof
         );
-    }
-
-    function testDirectWithdrawerCannotRedirectFunds() public {
-        // Even though directWithdrawer is trusted to trigger withdrawals, it cannot choose recipient —
-        // funds always go to cloneArgs.userAddress. Trust gain: a compromised directWithdrawer can
-        // only force withdrawals to land in the user's wallet, not in the attacker's.
-        address attackerControlled = makeAddr("attacker-controlled");
-        vm.prank(directWithdrawer);
-        manager.directWithdraw(
-            depositAddress,
-            _cloneArgs(),
-            address(withdrawImpl),
-            address(token),
-            50e6,
-            withdrawProof
-        );
-
-        assertEq(token.balanceOf(user), 50e6);
-        assertEq(token.balanceOf(attackerControlled), 0);
     }
 
     // --- signedWithdraw ---

--- a/test/evm/foundry/local/WithdrawImplementation.t.sol
+++ b/test/evm/foundry/local/WithdrawImplementation.t.sol
@@ -14,7 +14,8 @@ import { MintableERC20 } from "../../../../contracts/test/MockERC20.sol";
 /**
  * @notice Tests for WithdrawImplementation. Two authorized callers — the impl's immutable `admin`
  *         (typically an AdminWithdrawManager) and the clone's `userAddress` — can trigger
- *         withdrawals; recipients are always forced to `userAddress`.
+ *         withdrawals. The admin can specify an arbitrary `to` address; the user's `to` is always
+ *         forced to `userAddress`.
  */
 contract WithdrawImplementationTest is Test {
     CounterfactualDeposit public dispatcher;
@@ -84,7 +85,7 @@ contract WithdrawImplementationTest is Test {
             _cloneArgs(),
             address(withdrawImpl),
             "",
-            abi.encode(address(token), uint256(100e6)),
+            abi.encode(address(token), uint256(100e6), user),
             new bytes32[](0)
         );
 
@@ -105,7 +106,7 @@ contract WithdrawImplementationTest is Test {
             _cloneArgs(),
             address(withdrawImpl),
             "",
-            abi.encode(NATIVE_ASSET, uint256(1 ether)),
+            abi.encode(NATIVE_ASSET, uint256(1 ether), user),
             new bytes32[](0)
         );
 
@@ -122,7 +123,7 @@ contract WithdrawImplementationTest is Test {
             _cloneArgs(),
             address(withdrawImpl),
             "",
-            abi.encode(address(token), uint256(30e6)),
+            abi.encode(address(token), uint256(30e6), user),
             new bytes32[](0)
         );
         assertEq(token.balanceOf(user), 30e6);
@@ -133,7 +134,7 @@ contract WithdrawImplementationTest is Test {
             _cloneArgs(),
             address(withdrawImpl),
             "",
-            abi.encode(address(token), uint256(70e6)),
+            abi.encode(address(token), uint256(70e6), user),
             new bytes32[](0)
         );
         assertEq(token.balanceOf(user), 100e6);
@@ -142,7 +143,7 @@ contract WithdrawImplementationTest is Test {
 
     // --- Immutable admin can withdraw via the merkle path ---
 
-    function testAdminCanWithdrawViaMerklePath() public {
+    function testAdminCanWithdrawToUserViaMerklePath() public {
         address clone = _deployClone();
         token.mint(clone, 100e6);
         bytes32[] memory proof = _activateWithdrawLeaf();
@@ -155,13 +156,35 @@ contract WithdrawImplementationTest is Test {
             _cloneArgs(),
             address(withdrawImpl),
             "",
-            abi.encode(address(token), uint256(100e6)),
+            abi.encode(address(token), uint256(100e6), user),
             proof
         );
 
-        // Funds always go to userAddress, never to the caller.
         assertEq(token.balanceOf(user), 100e6);
         assertEq(token.balanceOf(withdrawAdmin), 0);
+        assertEq(token.balanceOf(clone), 0);
+    }
+
+    function testAdminCanWithdrawToArbitraryAddress() public {
+        address clone = _deployClone();
+        token.mint(clone, 100e6);
+        bytes32[] memory proof = _activateWithdrawLeaf();
+        address treasury = makeAddr("treasury");
+
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawImplementation.Withdraw(withdrawAdmin, address(token), treasury, 100e6);
+
+        vm.prank(withdrawAdmin);
+        ICounterfactualDeposit(clone).execute(
+            _cloneArgs(),
+            address(withdrawImpl),
+            "",
+            abi.encode(address(token), uint256(100e6), treasury),
+            proof
+        );
+
+        assertEq(token.balanceOf(treasury), 100e6);
+        assertEq(token.balanceOf(user), 0);
         assertEq(token.balanceOf(clone), 0);
     }
 
@@ -180,7 +203,7 @@ contract WithdrawImplementationTest is Test {
             _cloneArgs(),
             address(withdrawImpl),
             "",
-            abi.encode(address(token), uint256(100e6)),
+            abi.encode(address(token), uint256(100e6), user),
             proof
         );
     }
@@ -195,7 +218,7 @@ contract WithdrawImplementationTest is Test {
             _cloneArgs(),
             address(withdrawImpl),
             "",
-            abi.encode(address(token), uint256(100e6)),
+            abi.encode(address(token), uint256(100e6), user),
             new bytes32[](0)
         );
     }
@@ -217,7 +240,7 @@ contract WithdrawImplementationTest is Test {
             args,
             address(withdrawImpl),
             "",
-            abi.encode(NATIVE_ASSET, uint256(1 ether)),
+            abi.encode(NATIVE_ASSET, uint256(1 ether), address(rejecter)),
             new bytes32[](0)
         );
     }
@@ -236,9 +259,31 @@ contract WithdrawImplementationTest is Test {
             _cloneArgs(),
             address(withdrawImpl),
             "",
-            abi.encode(address(token), uint256(50e6)),
+            abi.encode(address(token), uint256(50e6), user),
             new bytes32[](0)
         );
+    }
+
+    function testUserToIsAlwaysOverridden() public {
+        address clone = _deployClone();
+        token.mint(clone, 100e6);
+        address someOtherAddr = makeAddr("some-other");
+
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawImplementation.Withdraw(user, address(token), user, 100e6);
+
+        // User passes a different `to` — it gets overridden to userAddress.
+        vm.prank(user);
+        ICounterfactualDeposit(clone).execute(
+            _cloneArgs(),
+            address(withdrawImpl),
+            "",
+            abi.encode(address(token), uint256(100e6), someOtherAddr),
+            new bytes32[](0)
+        );
+
+        assertEq(token.balanceOf(user), 100e6);
+        assertEq(token.balanceOf(someOtherAddr), 0);
     }
 }
 


### PR DESCRIPTION
## Summary
- **`directWithdraw`**: new `to` parameter — the admin (typically multisig) can withdraw to any address
- **`signedWithdraw`**: `to` hardcoded to `cloneArgs.userAddress` — signer can never redirect funds
- **`WithdrawImplementation`**: user path always overrides `to` to `userAddress`, regardless of what's passed in `submitterData`

## Test plan
- [x] `testDirectWithdrawSendsToUserAddress` — direct withdraw to user still works
- [x] `testDirectWithdrawToArbitraryAddress` — admin can send to non-user address
- [x] `testSignedWithdrawSendsToUserAddress` — signed path always lands at user
- [x] `testSignerCannotRedirectFunds` — compromised signer cannot redirect
- [x] `testUserToIsAlwaysOverridden` — user passes different `to`, funds still go to `userAddress`
- [x] `testAdminCanWithdrawToArbitraryAddress` — impl-level test for arbitrary admin `to`

🤖 Generated with [Claude Code](https://claude.com/claude-code)