### PR TITLE
feat: Tron MulticallHandler

### DIFF
--- a/contracts/handlers/MulticallHandler.sol
+++ b/contracts/handlers/MulticallHandler.sol
@@ -109,7 +109,7 @@ contract MulticallHandler is AcrossMessageHandler, ReentrancyGuard {
             // ERC20 token.
             uint256 amount = IERC20(token).balanceOf(address(this));
             if (amount > 0) {
-                IERC20(token).safeTransfer(destination, amount);
+                _safeTransfer(token, destination, amount);
                 emit DrainedTokens(destination, token, amount);
             }
         } else {
@@ -177,6 +177,10 @@ contract MulticallHandler is AcrossMessageHandler, ReentrancyGuard {
 
         (bool success, ) = target.call{ value: value }(callData);
         if (!success) revert ReplacementCallFailed(callData);
+    }
+
+    function _safeTransfer(address token, address to, uint256 amount) internal virtual {
+        IERC20(token).safeTransfer(to, amount);
     }
 
     function _requireSelf() internal view {

--- a/contracts/handlers/TronMulticallHandler.sol
+++ b/contracts/handlers/TronMulticallHandler.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+
+import { MulticallHandler } from "./MulticallHandler.sol";
+import { TronTransferLib } from "../libraries/TronTransferLib.sol";
+
+/**
+ * @title TronMulticallHandler
+ * @notice Tron-specific variant of `MulticallHandler` for tokens such as Tron USDT whose
+ *         `transfer` returns false even when it moves balances successfully.
+ * @dev Inherits all multicall behavior from the mainline handler and overrides only the
+ *      ERC20 drain transfer hook to use a balance-delta success check.
+ * @custom:security-contact bugs@across.to
+ */
+contract TronMulticallHandler is MulticallHandler {
+    /// @dev TRON OVERRIDE: was `IERC20(token).safeTransfer(to, amount)` in the parent.
+    function _safeTransfer(address token, address to, uint256 amount) internal override {
+        TronTransferLib._safeTransferBalanceCheck(token, to, amount);
+    }
+}

--- a/contracts/tron/TronPeripheryImports.sol
+++ b/contracts/tron/TronPeripheryImports.sol
@@ -4,3 +4,4 @@ pragma solidity ^0.8.0;
 // Entry point for SpokePoolPeriphery and SwapProxy in the tron Foundry profile. These use OZ v4
 // and are kept in a separate file from SP1Helios/Tron_SpokePool (OZ v5) to avoid name collisions.
 import "../periphery/SpokePoolPeriphery.sol";
+import "../handlers/TronMulticallHandler.sol";

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "tron-deploy-counterfactual-clone": "ts-node script/tron/counterfactual/tron-deploy-counterfactual-clone.ts",
     "tron-deploy-clone": "ts-node script/tron/counterfactual/tron-deploy-clone.ts",
     "tron-execute-clone-deposit": "ts-node script/tron/counterfactual/tron-execute-clone-deposit.ts",
+    "tron-deploy-tron-multicall-handler": "ts-node script/tron/periphery/tron-deploy-tron-multicall-handler.ts",
     "tron-deploy-spoke-pool-periphery": "ts-node script/tron/periphery/tron-deploy-spoke-pool-periphery.ts",
     "tron-deploy-swap-proxy": "ts-node script/tron/periphery/tron-deploy-swap-proxy.ts"
   },

--- a/script/tron/README.md
+++ b/script/tron/README.md
@@ -147,6 +147,14 @@ yarn tron-deploy-counterfactual-clone <factory> <implementation> <merkleRoot> <s
 
 ## Periphery Scripts
 
+### TronMulticallHandler
+
+Tron-specific `MulticallHandler` variant that drains leftover TRC20 tokens with a balance-delta transfer check, required for Tron USDT because its `transfer` returns `false` even on success. No constructor args.
+
+```bash
+yarn tron-deploy-tron-multicall-handler [--testnet]
+```
+
 ### SpokePoolPeriphery
 
 Deploys `SpokePoolPeriphery`. The constructor internally deploys a `SwapProxy`, which is accessible via `spokePoolPeriphery.swapProxy()` — a separate `SwapProxy` deployment is not required when deploying the periphery.
@@ -203,6 +211,7 @@ Each deployment writes a Foundry-compatible broadcast artifact to `broadcast/Tro
 | `counterfactual/tron-deploy-admin-withdraw-manager.ts`                | Deploys AdminWithdrawManager                                           |
 | `counterfactual/tron-deploy-withdraw-implementation-tron.ts`          | Deploys WithdrawImplementationTron (no args)                           |
 | `counterfactual/tron-deploy-counterfactual-clone.ts`                  | Deploys a clone from factory, verifies address prediction              |
+| `periphery/tron-deploy-tron-multicall-handler.ts`                     | Deploys TronMulticallHandler (no args)                                 |
 | `periphery/tron-deploy-spoke-pool-periphery.ts`                       | Deploys SpokePoolPeriphery (constructor also deploys inner SwapProxy)  |
 | `periphery/tron-deploy-swap-proxy.ts`                                 | Deploys a standalone SwapProxy                                         |
 

--- a/script/tron/periphery/tron-deploy-tron-multicall-handler.ts
+++ b/script/tron/periphery/tron-deploy-tron-multicall-handler.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env ts-node
+/**
+ * Deploys TronMulticallHandler to Tron. No constructor args.
+ *
+ * Options:
+ *   --testnet  — deploy to Tron Nile testnet (default: mainnet)
+ *
+ * Usage:
+ *   yarn tron-deploy-tron-multicall-handler [--testnet]
+ */
+
+import "dotenv/config";
+import * as path from "path";
+import { deployContract, resolveChainId } from "../deploy";
+
+async function main(): Promise<void> {
+  const chainId = resolveChainId();
+
+  console.log("=== TronMulticallHandler Deployment ===");
+  console.log(`Chain ID: ${chainId}`);
+
+  const artifactPath = path.resolve(__dirname, "../../../out-tron/TronMulticallHandler.sol/TronMulticallHandler.json");
+
+  await deployContract({ chainId, artifactPath });
+}
+
+main().catch((err) => {
+  console.log("Fatal error:", err.message || err);
+  process.exit(1);
+});

--- a/test/evm/foundry/local/TronMulticallHandler.t.sol
+++ b/test/evm/foundry/local/TronMulticallHandler.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+
+import { MulticallHandler } from "../../../../contracts/handlers/MulticallHandler.sol";
+import { TronMulticallHandler } from "../../../../contracts/handlers/TronMulticallHandler.sol";
+import { TronTransferLib } from "../../../../contracts/libraries/TronTransferLib.sol";
+import { MockTronUSDT } from "../../../../contracts/test/MockTronUSDT.sol";
+
+contract TronMulticallHandlerTest is Test {
+    TronMulticallHandler handler;
+    MockTronUSDT usdt;
+
+    address fallbackRecipient = makeAddr("fallbackRecipient");
+
+    function setUp() public {
+        handler = new TronMulticallHandler();
+        usdt = new MockTronUSDT();
+    }
+
+    function testFallbackDrain_TronUSDT_SucceedsWhenTransferReturnsFalse() public {
+        uint256 amount = 100e6;
+        usdt.mint(address(handler), amount);
+
+        MulticallHandler.Instructions memory instructions = MulticallHandler.Instructions({
+            calls: new MulticallHandler.Call[](0),
+            fallbackRecipient: fallbackRecipient
+        });
+
+        handler.handleV3AcrossMessage(address(usdt), amount, address(0), abi.encode(instructions));
+
+        assertEq(usdt.balanceOf(fallbackRecipient), amount, "recipient should receive USDT");
+        assertEq(usdt.balanceOf(address(handler)), 0, "handler should be drained");
+    }
+
+    function testFallbackDrain_TronUSDT_RevertsOnActualTransferFailure() public {
+        uint256 amount = 100e6;
+        usdt.mint(address(handler), amount);
+        usdt.setBlacklisted(fallbackRecipient, true);
+
+        MulticallHandler.Instructions memory instructions = MulticallHandler.Instructions({
+            calls: new MulticallHandler.Call[](0),
+            fallbackRecipient: fallbackRecipient
+        });
+
+        vm.expectRevert(TronTransferLib.TronTransferCallReverted.selector);
+        handler.handleV3AcrossMessage(address(usdt), amount, address(0), abi.encode(instructions));
+    }
+}


### PR DESCRIPTION
Adds TronMulticallHandler, a Tron-specific MulticallHandler variant that keeps the existing multicall behavior but drains leftover ERC20/TRC20 balances through TronTransferLib so Tron USDT’s false-returning transfer does not break recovery. 

The base handler now exposes a virtual transfer hook, and the Tron build/deploy path, docs, and focused tests were updated to cover the new contract.