### PR TITLE
N-01: Dead Code

### DIFF
--- a/contracts/libraries/HyperCoreLib.sol
+++ b/contracts/libraries/HyperCoreLib.sol
@@ -383,15 +383,6 @@ library HyperCoreLib {
     }
 
     /**
-     * @notice Converts an asset bridge address to a core index id
-     * @param assetBridgeAddress The asset bridge address to convert
-     * @return erc20CoreIndex The core token index id
-     */
-    function toTokenId(address assetBridgeAddress) internal pure returns (uint64) {
-        return SafeCast.toUint64(uint160(assetBridgeAddress) - BASE_ASSET_BRIDGE_ADDRESS_UINT256);
-    }
-
-    /**
      * @notice Returns an amount to send on HyperEVM to receive AT LEAST the minimumCoreReceiveAmount on HyperCore
      * @param minimumCoreReceiveAmount The minimum amount desired to receive on HyperCore
      * @param decimalDiff The decimal difference of evmDecimals - coreDecimals


### PR DESCRIPTION
# Dead Code

The internal pure function [`toTokenId`](https://github.com/across-protocol/contracts/blob/1fb0f54bb89a196eae3c0a3dd790b07791301ab1/contracts/libraries/HyperCoreLib.sol#L390-L392) is defined in `HyperCoreLib`, but is never called elsewhere.

Consider deleting `toTokenId` and any other dead code to simplify the codebase and avoid maintaining unused functionality.

<!-- fabdd502-e115-4e13-8971-446d64652182 -->

# Solution

Remove `toTokenId` function