### PR TITLE
feat: make SwapHandler reusable, harden HyperCoreLib casts

### DIFF
--- a/contracts/libraries/HyperCoreLib.sol
+++ b/contracts/libraries/HyperCoreLib.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { IERC20 } from "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts-v4/token/ERC20/utils/SafeERC20.sol";
-import { SafeCast } from "@openzeppelin/contracts-v4/utils/math/SafeCast.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { ICoreDepositWallet } from "../external/interfaces/ICoreDepositWallet.sol";
 
 interface ICoreWriter {
@@ -388,7 +388,7 @@ library HyperCoreLib {
      * @return erc20CoreIndex The core token index id
      */
     function toTokenId(address assetBridgeAddress) internal pure returns (uint64) {
-        return uint64(uint160(assetBridgeAddress) - BASE_ASSET_BRIDGE_ADDRESS_UINT256);
+        return SafeCast.toUint64(uint160(assetBridgeAddress) - BASE_ASSET_BRIDGE_ADDRESS_UINT256);
     }
 
     /**
@@ -416,7 +416,7 @@ library HyperCoreLib {
             // Scale down, rounding UP to avoid shortfall on Core
             uint256 scaleDivisor = 10 ** uint8(-decimalDiff);
             amountEVMToSend = (uint256(minimumCoreReceiveAmount) + scaleDivisor - 1) / scaleDivisor; // ceil division
-            amountCoreToReceive = uint64(amountEVMToSend * scaleDivisor);
+            amountCoreToReceive = SafeCast.toUint64(amountEVMToSend * scaleDivisor);
         }
     }
 
@@ -461,7 +461,7 @@ library HyperCoreLib {
         if (decimalsFrom == decimalsTo) {
             return amountDecimalsFrom;
         } else if (decimalsFrom < decimalsTo) {
-            return uint64(amountDecimalsFrom * 10 ** (decimalsTo - decimalsFrom));
+            return SafeCast.toUint64(amountDecimalsFrom * 10 ** (decimalsTo - decimalsFrom));
         } else {
             // round down
             return uint64(amountDecimalsFrom / 10 ** (decimalsFrom - decimalsTo));

--- a/contracts/periphery/mintburn/HyperCoreFlowExecutor.sol
+++ b/contracts/periphery/mintburn/HyperCoreFlowExecutor.sol
@@ -992,7 +992,13 @@ contract HyperCoreFlowExecutor is AccessControlUpgradeable, AuthorizedFundedFlow
         uint128 cloid
     ) external onlyRole(PERMISSIONED_BOT_ROLE) {
         FinalTokenInfo memory finalTokenInfo = _getExistingFinalTokenInfo(finalToken);
-        finalTokenInfo.swapHandler.submitSpotLimitOrder(finalTokenInfo, priceX1e8, sizeX1e8, cloid);
+        finalTokenInfo.swapHandler.submitSpotLimitOrder(
+            finalTokenInfo.spotIndex,
+            finalTokenInfo.isBuy,
+            priceX1e8,
+            sizeX1e8,
+            cloid
+        );
 
         emit SubmittedLimitOrder(finalToken, priceX1e8, sizeX1e8, cloid);
     }

--- a/contracts/periphery/mintburn/SwapHandler.sol
+++ b/contracts/periphery/mintburn/SwapHandler.sol
@@ -1,9 +1,9 @@
-//SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
-import { IERC20 } from "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts-v4/token/ERC20/utils/SafeERC20.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { HyperCoreLib } from "../../libraries/HyperCoreLib.sol";
-import { FinalTokenInfo } from "./Structs.sol";
 
 contract SwapHandler {
     // See https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#asset
@@ -46,14 +46,15 @@ contract SwapHandler {
     }
 
     function submitSpotLimitOrder(
-        FinalTokenInfo memory finalTokenInfo,
+        uint32 spotIndex,
+        bool isBuy,
         uint64 limitPriceX1e8,
         uint64 sizeX1e8,
         uint128 cloid
     ) external onlyParentHandler {
         HyperCoreLib.submitLimitOrder(
-            finalTokenInfo.spotIndex + SPOT_MARKET_INDEX_OFFSET,
-            finalTokenInfo.isBuy,
+            spotIndex + SPOT_MARKET_INDEX_OFFSET,
+            isBuy,
             limitPriceX1e8,
             sizeX1e8,
             false,

--- a/test/evm/foundry/local/HyperCoreLib.t.sol
+++ b/test/evm/foundry/local/HyperCoreLib.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import { Test } from "forge-std/Test.sol";
 
 import { HyperCoreLib } from "../../../../contracts/libraries/HyperCoreLib.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 // Wrapper contract to expose internal library functions for testing
 contract HyperCoreLibWrapper {
@@ -28,7 +29,7 @@ contract HyperCoreLibTest is Test {
     function testMaximumEVMSendAmountToAmounts_RevertsWhenCoreAmountExceedsUint64Max_ZeroDecimalDiff() public {
         uint256 tooLargeAmount = uint256(type(uint64).max) + 1;
 
-        vm.expectRevert("SafeCast: value doesn't fit in 64 bits");
+        vm.expectRevert(abi.encodeWithSelector(SafeCast.SafeCastOverflowedUintDowncast.selector, 64, tooLargeAmount));
         wrapper.maximumEVMSendAmountToAmounts(tooLargeAmount, 0);
     }
 
@@ -55,7 +56,7 @@ contract HyperCoreLibTest is Test {
         uint256 evmAmount = uint256(type(uint64).max / 1e6) + 1; // Just over the limit
         int8 decimalDiff = -6;
 
-        vm.expectRevert("SafeCast: value doesn't fit in 64 bits");
+        vm.expectRevert(abi.encodeWithSelector(SafeCast.SafeCastOverflowedUintDowncast.selector, 64, evmAmount * 1e6));
         wrapper.maximumEVMSendAmountToAmounts(evmAmount, decimalDiff);
     }
 


### PR DESCRIPTION
refactor: decouple SwapHandler from structs, move HyperCore libs to OZ v5

- SwapHandler.submitSpotLimitOrder takes spotIndex/isBuy scalars instead
  of FinalTokenInfo, so it no longer imports Structs.sol and is reusable
  downstream; update HyperCoreFlowExecutor caller accordingly
- migrate HyperCoreLib + SwapHandler to @openzeppelin/contracts v5
- harden 3 unchecked uint64 casts in HyperCoreLib with SafeCast.toUint64
  (reverts on overflow instead of truncating); update tests to the v5
  SafeCastOverflowedUintDowncast error
- SwapHandler license Unlicense -> BUSL-1.1