### PR TITLE
feat: vanilla CCTP counterfactual deposit route

### DIFF
--- a/contracts/periphery/counterfactual/CounterfactualDepositVanillaCCTP.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDepositVanillaCCTP.sol
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import { ITokenMessengerV2 } from "../../external/interfaces/CCTPInterfaces.sol";
+import { ICounterfactualImplementation } from "../../interfaces/ICounterfactualImplementation.sol";
+import { BPS_SCALAR } from "./CounterfactualConstants.sol";
+
+/**
+ * @notice Route parameters committed to in the merkle leaf.
+ * @dev `hookData` selects the CCTP entrypoint: empty ⇒ `depositForBurn` (plain CCTP, USDC mints to
+ *      `mintRecipient`); non-empty ⇒ `depositForBurnWithHook` (e.g. HyperCore, where `mintRecipient` is
+ *      Circle's `CctpForwarder` and `hookData` is its envelope encoding the HyperCore recipient — both
+ *      opaque here and built off-chain into the leaf). `cctpMaxFeeBps`/`minFinalityThreshold` choose the
+ *      fast vs standard transfer (standard ⇒ `cctpMaxFeeBps = 0`).
+ */
+struct VanillaCCTPRouteParams {
+    uint256 sourceChainId;
+    uint32 destinationDomain;
+    bytes32 mintRecipient;
+    bytes32 burnToken;
+    bytes32 destinationCaller;
+    uint256 cctpMaxFeeBps;
+    uint32 minFinalityThreshold;
+    bytes hookData;
+    uint256 maxExecutionFee;
+}
+
+/**
+ * @notice Data supplied by the submitter at execution time.
+ */
+struct VanillaCCTPSubmitterData {
+    uint256 amount;
+    address executionFeeRecipient;
+    uint256 executionFee;
+    uint32 signatureDeadline;
+    bytes counterfactualSignature;
+}
+
+/**
+ * @title CounterfactualDepositVanillaCCTP
+ * @notice Implementation contract for counterfactual deposits via vanilla (non-sponsored) Circle CCTP v2.
+ * @dev Called via delegatecall from the CounterfactualDeposit dispatcher, so `address(this)` is the
+ *      counterfactual proxy (it holds the funds and is the EIP-712 `verifyingContract`) and `msg.sender`
+ *      is the original caller. Unlike `CounterfactualDepositCCTP`, this calls Circle's `ITokenMessengerV2`
+ *      directly — there is no Across periphery and no sponsored destination machinery: USDC mints natively
+ *      on the destination. An empty `hookData` uses `depositForBurn` (plain CCTP); a non-empty `hookData`
+ *      uses `depositForBurnWithHook` (e.g. HyperCore via Circle's `CctpForwarder`).
+ *
+ *      Because there is no periphery quote signature to bind the route/amount, the local EIP-712 fee
+ *      signature binds the full route (`routeParamsHash`), the `amount`, the `executionFee`, and a
+ *      `signatureDeadline`, and resolves `verifyingContract` to this proxy. Replay protection is the short
+ *      `signatureDeadline` (no nonce). ERC-20 only (no native tokens).
+ * @custom:security-contact bugs@across.to
+ */
+contract CounterfactualDepositVanillaCCTP is ICounterfactualImplementation, EIP712 {
+    using SafeERC20 for IERC20;
+
+    /**
+     * @notice Emitted after a vanilla CCTP deposit is successfully executed.
+     * @param amount Total input amount (including execution fee).
+     * @param executionFeeRecipient Address that received the execution fee.
+     * @param executionFee Execution fee paid to the executor (in input token).
+     * @param depositAmount Amount burned via CCTP (`amount - executionFee`).
+     */
+    event VanillaCCTPDepositExecuted(
+        uint256 amount,
+        address indexed executionFeeRecipient,
+        uint256 executionFee,
+        uint256 depositAmount
+    );
+
+    error InvalidSignature();
+    error SignatureExpired();
+    error MaxExecutionFee();
+    error SourceChainMismatch();
+
+    /// @notice EIP-712 typehash binding the fee signature to the route, amount, runtime fee, and deadline.
+    bytes32 public constant EXECUTE_VANILLA_CCTP_TYPEHASH =
+        keccak256(
+            "ExecuteVanillaCCTP(bytes32 routeParamsHash,uint256 amount,uint256 executionFee,uint32 signatureDeadline)"
+        );
+
+    /// @notice Circle CCTP v2 TokenMessenger (immutable, same for all deposits on this chain).
+    ITokenMessengerV2 public immutable tokenMessenger;
+
+    /// @notice CCTP source domain ID for this chain.
+    uint32 public immutable sourceDomain;
+
+    /// @notice Signer that authorizes the runtime execution fee (and, here, the route + amount).
+    address public immutable signer;
+
+    constructor(
+        address _tokenMessenger,
+        uint32 _sourceDomain,
+        address _signer
+    ) EIP712("CounterfactualDepositVanillaCCTP", "v2.0.0") {
+        tokenMessenger = ITokenMessengerV2(_tokenMessenger);
+        sourceDomain = _sourceDomain;
+        signer = _signer;
+    }
+
+    /**
+     * @inheritdoc ICounterfactualImplementation
+     * @dev Bridges tokens via Circle CCTP v2. `routeParamsEncoded` is ABI-encoded as `VanillaCCTPRouteParams`;
+     *      `submitterDataEncoded` as `VanillaCCTPSubmitterData`. ERC-20 only.
+     */
+    function execute(bytes calldata routeParamsEncoded, bytes calldata submitterDataEncoded) external payable {
+        VanillaCCTPRouteParams memory routeParams = abi.decode(routeParamsEncoded, (VanillaCCTPRouteParams));
+        VanillaCCTPSubmitterData memory submitterData = abi.decode(submitterDataEncoded, (VanillaCCTPSubmitterData));
+
+        if (block.chainid != routeParams.sourceChainId) revert SourceChainMismatch();
+        // Binds the exact merkle leaf (`keccak256(params)` is the leaf's params component), the amount, and
+        // the fee — the sole authorization of this transfer, since there is no periphery quote signature.
+        _verifySignature(keccak256(routeParamsEncoded), submitterData);
+        if (submitterData.executionFee > routeParams.maxExecutionFee) revert MaxExecutionFee();
+
+        address inputToken = address(uint160(uint256(routeParams.burnToken)));
+
+        if (submitterData.executionFee > 0)
+            IERC20(inputToken).safeTransfer(submitterData.executionFeeRecipient, submitterData.executionFee);
+
+        uint256 depositAmount = submitterData.amount - submitterData.executionFee;
+        uint256 maxFee = (depositAmount * routeParams.cctpMaxFeeBps) / BPS_SCALAR;
+
+        IERC20(inputToken).forceApprove(address(tokenMessenger), depositAmount);
+
+        // Non-empty hookData routes through depositForBurnWithHook (HyperCore via Circle's CctpForwarder,
+        // or any hook-aware destination); empty hookData is a plain native CCTP mint to `mintRecipient`.
+        if (routeParams.hookData.length > 0) {
+            tokenMessenger.depositForBurnWithHook(
+                depositAmount,
+                routeParams.destinationDomain,
+                routeParams.mintRecipient,
+                inputToken,
+                routeParams.destinationCaller,
+                maxFee,
+                routeParams.minFinalityThreshold,
+                routeParams.hookData
+            );
+        } else {
+            tokenMessenger.depositForBurn(
+                depositAmount,
+                routeParams.destinationDomain,
+                routeParams.mintRecipient,
+                inputToken,
+                routeParams.destinationCaller,
+                maxFee,
+                routeParams.minFinalityThreshold
+            );
+        }
+
+        emit VanillaCCTPDepositExecuted(
+            submitterData.amount,
+            submitterData.executionFeeRecipient,
+            submitterData.executionFee,
+            depositAmount
+        );
+    }
+
+    function _verifySignature(bytes32 routeParamsHash, VanillaCCTPSubmitterData memory submitterData) private view {
+        if (block.timestamp > submitterData.signatureDeadline) revert SignatureExpired();
+        bytes32 structHash = keccak256(
+            abi.encode(
+                EXECUTE_VANILLA_CCTP_TYPEHASH,
+                routeParamsHash,
+                submitterData.amount,
+                submitterData.executionFee,
+                submitterData.signatureDeadline
+            )
+        );
+        if (ECDSA.recover(_hashTypedDataV4(structHash), submitterData.counterfactualSignature) != signer)
+            revert InvalidSignature();
+    }
+}

--- a/contracts/periphery/counterfactual/CounterfactualDepositVanillaCCTP.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDepositVanillaCCTP.sol
@@ -87,19 +87,11 @@ contract CounterfactualDepositVanillaCCTP is ICounterfactualImplementation, EIP7
     /// @notice Circle CCTP v2 TokenMessenger (immutable, same for all deposits on this chain).
     ITokenMessengerV2 public immutable tokenMessenger;
 
-    /// @notice CCTP source domain ID for this chain.
-    uint32 public immutable sourceDomain;
-
     /// @notice Signer that authorizes the runtime execution fee (and, here, the route + amount).
     address public immutable signer;
 
-    constructor(
-        address _tokenMessenger,
-        uint32 _sourceDomain,
-        address _signer
-    ) EIP712("CounterfactualDepositVanillaCCTP", "v2.0.0") {
+    constructor(address _tokenMessenger, address _signer) EIP712("CounterfactualDepositVanillaCCTP", "v2.0.0") {
         tokenMessenger = ITokenMessengerV2(_tokenMessenger);
-        sourceDomain = _sourceDomain;
         signer = _signer;
     }
 

--- a/contracts/periphery/counterfactual/DESIGN.md
+++ b/contracts/periphery/counterfactual/DESIGN.md
@@ -186,7 +186,7 @@ Two kinds of leaves:
 Each names a **bridge-specific implementation** and a route-specific `params`:
 
 ```
-implementation = CounterfactualDepositSpokePool | CounterfactualDepositCCTP | CounterfactualDepositOFT
+implementation = CounterfactualDepositSpokePool | CounterfactualDepositCCTP | CounterfactualDepositVanillaCCTP | CounterfactualDepositOFT
 params         = sourceChainId + bridge target + input token + fee caps + quote params + destination identity
 ```
 
@@ -334,14 +334,14 @@ delivery mechanism.
 
 ## Execution Fees (dynamic, signed)
 
-All three bridge implementations (`CounterfactualDepositSpokePool` / `CounterfactualDepositCCTP` /
-`CounterfactualDepositOFT`) **must** support a **dynamic execution fee** chosen at execution time by
+All four bridge implementations (`CounterfactualDepositSpokePool` / `CounterfactualDepositCCTP` /
+`CounterfactualDepositVanillaCCTP` / `CounterfactualDepositOFT`) **must** support a **dynamic execution fee** chosen at execution time by
 the submitter: the fee is paid in the input token to an `executionFeeRecipient`, and only
 `amount − executionFee` is bridged. Because the fee is not committed in the route leaf, it must be
 **authorized by an off-chain `signer` and verified on-chain**. We reproduce the scheme used on the
 `taylor/counterfactual-route-policy` branch verbatim so off-chain quoting/tooling stays compatible.
 
-Mechanism (identical across the three impls):
+Mechanism (identical across the four impls):
 
 - Each impl is an **`EIP712`** contract (`name = "CounterfactualDeposit<Bridge>"`,
   `version = "v2.0.0"`) with an immutable **`signer`** set at construction. Under delegatecall the
@@ -353,7 +353,7 @@ Mechanism (identical across the three impls):
   `ECDSA.recover(_hashTypedDataV4(structHash), counterfactualSignature) == signer` (else
   `InvalidSignature`).
 - The route leaf commits an **upper bound** on the fee, checked _after_ verification:
-  `maxExecutionFee` for CCTP/OFT, or the combined `maxFeeFixed + maxFeeBps × inputAmount` cap for
+  `maxExecutionFee` for CCTP/Vanilla CCTP/OFT, or the combined `maxFeeFixed + maxFeeBps × inputAmount` cap for
   SpokePool (which bounds the implicit relayer fee + execution fee together via `_checkFee`). For
   SpokePool, a leaf-committed `checkStableExchangeRate` bool gates the rate-derived relayer-fee term: when
   `false` (e.g. non-stable pairs, where `stableExchangeRate` can't bound the relayer fee and `outputAmount`
@@ -364,16 +364,19 @@ Mechanism (identical across the three impls):
 
 Per-bridge typehash and binding:
 
-| Impl          | EIP-712 typehash                                                                                                                                                                                                                             | Route / amount binding                                                                                                                                                                                             |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **SpokePool** | `ExecuteDeposit(address clone,bytes32 routeParamsHash,uint256 inputAmount,uint256 outputAmount,bytes32 exclusiveRelayer,uint32 exclusivityDeadline,uint32 quoteTimestamp,uint32 fillDeadline,uint32 signatureDeadline,uint256 executionFee)` | Binds **everything explicitly** — `clone`, `routeParamsHash`, and all runtime fields — because there is no separate periphery quote signature.                                                                     |
-| **CCTP**      | `ExecuteCCTP(bytes32 nonce,uint256 executionFee,uint32 signatureDeadline)`                                                                                                                                                                   | Clone bound via the domain; amount/route bound **transitively** through the periphery quote signature (which commits `(route, nonce)`); `nonce` gives single-use replay protection once the periphery consumes it. |
-| **OFT**       | `ExecuteOFT(bytes32 nonce,uint256 executionFee,uint32 signatureDeadline)`                                                                                                                                                                    | Same as CCTP.                                                                                                                                                                                                      |
+| Impl             | EIP-712 typehash                                                                                                                                                                                                                             | Route / amount binding                                                                                                                                                                                             |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **SpokePool**    | `ExecuteDeposit(address clone,bytes32 routeParamsHash,uint256 inputAmount,uint256 outputAmount,bytes32 exclusiveRelayer,uint32 exclusivityDeadline,uint32 quoteTimestamp,uint32 fillDeadline,uint32 signatureDeadline,uint256 executionFee)` | Binds **everything explicitly** — `clone`, `routeParamsHash`, and all runtime fields — because there is no separate periphery quote signature.                                                                     |
+| **CCTP**         | `ExecuteCCTP(bytes32 nonce,uint256 executionFee,uint32 signatureDeadline)`                                                                                                                                                                   | Clone bound via the domain; amount/route bound **transitively** through the periphery quote signature (which commits `(route, nonce)`); `nonce` gives single-use replay protection once the periphery consumes it. |
+| **Vanilla CCTP** | `ExecuteVanillaCCTP(bytes32 routeParamsHash,uint256 amount,uint256 executionFee,uint32 signatureDeadline)`                                                                                                                                   | No periphery, so binds **everything explicitly** — `routeParamsHash` (the leaf), `amount`, and the fee; clone bound via the EIP-712 domain. Replay protection is the short `signatureDeadline` (no nonce).         |
+| **OFT**          | `ExecuteOFT(bytes32 nonce,uint256 executionFee,uint32 signatureDeadline)`                                                                                                                                                                    | Same as CCTP.                                                                                                                                                                                                      |
 
 > CCTP and OFT additionally forward a **separate periphery quote signature** (`peripherySignature`) to
 > the sponsored-bridge periphery unchanged — **two signatures per execute**. SpokePool calls
 > `SpokePool.deposit` directly (no periphery), so it has only the one EIP-712 fee signature and
-> therefore must bind the clone, route hash, and all runtime fields in its own typehash.
+> therefore must bind the clone, route hash, and all runtime fields in its own typehash. **Vanilla CCTP**
+> likewise calls `ITokenMessengerV2` directly (no periphery), so it too is single-signature and binds the
+> route hash + amount in its own typehash (see _Vanilla CCTP route_).
 >
 > **Trust split (CCTP/OFT).** The counterfactual `counterfactualSignature` authorizes **only** the
 > `(nonce, executionFee, signatureDeadline)` — i.e. the **fee**. The **route, amount, recipient, and
@@ -388,6 +391,49 @@ Per-bridge typehash and binding:
 > parity (it is in no address — see _Address Determinism_), but the **same `signer` must be used on every
 > chain** for fee signatures to verify consistently; deploying the impl deterministically (Phase 0/5) is
 > the simplest way to guarantee that.
+
+---
+
+## Vanilla CCTP route (`CounterfactualDepositVanillaCCTP`)
+
+`CounterfactualDepositCCTP` bridges through the **sponsored** path (`SponsoredCCTPSrcPeriphery` →
+`SponsoredCCTPDstPeriphery`), whose destination periphery runs Across's HyperCore / relayer-sponsorship
+machinery. `CounterfactualDepositVanillaCCTP` is the **non-sponsored** alternative: it calls Circle's
+`ITokenMessengerV2` **directly**, so USDC mints natively on the destination with no Across destination
+contract involved. It is an ordinary per-bridge leaf implementation (named by the leaf's `implementation`
+field, delegatecalled by the dispatcher) — adding it needs no dispatcher / factory / beacon change.
+
+**Two destination shapes, one branch on `hookData`:**
+
+- **Plain CCTP v2 (fast or standard)** — `hookData` empty ⇒ `depositForBurn`. USDC mints to `mintRecipient`
+  on `destinationDomain`. Fast vs standard is `minFinalityThreshold` (+ a `maxFee` derived from
+  `cctpMaxFeeBps`); a standard transfer sets `cctpMaxFeeBps = 0`.
+- **HyperCore** ([Circle docs](https://developers.circle.com/cctp/concepts/cctp-on-hypercore)) — `hookData`
+  non-empty ⇒ `depositForBurnWithHook`. A HyperCore transfer is just a CCTP burn to **HyperEVM (domain 19)** where `mintRecipient` is Circle's **`CctpForwarder`** proxy and `hookData` is its envelope; the
+  forwarder mints on HyperEVM, then routes through `CoreDepositWallet` to the HyperCore account. The
+  contract treats `mintRecipient` and `hookData` as **opaque** — the forwarder address and hook bytes are
+  built off-chain into the route leaf, so the contract carries no HyperCore-specific logic.
+
+  Circle's `CctpForwarderHookData` envelope (built off-chain; documented here for the leaf builder):
+
+  ```
+  bytes 0–23   bytes24  magic "cctp-forward"
+  bytes 24–27  uint32   hook version (0)
+  bytes 28–31  uint32   hook data length (24 = 20-byte recipient + 4-byte destinationId)
+  bytes 32–51  address  forwardRecipient (the HyperCore recipient)
+  bytes 52–55  uint32   destinationId (CoreDepositWallet routing id)
+  ```
+
+  (Arbitrum → HyperCore has no fast-transfer fee.)
+
+**Authorization.** There is no periphery quote signature, so — unlike the sponsored CCTP/OFT impls — the
+route and amount are **not** bound transitively. Instead the impl's own EIP-712 signature binds them
+directly (mirroring SpokePool):
+`ExecuteVanillaCCTP(bytes32 routeParamsHash,uint256 amount,uint256 executionFee,uint32 signatureDeadline)`,
+where `routeParamsHash = keccak256(params)` is the exact merkle-leaf params and `verifyingContract`
+resolves to the proxy. `signer` authorizes it, `executionFee ≤ maxExecutionFee` (the leaf cap) is checked
+afterward, and **replay protection is the short `signatureDeadline`** — there is no nonce, so a re-funded
+proxy could be re-executed within the signature window; keep deadlines short. ERC-20 (USDC) only.
 
 ---
 

--- a/test/evm/foundry/local/CounterfactualDepositVanillaCCTP.t.sol
+++ b/test/evm/foundry/local/CounterfactualDepositVanillaCCTP.t.sol
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import { CounterfactualTestBase } from "./CounterfactualTestBase.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {
+    CounterfactualDepositVanillaCCTP,
+    VanillaCCTPRouteParams,
+    VanillaCCTPSubmitterData
+} from "../../../../contracts/periphery/counterfactual/CounterfactualDepositVanillaCCTP.sol";
+import { ICounterfactualDeposit } from "../../../../contracts/interfaces/ICounterfactualDeposit.sol";
+import { MintableERC20 } from "../../../../contracts/test/MockERC20.sol";
+
+/// @notice Mock Circle CCTP v2 TokenMessenger: pulls the burn token (as the real one does) and records the
+///         last call, including whether the hook variant was used and the forwarded hookData.
+contract MockTokenMessengerV2 {
+    using SafeERC20 for IERC20;
+
+    bool public lastWithHook;
+    uint256 public lastAmount;
+    uint32 public lastDestinationDomain;
+    bytes32 public lastMintRecipient;
+    address public lastBurnToken;
+    bytes32 public lastDestinationCaller;
+    uint256 public lastMaxFee;
+    uint32 public lastMinFinalityThreshold;
+    bytes public lastHookData;
+    uint256 public callCount;
+
+    function depositForBurn(
+        uint256 amount,
+        uint32 destinationDomain,
+        bytes32 mintRecipient,
+        address burnToken,
+        bytes32 destinationCaller,
+        uint256 maxFee,
+        uint32 minFinalityThreshold
+    ) external {
+        IERC20(burnToken).safeTransferFrom(msg.sender, address(this), amount);
+        lastWithHook = false;
+        lastAmount = amount;
+        lastDestinationDomain = destinationDomain;
+        lastMintRecipient = mintRecipient;
+        lastBurnToken = burnToken;
+        lastDestinationCaller = destinationCaller;
+        lastMaxFee = maxFee;
+        lastMinFinalityThreshold = minFinalityThreshold;
+        lastHookData = "";
+        callCount++;
+    }
+
+    function depositForBurnWithHook(
+        uint256 amount,
+        uint32 destinationDomain,
+        bytes32 mintRecipient,
+        address burnToken,
+        bytes32 destinationCaller,
+        uint256 maxFee,
+        uint32 minFinalityThreshold,
+        bytes calldata hookData
+    ) external {
+        IERC20(burnToken).safeTransferFrom(msg.sender, address(this), amount);
+        lastWithHook = true;
+        lastAmount = amount;
+        lastDestinationDomain = destinationDomain;
+        lastMintRecipient = mintRecipient;
+        lastBurnToken = burnToken;
+        lastDestinationCaller = destinationCaller;
+        lastMaxFee = maxFee;
+        lastMinFinalityThreshold = minFinalityThreshold;
+        lastHookData = hookData;
+        callCount++;
+    }
+}
+
+contract CounterfactualDepositVanillaCCTPTest is CounterfactualTestBase {
+    CounterfactualDepositVanillaCCTP internal vanillaImpl;
+    MockTokenMessengerV2 internal messenger;
+    MintableERC20 internal token;
+
+    uint32 constant SOURCE_DOMAIN = 0;
+    uint32 constant HYPEREVM_DOMAIN = 19;
+    bytes32 constant EXECUTE_VANILLA_CCTP_TYPEHASH =
+        keccak256(
+            "ExecuteVanillaCCTP(bytes32 routeParamsHash,uint256 amount,uint256 executionFee,uint32 signatureDeadline)"
+        );
+
+    function setUp() public {
+        _setUpCore();
+        messenger = new MockTokenMessengerV2();
+        vanillaImpl = new CounterfactualDepositVanillaCCTP(address(messenger), SOURCE_DOMAIN, signer);
+        token = new MintableERC20("USDC", "USDC", 6);
+        token.mint(user, 1000e6);
+    }
+
+    /// @dev Plain CCTP route (empty hookData): USDC mints natively to `mintRecipient` on the destination.
+    function _routeParams() internal returns (VanillaCCTPRouteParams memory) {
+        return
+            VanillaCCTPRouteParams({
+                sourceChainId: block.chainid,
+                destinationDomain: 3,
+                mintRecipient: bytes32(uint256(uint160(makeAddr("mintRecipient")))),
+                burnToken: bytes32(uint256(uint160(address(token)))),
+                destinationCaller: bytes32(uint256(uint160(makeAddr("caller")))),
+                cctpMaxFeeBps: 100,
+                minFinalityThreshold: 1000,
+                hookData: "",
+                maxExecutionFee: 5e6
+            });
+    }
+
+    /// @dev HyperCore route: burn to HyperEVM (domain 19) with `mintRecipient` = Circle's CctpForwarder and a
+    ///      representative `CctpForwarderHookData` envelope (magic | version | len | recipient | destinationId).
+    function _hyperCoreRouteParams() internal returns (VanillaCCTPRouteParams memory rp) {
+        rp = _routeParams();
+        rp.destinationDomain = HYPEREVM_DOMAIN;
+        rp.mintRecipient = bytes32(uint256(uint160(makeAddr("cctpForwarder"))));
+        rp.cctpMaxFeeBps = 0; // Arbitrum→HyperCore has no fast-transfer fee.
+        rp.hookData = abi.encodePacked(
+            bytes24("cctp-forward"), // magic bytes
+            uint32(0), // hook version
+            uint32(24), // hook data length (20-byte recipient + 4-byte destinationId)
+            makeAddr("hyperCoreRecipient"), // forwardRecipient
+            uint32(2) // destinationId
+        );
+    }
+
+    function _deploy(bytes memory route, bytes32 salt) internal returns (address proxy, bytes32[] memory proof) {
+        bytes32[] memory leaves = new bytes32[](2);
+        leaves[0] = _leaf(address(vanillaImpl), route);
+        leaves[1] = keccak256("padding");
+        bytes32 root = merkle.getRoot(leaves);
+        proof = merkle.getProof(leaves, 0);
+        proxy = factory.deploy(salt, root);
+    }
+
+    function _submitter(
+        address proxy,
+        bytes memory route,
+        uint256 amount,
+        uint256 executionFee,
+        uint32 signatureDeadline,
+        uint256 pk
+    ) internal view returns (bytes memory) {
+        bytes32 structHash = keccak256(
+            abi.encode(EXECUTE_VANILLA_CCTP_TYPEHASH, keccak256(route), amount, executionFee, signatureDeadline)
+        );
+        bytes memory sig = _sign(pk, _domainSeparator("CounterfactualDepositVanillaCCTP", proxy), structHash);
+        return
+            abi.encode(
+                VanillaCCTPSubmitterData({
+                    amount: amount,
+                    executionFeeRecipient: relayer,
+                    executionFee: executionFee,
+                    signatureDeadline: signatureDeadline,
+                    counterfactualSignature: sig
+                })
+            );
+    }
+
+    function testDepositPlainCCTP() public {
+        VanillaCCTPRouteParams memory rp = _routeParams();
+        bytes memory route = abi.encode(rp);
+        (address proxy, bytes32[] memory proof) = _deploy(route, bytes32(0));
+        uint256 amount = 100e6;
+        uint256 fee = 1e6;
+        bytes memory submitter = _submitter(proxy, route, amount, fee, uint32(block.timestamp) + 3600, signerPk);
+
+        vm.prank(user);
+        token.transfer(proxy, amount);
+
+        vm.prank(relayer);
+        ICounterfactualDeposit(proxy).execute(address(vanillaImpl), route, submitter, proof);
+
+        assertEq(messenger.lastWithHook(), false);
+        assertEq(messenger.lastAmount(), amount - fee);
+        assertEq(messenger.lastDestinationDomain(), rp.destinationDomain);
+        assertEq(messenger.lastMintRecipient(), rp.mintRecipient);
+        assertEq(messenger.lastBurnToken(), address(token));
+        assertEq(messenger.lastDestinationCaller(), rp.destinationCaller);
+        assertEq(messenger.lastMaxFee(), ((amount - fee) * 100) / 10000);
+        assertEq(messenger.lastMinFinalityThreshold(), 1000);
+        assertEq(token.balanceOf(relayer), fee);
+        assertEq(token.balanceOf(proxy), 0);
+        assertEq(messenger.callCount(), 1);
+    }
+
+    function testDepositHyperCore() public {
+        VanillaCCTPRouteParams memory rp = _hyperCoreRouteParams();
+        bytes memory route = abi.encode(rp);
+        (address proxy, bytes32[] memory proof) = _deploy(route, bytes32(0));
+        uint256 amount = 100e6;
+        uint256 fee = 1e6;
+        bytes memory submitter = _submitter(proxy, route, amount, fee, uint32(block.timestamp) + 3600, signerPk);
+
+        vm.prank(user);
+        token.transfer(proxy, amount);
+
+        vm.prank(relayer);
+        ICounterfactualDeposit(proxy).execute(address(vanillaImpl), route, submitter, proof);
+
+        assertEq(messenger.lastWithHook(), true);
+        assertEq(messenger.lastAmount(), amount - fee);
+        assertEq(messenger.lastDestinationDomain(), HYPEREVM_DOMAIN);
+        assertEq(messenger.lastMintRecipient(), rp.mintRecipient);
+        assertEq(messenger.lastMaxFee(), 0);
+        assertEq(messenger.lastHookData(), rp.hookData);
+        assertEq(token.balanceOf(proxy), 0);
+    }
+
+    function testZeroExecutionFee() public {
+        bytes memory route = abi.encode(_routeParams());
+        (address proxy, bytes32[] memory proof) = _deploy(route, bytes32(0));
+        bytes memory submitter = _submitter(proxy, route, 100e6, 0, uint32(block.timestamp) + 3600, signerPk);
+
+        vm.prank(user);
+        token.transfer(proxy, 100e6);
+        vm.prank(relayer);
+        ICounterfactualDeposit(proxy).execute(address(vanillaImpl), route, submitter, proof);
+
+        assertEq(messenger.lastAmount(), 100e6);
+        assertEq(token.balanceOf(relayer), 0);
+    }
+
+    function testStandardTransferZeroFee() public {
+        VanillaCCTPRouteParams memory rp = _routeParams();
+        rp.cctpMaxFeeBps = 0;
+        rp.minFinalityThreshold = 2000;
+        bytes memory route = abi.encode(rp);
+        (address proxy, bytes32[] memory proof) = _deploy(route, bytes32(0));
+        bytes memory submitter = _submitter(proxy, route, 100e6, 1e6, uint32(block.timestamp) + 3600, signerPk);
+
+        vm.prank(user);
+        token.transfer(proxy, 100e6);
+        vm.prank(relayer);
+        ICounterfactualDeposit(proxy).execute(address(vanillaImpl), route, submitter, proof);
+
+        assertEq(messenger.lastMaxFee(), 0);
+        assertEq(messenger.lastMinFinalityThreshold(), 2000);
+    }
+
+    function testMaxExecutionFeeReverts() public {
+        bytes memory route = abi.encode(_routeParams());
+        (address proxy, bytes32[] memory proof) = _deploy(route, bytes32(0));
+        // 6e6 > maxExecutionFee 5e6
+        bytes memory submitter = _submitter(proxy, route, 100e6, 6e6, uint32(block.timestamp) + 3600, signerPk);
+
+        vm.prank(user);
+        token.transfer(proxy, 100e6);
+        vm.prank(relayer);
+        vm.expectRevert(CounterfactualDepositVanillaCCTP.MaxExecutionFee.selector);
+        ICounterfactualDeposit(proxy).execute(address(vanillaImpl), route, submitter, proof);
+    }
+
+    function testInvalidSignatureReverts() public {
+        bytes memory route = abi.encode(_routeParams());
+        (address proxy, bytes32[] memory proof) = _deploy(route, bytes32(0));
+        bytes memory submitter = _submitter(proxy, route, 100e6, 1e6, uint32(block.timestamp) + 3600, 0xBEEF);
+
+        vm.prank(user);
+        token.transfer(proxy, 100e6);
+        vm.prank(relayer);
+        vm.expectRevert(CounterfactualDepositVanillaCCTP.InvalidSignature.selector);
+        ICounterfactualDeposit(proxy).execute(address(vanillaImpl), route, submitter, proof);
+    }
+
+    function testExpiredSignatureReverts() public {
+        bytes memory route = abi.encode(_routeParams());
+        (address proxy, bytes32[] memory proof) = _deploy(route, bytes32(0));
+        bytes memory submitter = _submitter(proxy, route, 100e6, 1e6, uint32(block.timestamp) + 100, signerPk);
+
+        vm.prank(user);
+        token.transfer(proxy, 100e6);
+        vm.warp(block.timestamp + 101);
+        vm.prank(relayer);
+        vm.expectRevert(CounterfactualDepositVanillaCCTP.SignatureExpired.selector);
+        ICounterfactualDeposit(proxy).execute(address(vanillaImpl), route, submitter, proof);
+    }
+
+    function testSourceChainMismatchReverts() public {
+        VanillaCCTPRouteParams memory rp = _routeParams();
+        rp.sourceChainId = block.chainid + 1;
+        bytes memory route = abi.encode(rp);
+        (address proxy, bytes32[] memory proof) = _deploy(route, bytes32(0));
+        bytes memory submitter = _submitter(proxy, route, 100e6, 1e6, uint32(block.timestamp) + 3600, signerPk);
+
+        vm.prank(user);
+        token.transfer(proxy, 100e6);
+        vm.prank(relayer);
+        vm.expectRevert(CounterfactualDepositVanillaCCTP.SourceChainMismatch.selector);
+        ICounterfactualDeposit(proxy).execute(address(vanillaImpl), route, submitter, proof);
+    }
+
+    /// @dev A signature is bound to one proxy via the EIP-712 `verifyingContract`, so it cannot be replayed
+    ///      against a different counterfactual sharing the same route.
+    function testCrossProxyReplayReverts() public {
+        bytes memory route = abi.encode(_routeParams());
+        (address proxyA, bytes32[] memory proofA) = _deploy(route, keccak256("a"));
+        (address proxyB, bytes32[] memory proofB) = _deploy(route, keccak256("b"));
+        bytes memory submitter = _submitter(proxyA, route, 100e6, 1e6, uint32(block.timestamp) + 3600, signerPk);
+
+        vm.prank(user);
+        token.transfer(proxyA, 100e6);
+        vm.prank(user);
+        token.transfer(proxyB, 100e6);
+
+        vm.prank(relayer);
+        ICounterfactualDeposit(proxyA).execute(address(vanillaImpl), route, submitter, proofA);
+
+        vm.prank(relayer);
+        vm.expectRevert(CounterfactualDepositVanillaCCTP.InvalidSignature.selector);
+        ICounterfactualDeposit(proxyB).execute(address(vanillaImpl), route, submitter, proofB);
+    }
+
+    /// @dev The signature binds `amount`; submitting a different amount than was signed must revert.
+    function testWrongAmountSignatureReverts() public {
+        bytes memory route = abi.encode(_routeParams());
+        (address proxy, bytes32[] memory proof) = _deploy(route, bytes32(0));
+        uint32 deadline = uint32(block.timestamp) + 3600;
+        // Sign over 100e6 but submit 200e6.
+        bytes32 structHash = keccak256(
+            abi.encode(EXECUTE_VANILLA_CCTP_TYPEHASH, keccak256(route), 100e6, 1e6, deadline)
+        );
+        bytes memory sig = _sign(signerPk, _domainSeparator("CounterfactualDepositVanillaCCTP", proxy), structHash);
+        bytes memory submitter = abi.encode(
+            VanillaCCTPSubmitterData({
+                amount: 200e6,
+                executionFeeRecipient: relayer,
+                executionFee: 1e6,
+                signatureDeadline: deadline,
+                counterfactualSignature: sig
+            })
+        );
+
+        vm.prank(user);
+        token.transfer(proxy, 200e6);
+        vm.prank(relayer);
+        vm.expectRevert(CounterfactualDepositVanillaCCTP.InvalidSignature.selector);
+        ICounterfactualDeposit(proxy).execute(address(vanillaImpl), route, submitter, proof);
+    }
+
+    /// @dev The signature binds `routeParamsHash`; a signature for a different route must revert even if the
+    ///      submitted route is itself a valid leaf.
+    function testWrongRouteSignatureReverts() public {
+        bytes memory route = abi.encode(_routeParams());
+        (address proxy, bytes32[] memory proof) = _deploy(route, bytes32(0));
+        uint32 deadline = uint32(block.timestamp) + 3600;
+        // Sign over a different route's hash.
+        VanillaCCTPRouteParams memory other = _routeParams();
+        other.destinationDomain = 6;
+        bytes32 structHash = keccak256(
+            abi.encode(EXECUTE_VANILLA_CCTP_TYPEHASH, keccak256(abi.encode(other)), 100e6, 1e6, deadline)
+        );
+        bytes memory sig = _sign(signerPk, _domainSeparator("CounterfactualDepositVanillaCCTP", proxy), structHash);
+        bytes memory submitter = abi.encode(
+            VanillaCCTPSubmitterData({
+                amount: 100e6,
+                executionFeeRecipient: relayer,
+                executionFee: 1e6,
+                signatureDeadline: deadline,
+                counterfactualSignature: sig
+            })
+        );
+
+        vm.prank(user);
+        token.transfer(proxy, 100e6);
+        vm.prank(relayer);
+        vm.expectRevert(CounterfactualDepositVanillaCCTP.InvalidSignature.selector);
+        ICounterfactualDeposit(proxy).execute(address(vanillaImpl), route, submitter, proof);
+    }
+}

--- a/test/evm/foundry/local/CounterfactualDepositVanillaCCTP.t.sol
+++ b/test/evm/foundry/local/CounterfactualDepositVanillaCCTP.t.sol
@@ -79,7 +79,6 @@ contract CounterfactualDepositVanillaCCTPTest is CounterfactualTestBase {
     MockTokenMessengerV2 internal messenger;
     MintableERC20 internal token;
 
-    uint32 constant SOURCE_DOMAIN = 0;
     uint32 constant HYPEREVM_DOMAIN = 19;
     bytes32 constant EXECUTE_VANILLA_CCTP_TYPEHASH =
         keccak256(
@@ -89,7 +88,7 @@ contract CounterfactualDepositVanillaCCTPTest is CounterfactualTestBase {
     function setUp() public {
         _setUpCore();
         messenger = new MockTokenMessengerV2();
-        vanillaImpl = new CounterfactualDepositVanillaCCTP(address(messenger), SOURCE_DOMAIN, signer);
+        vanillaImpl = new CounterfactualDepositVanillaCCTP(address(messenger), signer);
         token = new MintableERC20("USDC", "USDC", 6);
         token.mint(user, 1000e6);
     }


### PR DESCRIPTION
> **Stacked on #1452** (`taylor/counterfactual-upgradeable`). Base branch is set to that PR so this can be reviewed separately — the diff here is scoped to just the new vanilla-CCTP files. Merge/rebase onto `master` after #1452 lands.

## What

Adds **`CounterfactualDepositVanillaCCTP`**, a new per-bridge leaf implementation for the upgradeable counterfactual system that bridges via Circle **CCTP v2 directly** (`ITokenMessengerV2`) — no Across periphery — so USDC mints natively on the destination. Purely additive: per-bridge impls are selected by the route leaf's `implementation` field and delegatecalled by the dispatcher, so no dispatcher / factory / beacon changes are needed.

One branch on `hookData`:

- **empty** → `depositForBurn` — plain CCTPv2 (fast or standard, via `minFinalityThreshold` + `cctpMaxFeeBps`); USDC mints to `mintRecipient`.
- **non-empty** → `depositForBurnWithHook` — **HyperCore** ([Circle docs](https://developers.circle.com/cctp/concepts/cctp-on-hypercore)): burn to **HyperEVM (domain 19)** with `mintRecipient` = Circle's `CctpForwarder` and the hook envelope, routed on to HyperCore via `CoreDepositWallet`.

`mintRecipient` / `destinationCaller` / `hookData` are **opaque** route-leaf params, so the contract carries no HyperCore-specific logic — the forwarder address and hook bytes are built off-chain into the leaf.

## Authorization

There's no periphery quote signature, so (unlike the sponsored CCTP/OFT impls) route + amount aren't bound transitively. Instead the impl's own EIP-712 signature binds them directly, mirroring the SpokePool impl:

```
ExecuteVanillaCCTP(bytes32 routeParamsHash,uint256 amount,uint256 executionFee,uint32 signatureDeadline)
```

`routeParamsHash = keccak256(params)` (the exact merkle leaf), `verifyingContract` = the proxy, `signer` authorizes it, and `executionFee ≤ maxExecutionFee` (leaf cap) is checked. **Replay protection is the short `signatureDeadline`** — no nonce. ERC-20 (USDC) only.

## Tests

`test/evm/foundry/local/CounterfactualDepositVanillaCCTP.t.sol` — 11 cases: plain CCTP, HyperCore hook (with a realistic `CctpForwarderHookData` envelope), standard transfer, and the fee / sig / expiry / source-chain / cross-proxy / amount-binding / route-binding reverts.

- `yarn test-evm-foundry --match-contract CounterfactualDepositVanillaCCTP` → **11/11 pass**
- Full counterfactual suite → **67/67 pass**, no regressions

## Docs

`DESIGN.md` gets a *Vanilla CCTP route* section (incl. HyperCore wiring + hook-envelope layout for the off-chain leaf builder) and a typehash-table row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)