### PR TITLE
chore: Tron SpokePoolPeriphery N-01 Change in Revert Data for Failed Token Transfers

### DIFF
--- a/contracts/libraries/SafeTransferERC20.sol
+++ b/contracts/libraries/SafeTransferERC20.sol
@@ -8,9 +8,10 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
  * @notice Mixin exposing a virtual `_safeTransfer` hook. Default implementation uses
  *         OZ `SafeERC20.safeTransfer`. Inheritors may override to swap in alternative
  *         ERC20 transfer semantics.
- * @dev Intentionally uses OZ v5, even in inheritors that otherwise use OZ v4: failed transfers
- *      revert with the v5 custom error `SafeERC20FailedOperation(address)`, not the v4 string
- *      "SafeERC20: ERC20 operation did not succeed".
+ * @dev Intentionally uses OZ v5, even in inheritors that otherwise use OZ v4: a transfer failing
+ *      the return-value check reverts with the v5 custom error `SafeERC20FailedOperation(address)`,
+ *      not the v4 string "SafeERC20: ERC20 operation did not succeed". (A transfer that itself
+ *      reverts bubbles the token's revert data, as in v4.)
  */
 abstract contract SafeTransferERC20 {
     // This mixin is the only place in the codebase permitted to call `IERC20.safeTransfer`

--- a/contracts/libraries/SafeTransferERC20.sol
+++ b/contracts/libraries/SafeTransferERC20.sol
@@ -8,6 +8,9 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
  * @notice Mixin exposing a virtual `_safeTransfer` hook. Default implementation uses
  *         OZ `SafeERC20.safeTransfer`. Inheritors may override to swap in alternative
  *         ERC20 transfer semantics.
+ * @dev Intentionally uses OZ v5, even in inheritors that otherwise use OZ v4: failed transfers
+ *      revert with the v5 custom error `SafeERC20FailedOperation(address)`, not the v4 string
+ *      "SafeERC20: ERC20 operation did not succeed".
  */
 abstract contract SafeTransferERC20 {
     // This mixin is the only place in the codebase permitted to call `IERC20.safeTransfer`

--- a/contracts/periphery/SpokePoolPeriphery.sol
+++ b/contracts/periphery/SpokePoolPeriphery.sol
@@ -144,8 +144,8 @@ contract SwapProxy is ReentrancyGuard, SafeTransferERC20 {
 /**
  * @title SpokePoolPeriphery
  * @notice Contract for performing more complex interactions with an Across spoke pool deployment.
- * @dev note: Failed token transfers here and in SwapProxy revert with the OZ v5 error `SafeERC20FailedOperation`,
- * not the OZ v4 string (see `SafeTransferERC20`).
+ * @dev note: Token transfers here and in SwapProxy that fail the return-value check revert with the
+ * OZ v5 error `SafeERC20FailedOperation`, not the OZ v4 string (see `SafeTransferERC20`).
  * @custom:security-contact bugs@across.to
  */
 contract SpokePoolPeriphery is SpokePoolPeripheryInterface, ReentrancyGuard, MultiCaller, EIP712, SafeTransferERC20 {

--- a/contracts/periphery/SpokePoolPeriphery.sol
+++ b/contracts/periphery/SpokePoolPeriphery.sol
@@ -144,6 +144,8 @@ contract SwapProxy is ReentrancyGuard, SafeTransferERC20 {
 /**
  * @title SpokePoolPeriphery
  * @notice Contract for performing more complex interactions with an Across spoke pool deployment.
+ * @dev note: Failed token transfers here and in SwapProxy revert with the OZ v5 error `SafeERC20FailedOperation`,
+ * not the OZ v4 string (see `SafeTransferERC20`).
  * @custom:security-contact bugs@across.to
  */
 contract SpokePoolPeriphery is SpokePoolPeripheryInterface, ReentrancyGuard, MultiCaller, EIP712, SafeTransferERC20 {

--- a/contracts/tron/TronPeripheryImports.sol
+++ b/contracts/tron/TronPeripheryImports.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.0;
 
 // Entry point for SpokePoolPeriphery and SwapProxy (and their Tron variants) in the tron Foundry
-// profile. These use OZ v4 (except the `_safeTransfer` hook, which is OZ v5 — see
-// `SafeTransferERC20`) and are kept in a separate file from SP1Helios/Tron_SpokePool (OZ v5)
-// to avoid name collisions.
+// profile. These use OZ v4, except the `_safeTransfer` hook: OZ v5 in the mainline contracts (see
+// `SafeTransferERC20`), overridden with `TronTransferLib` errors in the Tron variants. Kept in a
+// separate file from SP1Helios/Tron_SpokePool (OZ v5) to avoid name collisions.
 import "../periphery/SpokePoolPeriphery.sol";
 import "../periphery/Tron_SpokePoolPeriphery.sol";
 import "../periphery/AcrossEventEmitter.sol";

--- a/contracts/tron/TronPeripheryImports.sol
+++ b/contracts/tron/TronPeripheryImports.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.0;
 
 // Entry point for SpokePoolPeriphery and SwapProxy (and their Tron variants) in the tron Foundry
-// profile. These use OZ v4 and are kept in a separate file from SP1Helios/Tron_SpokePool (OZ v5)
+// profile. These use OZ v4 (except the `_safeTransfer` hook, which is OZ v5 — see
+// `SafeTransferERC20`) and are kept in a separate file from SP1Helios/Tron_SpokePool (OZ v5)
 // to avoid name collisions.
 import "../periphery/SpokePoolPeriphery.sol";
 import "../periphery/Tron_SpokePoolPeriphery.sol";


### PR DESCRIPTION
Change in Revert Data for Failed Token Transfers

SpokePoolPeriphery.sol imports IERC20, SafeERC20, EIP712, and ReentrancyGuard from OpenZeppelin Contracts v4, while the new _safeTransfer hook is [inherited](https://github.com/across-protocol/contracts/blob/b5ba27e5b2437eb55deeac53c0ff2bc8a64783fc/contracts/periphery/SpokePoolPeriphery.sol#L31) from the SafeTransferERC20 mixin, which uses SafeERC20 from OpenZeppelin Contracts v5. The default transfer path of SwapProxy and SpokePoolPeriphery therefore executes v5 code on every chain, not only on Tron. Both versions accept and reject the same set of token return values, so no transfer outcome changes. However, a transfer that fails the return-value check now [reverts with the v5 custom error](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/utils/SafeERC20.sol) SafeERC20FailedOperation rather than the [v4 string](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/dc44c9f1a4c3b10af99492eed84f83ed244203f6/contracts/token/ERC20/utils/SafeERC20.sol#L123) "SafeERC20: ERC20 operation did not succeed".

No code within the repository matches on the former string, but off-chain consumers that classify periphery failures by revert data, such as relayers, quoting services, and simulation tooling, would observe this change on every chain where the periphery is deployed. Drawing transfer semantics from two major library versions within a single contract also makes those semantics harder to review, although SpokePool.sol already inherits the same v5 mixin while itself using v4. This also makes inaccurate the documentation in TronPeripheryImports that [states](https://github.com/across-protocol/contracts/blob/b5ba27e5b2437eb55deeac53c0ff2bc8a64783fc/contracts/tron/TronPeripheryImports.sol#L5) that these contracts (meaning SpokePoolPeriphery and SwapProxy) use OZ v4, since SpokePoolPeriphery now uses both v4 and v5.5.

Consider documenting this change in revert data so that integrators can be notified, or adding a v4-based variant of the SafeTransferERC20 mixin for contracts that otherwise use OpenZeppelin Contracts v4, so that each contract draws its transfer semantics from a single library version.