### PR TITLE
feat: HyperCore spot-balance withdraw leaf for counterfactual deposits

### DIFF
--- a/contracts/periphery/counterfactual/DESIGN.md
+++ b/contracts/periphery/counterfactual/DESIGN.md
@@ -309,6 +309,14 @@ leaf commits the permitted withdrawer) — **not permissionless** — so it can'
 in-flight deposits by sweeping funds to the source-chain refund path before they're bridged (see Open
 Questions #8).
 
+`WithdrawImplementation` only reaches EVM-side ERC-20/native balances. On HyperEVM,
+`HyperCoreWithdrawImplementation` is the Core-side counterpart: same `withdrawParams` and
+`submitterData` shapes (so both `AdminWithdrawManager` paths work unchanged), but it CoreWriter
+`spotSend`s the proxy's **HyperCore spot balance** to the committed user (`token` = the Core token's
+asset-bridge address, `amount` in Core wei units). Used to rescue Core-side sends made directly to a
+deposit address; for proxies minted without this leaf, add it via a root update
+(`script/counterfactual/RecoverHyperCoreSpotBalance.s.sol` is the worked example).
+
 `initialRoot` is just this tree at deploy time; after an upgrade, `activeRoot` may commit a different
 tree (more/updated routes), while the address — fixed by `initialRoot` — is unchanged.
 

--- a/contracts/periphery/counterfactual/HyperCoreWithdrawImplementation.sol
+++ b/contracts/periphery/counterfactual/HyperCoreWithdrawImplementation.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { ICounterfactualImplementation } from "../../interfaces/ICounterfactualImplementation.sol";
+import { HyperCoreLib } from "../../libraries/HyperCoreLib.sol";
+import { WithdrawParams } from "./WithdrawImplementation.sol";
+
+/**
+ * @title HyperCoreWithdrawImplementation
+ * @notice Recovers funds sitting in a counterfactual's **HyperCore spot balance** — e.g. a Core-side spot
+ *         Send made directly to the deposit address, which never touches an EVM chain and is therefore
+ *         unreachable by `WithdrawImplementation` (the clone's Core account can only be debited by the
+ *         clone itself, via a CoreWriter action). Sends the requested amount to the leaf-committed `user`
+ *         on HyperCore. HyperEVM only — the CoreWriter/precompile addresses exist on no other chain.
+ * @dev Called via delegatecall from the CounterfactualDeposit dispatcher, so the CoreWriter action is
+ *      credited against the clone's own Core account. `params` and `submitterData` mirror
+ *      `WithdrawImplementation` — `WithdrawParams(admin, user)` and `(address token, address to,
+ *      uint256 amount)` — so both `AdminWithdrawManager` paths (`directWithdraw`,
+ *      `signedWithdrawToUser`) work unchanged. Differences:
+ *      - `token` is the HyperCore **asset-bridge address** of the Core token
+ *        (`0x2000…0000 + coreIndex`; USDC = `0x2000…0000`), not an ERC-20. Addresses below the bridge
+ *        range revert (checked underflow in `toTokenId`).
+ *      - `amount` is in Core wei units (must fit uint64).
+ *      - the Core recipient is ALWAYS the committed `user`; the `to` field is ignored.
+ *      NOTE: CoreWriter actions are enqueued, not executed, by the EVM tx — a Core-side failure (bad
+ *      token index, insufficient spot balance, non-existent recipient account) is silent and leaves the
+ *      funds in place. Verify the Core-side transfer landed before treating a withdrawal as done.
+ * @custom:security-contact bugs@across.to
+ */
+contract HyperCoreWithdrawImplementation is ICounterfactualImplementation {
+    event CoreWithdraw(uint64 indexed coreToken, address indexed to, uint64 amountCore);
+
+    error Unauthorized();
+
+    /**
+     * @inheritdoc ICounterfactualImplementation
+     * @dev Recovery mechanism for Core-side balances — no bridging. `params` is ABI-encoded as
+     *      `WithdrawParams` (admin, user); `submitterData` as `(address token, address to, uint256 amount)`.
+     *      Reverts: `Unauthorized` (caller is not admin or user), arithmetic panic (`token` below the
+     *      asset-bridge range), `SafeCast` overflow (`amount` exceeds uint64).
+     */
+    function execute(bytes calldata params, bytes calldata submitterData) external payable {
+        WithdrawParams memory wp = abi.decode(params, (WithdrawParams));
+        (address token, , uint256 amount) = abi.decode(submitterData, (address, address, uint256));
+
+        if (msg.sender != wp.admin && msg.sender != wp.user) revert Unauthorized();
+
+        uint64 coreToken = HyperCoreLib.toTokenId(token);
+        uint64 amountCore = SafeCast.toUint64(amount);
+        HyperCoreLib.transferERC20SpotToSpot(coreToken, wp.user, amountCore);
+
+        emit CoreWithdraw(coreToken, wp.user, amountCore);
+    }
+}

--- a/script/counterfactual/DeployHyperCoreWithdrawImplementation.s.sol
+++ b/script/counterfactual/DeployHyperCoreWithdrawImplementation.s.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import { console } from "forge-std/console.sol";
+import { DeploymentUtils } from "../utils/DeploymentUtils.sol";
+import { HyperCoreWithdrawImplementation } from "../../contracts/periphery/counterfactual/HyperCoreWithdrawImplementation.sol";
+
+// HyperEVM (chain 999) only — the CoreWriter/precompile addresses exist on no other chain.
+// How to run:
+// 1. `source .env` where `.env` has MNEMONIC="x x x ... x"
+// 2. forge script script/counterfactual/DeployHyperCoreWithdrawImplementation.s.sol:DeployHyperCoreWithdrawImplementation --rpc-url $NODE_URL_999 -vvvv
+// 3. Verify simulation works
+// 4. Deploy: append --broadcast to the command above
+contract DeployHyperCoreWithdrawImplementation is DeploymentUtils {
+    function run() external {
+        string memory deployerMnemonic = vm.envString("MNEMONIC");
+        uint256 deployerPrivateKey = vm.deriveKey(deployerMnemonic, 0);
+
+        bytes memory initCode = type(HyperCoreWithdrawImplementation).creationCode;
+
+        console.log("Deploying HyperCoreWithdrawImplementation via CREATE2...");
+        console.log("Chain ID:", block.chainid);
+        require(block.chainid == 999, "HyperCoreWithdrawImplementation is HyperEVM-only");
+
+        vm.startBroadcast(deployerPrivateKey);
+        address deployed = _deployCreate2(bytes32(0), initCode);
+        vm.stopBroadcast();
+
+        console.log("HyperCoreWithdrawImplementation deployed to:", deployed);
+    }
+}

--- a/script/counterfactual/RecoverHyperCoreSpotBalance.s.sol
+++ b/script/counterfactual/RecoverHyperCoreSpotBalance.s.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import { console } from "forge-std/console.sol";
+import { Merkle } from "murky/Merkle.sol";
+import { MerkleProof } from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import { DeploymentUtils } from "../utils/DeploymentUtils.sol";
+import { HyperCoreWithdrawImplementation } from "../../contracts/periphery/counterfactual/HyperCoreWithdrawImplementation.sol";
+import { WithdrawParams } from "../../contracts/periphery/counterfactual/WithdrawImplementation.sol";
+import { AdminWithdrawManager } from "../../contracts/periphery/counterfactual/AdminWithdrawManager.sol";
+import { CounterfactualBeaconBase } from "../../contracts/periphery/counterfactual/CounterfactualBeaconBase.sol";
+import { CounterfactualDeposit } from "../../contracts/periphery/counterfactual/CounterfactualDeposit.sol";
+import { CounterfactualDepositFactory } from "../../contracts/periphery/counterfactual/CounterfactualDepositFactory.sol";
+
+/**
+ * @notice Builds the full transaction sequence to recover a **HyperCore spot balance** stranded at a v3
+ *         counterfactual deposit address (funds sent to the address Core-side, unreachable by any leaf in
+ *         its creation-time route tree). It authorizes ONE new leaf — `HyperCoreWithdrawImplementation`
+ *         with the same `WithdrawParams(admin, user)` as the existing withdraw leaf — for this ONE proxy,
+ *         via the beacon's upgrade tree. Recipient is pinned to the creation-time refund address; nothing
+ *         in the sequence can redirect funds.
+ *
+ *         Incident: counterfactual_deposit_address id 1083070, 3,848.240373 USDC spot-sent to the deposit
+ *         address on HyperCore (2026-07-19 / 2026-07-21, Intercom 215475222911726).
+ *
+ * How to run (read-only; prints calldata, broadcasts nothing):
+ *   forge script script/counterfactual/RecoverHyperCoreSpotBalance.s.sol:RecoverHyperCoreSpotBalance \
+ *     --rpc-url $NODE_URL_999 -vvvv
+ *
+ * Output is four transactions, in order:
+ *   1. beacon.setUpgradeRoot(upgradeRoot)      — beacon owner (Safe)
+ *   2. factory.deploy(salt, initialRoot)       — anyone (deploys the proxy at the deposit address)
+ *   3. proxy.updateRoot(newRoot, [])           — anyone
+ *   4. manager.directWithdraw(...)             — directWithdrawer (Safe)
+ * Steps 1+4 can be batched with 2+3 into a single Safe MultiSend (order preserved).
+ * After broadcast, verify the Core-side transfer landed (CoreWriter actions fail silently):
+ * the deposit address's HyperCore USDC spot balance must be 0 and the user's credited.
+ */
+contract RecoverHyperCoreSpotBalance is DeploymentUtils {
+    // --- Canonical counterfactual v3 stack on HyperEVM (chain 999), verified live 2026-07-25 ---
+    address constant FACTORY = 0x9F62dcc4B939485911C4f9b24BdCa4324D6b97d1;
+    address constant BEACON = 0xB7eBaD46Ae4Ccbd0d9676ee1A34Ceb0136388133;
+    address constant ADMIN_WITHDRAW_MANAGER = 0xa8cD6EDDa01d394434Dc0cb1A7958a0223374689;
+
+    // --- Incident data: counterfactual_deposit_address id 1083070 ---
+    address constant DEPOSIT_ADDRESS = 0xACDe1Bc40B4DF760FB388DA503ee6a99794E2cb6;
+    address constant USER = 0xfae1d8C606A26071A01B59F3F02e157083114B90; // recipient AND refund address
+    bytes32 constant SALT = 0x017b00000000000000000000000000000000000000000000000000000000010b;
+    bytes32 constant INITIAL_ROOT = 0xecfb05ceee3461857e6a4e53f6681ae7cc4e52aeb8160b8554c2de3beb0eed1f;
+    address constant EVM_WITHDRAW_IMPL = 0x4eCffb4A23e26aE937Bd9185969c8bb71073fBb9;
+
+    // USDC on HyperCore: index 0 → asset-bridge address 0x2000…0000; wei decimals 8.
+    address constant USDC_BRIDGE = 0x2000000000000000000000000000000000000000;
+    // Full stranded balance: 3,848.240373 USDC = 384_824_037_300 Core wei. Static — no other party can
+    // debit the account. Re-verify against the HL API (spotClearinghouseState) before broadcasting.
+    uint256 constant AMOUNT_CORE = 384_824_037_300;
+
+    /// @dev The 7 creation-time route-tree leaf hashes, from `counterfactualMaterialsV3` (id 1083070):
+    ///      vanilla-cctp, sponsored-cctp, 2x spokepool-usdc, 2x spokepool-usdt, withdraw.
+    function _existingLeaves() internal pure returns (bytes32[] memory leaves) {
+        leaves = new bytes32[](7);
+        leaves[0] = 0xcfc30f5953ef862bf306e6db703626600dcdc9a2750b2606d0b84fea9a9cb329;
+        leaves[1] = 0x89cfce39be080cc0221f3ab35485509b8cdc3e0e4a1bc4db92cd42640c8fd1a4;
+        leaves[2] = 0x3e9627ffb1ccf528385e3130123aa1a53f8623bb1deec249a766a91f011564fc;
+        leaves[3] = 0xe23f711007fab1939099331939099b9c3eeaf5836afd0f3b76153ff466a47a52;
+        leaves[4] = 0x69bb1049a57b9b3336d9ee49e2b6b98ccb0562765a03a105428e84b17a15f0b9;
+        leaves[5] = 0x030fc29427195ece3ef08ca39f25cf88cc5bd206971bc3f591675f2daca62058;
+        leaves[6] = 0x18c49958fdc17284ba5be31e811319b16c74ae37fcf55b22507132dce2e4e1c6; // withdraw
+    }
+
+    function _leaf(address implementation, bytes memory params) internal pure returns (bytes32) {
+        return keccak256(bytes.concat(keccak256(abi.encode(implementation, keccak256(params)))));
+    }
+
+    function run() external {
+        // The new leaf reuses the existing withdraw leaf's params: admin = AdminWithdrawManager,
+        // user = the creation-pinned refund address.
+        bytes memory withdrawParams = abi.encode(WithdrawParams({ admin: ADMIN_WITHDRAW_MANAGER, user: USER }));
+
+        // Sanity: our params encoding must reproduce the creation-time withdraw leaf exactly.
+        require(
+            _leaf(EVM_WITHDRAW_IMPL, withdrawParams) == _existingLeaves()[6],
+            "withdraw leaf mismatch vs creation materials"
+        );
+
+        // Resolve the HyperCoreWithdrawImplementation address (CREATE2, salt 0 — deploy with
+        // DeployHyperCoreWithdrawImplementation.s.sol first, or let this predict it).
+        address coreImpl = vm.envOr("HYPERCORE_WITHDRAW_IMPL", address(0));
+        if (coreImpl == address(0)) {
+            coreImpl = _predictCreate2(bytes32(0), type(HyperCoreWithdrawImplementation).creationCode);
+        }
+
+        // New route tree = the 7 creation-time leaves + the HyperCore withdraw leaf.
+        bytes32[] memory leaves = new bytes32[](8);
+        bytes32[] memory existing = _existingLeaves();
+        for (uint256 i = 0; i < 7; i++) leaves[i] = existing[i];
+        leaves[7] = _leaf(coreImpl, withdrawParams);
+
+        Merkle merkle = new Merkle();
+        bytes32 newRoot = merkle.getRoot(leaves);
+        bytes32[] memory coreLeafProof = merkle.getProof(leaves, 7);
+        require(MerkleProof.verify(coreLeafProof, newRoot, leaves[7]), "core leaf proof invalid");
+
+        // Upgrade tree: a single (proxy, newRoot) leaf — root IS the leaf, proof is empty.
+        bytes32 upgradeRoot = keccak256(bytes.concat(keccak256(abi.encode(DEPOSIT_ADDRESS, newRoot))));
+        bytes32[] memory emptyProof = new bytes32[](0);
+        require(MerkleProof.verify(emptyProof, upgradeRoot, upgradeRoot), "upgrade tree invalid");
+
+        // Live checks when pointed at HyperEVM.
+        if (block.chainid == 999) {
+            require(
+                CounterfactualDepositFactory(FACTORY).predictAddress(SALT, INITIAL_ROOT) == DEPOSIT_ADDRESS,
+                "predictAddress mismatch"
+            );
+            console.log("Live check OK: factory.predictAddress(salt, initialRoot) == deposit address");
+        }
+
+        console.log("HyperCoreWithdrawImplementation:", coreImpl);
+        console.log("New route root / upgrade root:");
+        console.logBytes32(newRoot);
+        console.logBytes32(upgradeRoot);
+
+        console.log("\n--- tx 1 (beacon owner Safe): beacon.setUpgradeRoot ---");
+        console.log("to:", BEACON);
+        console.logBytes(abi.encodeCall(CounterfactualBeaconBase.setUpgradeRoot, (upgradeRoot)));
+
+        console.log("\n--- tx 2 (anyone): factory.deploy ---");
+        console.log("to:", FACTORY);
+        console.logBytes(abi.encodeCall(CounterfactualDepositFactory.deploy, (SALT, INITIAL_ROOT)));
+
+        console.log("\n--- tx 3 (anyone): proxy.updateRoot ---");
+        console.log("to:", DEPOSIT_ADDRESS);
+        console.logBytes(abi.encodeCall(CounterfactualDeposit.updateRoot, (newRoot, emptyProof)));
+
+        console.log("\n--- tx 4 (directWithdrawer Safe): manager.directWithdraw ---");
+        console.log("to:", ADMIN_WITHDRAW_MANAGER);
+        console.logBytes(
+            abi.encodeCall(
+                AdminWithdrawManager.directWithdraw,
+                (DEPOSIT_ADDRESS, coreImpl, withdrawParams, abi.encode(USDC_BRIDGE, USER, AMOUNT_CORE), coreLeafProof)
+            )
+        );
+    }
+}

--- a/test/evm/foundry/local/HyperCoreWithdrawImplementation.t.sol
+++ b/test/evm/foundry/local/HyperCoreWithdrawImplementation.t.sol
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import { stdError } from "forge-std/Test.sol";
+import { CounterfactualTestBase } from "./CounterfactualTestBase.sol";
+import { HyperCoreMockHelper } from "./HyperCoreMockHelper.sol";
+import { HyperCoreWithdrawImplementation } from "../../../../contracts/periphery/counterfactual/HyperCoreWithdrawImplementation.sol";
+import { WithdrawParams } from "../../../../contracts/periphery/counterfactual/WithdrawImplementation.sol";
+import { AdminWithdrawManager } from "../../../../contracts/periphery/counterfactual/AdminWithdrawManager.sol";
+import { CounterfactualDeposit } from "../../../../contracts/periphery/counterfactual/CounterfactualDeposit.sol";
+import { ICounterfactualDeposit } from "../../../../contracts/interfaces/ICounterfactualDeposit.sol";
+import { HyperCoreLib, ICoreWriter } from "../../../../contracts/libraries/HyperCoreLib.sol";
+
+contract HyperCoreWithdrawImplementationTest is CounterfactualTestBase, HyperCoreMockHelper {
+    HyperCoreWithdrawImplementation public coreWithdrawImpl;
+
+    // USDC on HyperCore: index 0, asset-bridge address 0x2000…0000.
+    uint64 constant USDC_CORE_INDEX = 0;
+    address constant USDC_BRIDGE = 0x2000000000000000000000000000000000000000;
+    uint64 constant AMOUNT_CORE = 384_824_037_300; // 3,848.240373 USDC in Core wei (8 decimals)
+
+    function setUp() public {
+        _setUpCore();
+        _deployBeacon(_baseConfig());
+        coreWithdrawImpl = new HyperCoreWithdrawImplementation();
+        mockCoreWriter(true);
+    }
+
+    function _deployCloneWithCoreLeaf(
+        bytes memory withdrawParams
+    ) internal returns (address clone, bytes32[] memory proof) {
+        bytes32[] memory leaves = new bytes32[](2);
+        leaves[0] = _leaf(address(coreWithdrawImpl), withdrawParams);
+        leaves[1] = keccak256("padding");
+        bytes32 root = merkle.getRoot(leaves);
+        proof = merkle.getProof(leaves, 0);
+        clone = factory.deploy(keccak256("salt"), root);
+    }
+
+    /// @dev The exact CoreWriter spotSend payload `HyperCoreLib.transferERC20SpotToSpot` emits.
+    function _spotSendCall(address to, uint64 token, uint64 amount) internal pure returns (bytes memory) {
+        return
+            abi.encodeCall(
+                ICoreWriter.sendRawAction,
+                (abi.encodePacked(HyperCoreLib.SPOT_SEND_HEADER, abi.encode(to, token, amount)))
+            );
+    }
+
+    // --- direct clone.execute tests ---
+
+    function testCoreWithdrawByUser() public {
+        bytes memory wp = abi.encode(WithdrawParams({ admin: admin, user: user }));
+        (address clone, bytes32[] memory proof) = _deployCloneWithCoreLeaf(wp);
+
+        vm.expectCall(CORE_WRITER_PRECOMPILE, _spotSendCall(user, USDC_CORE_INDEX, AMOUNT_CORE));
+        vm.expectEmit(true, true, true, true);
+        emit HyperCoreWithdrawImplementation.CoreWithdraw(USDC_CORE_INDEX, user, AMOUNT_CORE);
+
+        vm.prank(user);
+        ICounterfactualDeposit(clone).execute(
+            address(coreWithdrawImpl),
+            wp,
+            abi.encode(USDC_BRIDGE, user, uint256(AMOUNT_CORE)),
+            proof
+        );
+    }
+
+    function testCoreWithdrawByAdmin() public {
+        bytes memory wp = abi.encode(WithdrawParams({ admin: admin, user: user }));
+        (address clone, bytes32[] memory proof) = _deployCloneWithCoreLeaf(wp);
+
+        // Recipient is the committed user even when the admin executes.
+        vm.expectCall(CORE_WRITER_PRECOMPILE, _spotSendCall(user, USDC_CORE_INDEX, AMOUNT_CORE));
+
+        vm.prank(admin);
+        ICounterfactualDeposit(clone).execute(
+            address(coreWithdrawImpl),
+            wp,
+            abi.encode(USDC_BRIDGE, admin, uint256(AMOUNT_CORE)),
+            proof
+        );
+    }
+
+    function testRecipientIgnoresSubmitterTo() public {
+        bytes memory wp = abi.encode(WithdrawParams({ admin: admin, user: user }));
+        (address clone, bytes32[] memory proof) = _deployCloneWithCoreLeaf(wp);
+        address attacker = makeAddr("attacker");
+
+        // `to` in submitterData cannot redirect the Core send.
+        vm.expectCall(CORE_WRITER_PRECOMPILE, _spotSendCall(user, USDC_CORE_INDEX, AMOUNT_CORE));
+
+        vm.prank(user);
+        ICounterfactualDeposit(clone).execute(
+            address(coreWithdrawImpl),
+            wp,
+            abi.encode(USDC_BRIDGE, attacker, uint256(AMOUNT_CORE)),
+            proof
+        );
+    }
+
+    function testUnauthorizedCallerReverts() public {
+        bytes memory wp = abi.encode(WithdrawParams({ admin: admin, user: user }));
+        (address clone, bytes32[] memory proof) = _deployCloneWithCoreLeaf(wp);
+
+        vm.expectRevert(HyperCoreWithdrawImplementation.Unauthorized.selector);
+        vm.prank(relayer); // not admin or user
+        ICounterfactualDeposit(clone).execute(
+            address(coreWithdrawImpl),
+            wp,
+            abi.encode(USDC_BRIDGE, relayer, uint256(AMOUNT_CORE)),
+            proof
+        );
+    }
+
+    function testTokenBelowBridgeRangeReverts() public {
+        bytes memory wp = abi.encode(WithdrawParams({ admin: admin, user: user }));
+        (address clone, bytes32[] memory proof) = _deployCloneWithCoreLeaf(wp);
+
+        vm.expectRevert(stdError.arithmeticError);
+        vm.prank(user);
+        ICounterfactualDeposit(clone).execute(
+            address(coreWithdrawImpl),
+            wp,
+            abi.encode(address(0x1234), user, uint256(AMOUNT_CORE)),
+            proof
+        );
+    }
+
+    function testAmountOverUint64Reverts() public {
+        bytes memory wp = abi.encode(WithdrawParams({ admin: admin, user: user }));
+        (address clone, bytes32[] memory proof) = _deployCloneWithCoreLeaf(wp);
+
+        vm.expectRevert();
+        vm.prank(user);
+        ICounterfactualDeposit(clone).execute(
+            address(coreWithdrawImpl),
+            wp,
+            abi.encode(USDC_BRIDGE, user, uint256(type(uint64).max) + 1),
+            proof
+        );
+    }
+
+    // --- AdminWithdrawManager paths (submitterData shape compatibility) ---
+
+    function testDirectWithdrawViaManager() public {
+        address directWithdrawer = makeAddr("directWithdrawer");
+        AdminWithdrawManager manager = new AdminWithdrawManager(makeAddr("managerOwner"), directWithdrawer, signer);
+
+        bytes memory wp = abi.encode(WithdrawParams({ admin: address(manager), user: user }));
+        (address clone, bytes32[] memory proof) = _deployCloneWithCoreLeaf(wp);
+
+        vm.expectCall(CORE_WRITER_PRECOMPILE, _spotSendCall(user, USDC_CORE_INDEX, AMOUNT_CORE));
+
+        vm.prank(directWithdrawer);
+        manager.directWithdraw(
+            clone,
+            address(coreWithdrawImpl),
+            wp,
+            abi.encode(USDC_BRIDGE, user, uint256(AMOUNT_CORE)),
+            proof
+        );
+    }
+
+    function testSignedWithdrawToUserViaManager() public {
+        AdminWithdrawManager manager = new AdminWithdrawManager(
+            makeAddr("managerOwner"),
+            makeAddr("directWithdrawer"),
+            signer
+        );
+
+        bytes memory wp = abi.encode(WithdrawParams({ admin: address(manager), user: user }));
+        (address clone, bytes32[] memory proof) = _deployCloneWithCoreLeaf(wp);
+
+        uint256 deadline = block.timestamp + 3600;
+        bytes32 structHash = keccak256(
+            abi.encode(
+                keccak256("SignedWithdraw(address depositAddress,address token,uint256 amount,uint256 deadline)"),
+                clone,
+                USDC_BRIDGE,
+                uint256(AMOUNT_CORE),
+                deadline
+            )
+        );
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPEHASH,
+                keccak256("AdminWithdrawManager"),
+                keccak256("v1.0.0"),
+                block.chainid,
+                address(manager)
+            )
+        );
+        bytes memory sig = _sign(signerPk, domainSeparator, structHash);
+
+        vm.expectCall(CORE_WRITER_PRECOMPILE, _spotSendCall(user, USDC_CORE_INDEX, AMOUNT_CORE));
+
+        manager.signedWithdrawToUser(
+            clone,
+            address(coreWithdrawImpl),
+            wp,
+            USDC_BRIDGE,
+            uint256(AMOUNT_CORE),
+            proof,
+            deadline,
+            sig
+        );
+    }
+
+    // --- full recovery flow: root update adds the Core leaf to an existing tree ---
+
+    /// @dev Mirrors the production recovery for a clone whose creation-time tree has no Core-withdraw
+    ///      leaf: beacon owner publishes an upgrade tree for (clone, newRoot), anyone updates the root,
+    ///      then the manager withdraws the Core balance to the committed user.
+    function testRecoveryFlowViaRootUpdate() public {
+        address directWithdrawer = makeAddr("directWithdrawer");
+        AdminWithdrawManager manager = new AdminWithdrawManager(makeAddr("managerOwner"), directWithdrawer, signer);
+        bytes memory wp = abi.encode(WithdrawParams({ admin: address(manager), user: user }));
+
+        // Creation-time tree: EVM withdraw leaf only — Core balance unreachable.
+        bytes32[] memory initialLeaves = new bytes32[](2);
+        initialLeaves[0] = _leaf(address(withdrawImpl), wp);
+        initialLeaves[1] = keccak256("padding");
+        bytes32 initialRoot = merkle.getRoot(initialLeaves);
+        address clone = factory.deploy(keccak256("incident-salt"), initialRoot);
+
+        // New route tree: same leaves plus the Core-withdraw leaf.
+        bytes32[] memory newLeaves = new bytes32[](3);
+        newLeaves[0] = initialLeaves[0];
+        newLeaves[1] = initialLeaves[1];
+        newLeaves[2] = _leaf(address(coreWithdrawImpl), wp);
+        bytes32 newRoot = merkle.getRoot(newLeaves);
+        bytes32[] memory coreLeafProof = merkle.getProof(newLeaves, 2);
+
+        // Beacon owner authorizes (clone → newRoot); anyone applies it.
+        bytes32[] memory updateProof = _setUpgradeTree(clone, newRoot);
+        CounterfactualDeposit(payable(clone)).updateRoot(newRoot, updateProof);
+        assertEq(CounterfactualDeposit(payable(clone)).activeRoot(), newRoot);
+
+        // Manager withdraws the Core balance to the committed user.
+        vm.expectCall(CORE_WRITER_PRECOMPILE, _spotSendCall(user, USDC_CORE_INDEX, AMOUNT_CORE));
+        vm.prank(directWithdrawer);
+        manager.directWithdraw(
+            clone,
+            address(coreWithdrawImpl),
+            wp,
+            abi.encode(USDC_BRIDGE, user, uint256(AMOUNT_CORE)),
+            coreLeafProof
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

First live case of a **Core-side stranding**: a user spot-Sent **3,848.240373 USDC on HyperCore** to their Across v3 counterfactual deposit address `0xACDe1Bc40B4DF760FB388DA503ee6a99794E2cb6` (`counterfactual_deposit_address` id 1083070, Intercom 215475222911726). A HyperCore internal Send never touches an EVM chain, so no leaf in the creation-time route tree — including `WithdrawImplementation` — can reach the funds: the clone's Core account can only be debited by the clone itself, via a CoreWriter action.

## What this adds

- **`HyperCoreWithdrawImplementation`** — a withdraw leaf implementation (HyperEVM-only) that CoreWriter-`spotSend`s the clone's HyperCore spot balance to the leaf-committed `user`. `params`/`submitterData` mirror `WithdrawImplementation` (`WithdrawParams(admin, user)` / `(token, to, amount)`), so both `AdminWithdrawManager` paths (`directWithdraw`, `signedWithdrawToUser`) work unchanged. Differences: `token` is the Core token's **asset-bridge address** (USDC = `0x2000…0000`), `amount` is in Core wei units (u64), and the Core recipient is **always the committed `user`** — `to` is ignored.
- **`DeployHyperCoreWithdrawImplementation.s.sol`** — CREATE2 deploy (salt 0), mirroring the existing withdraw-impl deploy script.
- **`RecoverHyperCoreSpotBalance.s.sol`** — worked recovery for the live incident: rebuilds the 8-leaf route tree (7 creation-time leaf hashes + the new Core-withdraw leaf, same `WithdrawParams` as the existing withdraw leaf), the single-leaf upgrade tree, and prints the 4-tx sequence:
  1. `beacon.setUpgradeRoot(upgradeRoot)` — beacon owner Safe (`0xd396Cc…2A7F`, 3/5 on chain 999)
  2. `factory.deploy(salt, initialRoot)` — anyone (materializes the proxy at the deposit address)
  3. `proxy.updateRoot(newRoot, [])` — anyone
  4. `manager.directWithdraw(…)` — directWithdrawer Safe (same Safe)
- DESIGN.md note under *Withdraw leaf*.

## Verification

- 9 Foundry tests incl. an end-to-end `testRecoveryFlowViaRootUpdate` (root update adds the Core leaf to a clone minted without it, then the manager withdraws) and both AWM-path compatibility tests. All pass.
- Recovery script run against live HyperEVM: `factory.predictAddress(salt, initialRoot)` == the deposit address; recomputed withdraw leaf == creation materials leaf hash; every DB merkle proof verifies against `initialRoot`.
- Live Core state re-verified 2026-07-25: exactly 3,848.240373 USDC (`total`, `hold` 0) at the address; recipient == creation-pinned refund address == the user's main account.

## Safety

The new leaf is authorized for **this one proxy only** (single-leaf upgrade tree), the recipient is pinned in the leaf params to the creation-time refund address, and `submitterData` cannot redirect funds. Worst case of a bad broadcast is a silently-failed Core action (funds stay put) — the script header documents the post-broadcast Core-side verification step.

Slack context: https://risklabs.slack.com/archives/C0B8JA20R24/p1784968036530869

🤖 Generated with [Claude Code](https://claude.com/claude-code)