### PR TITLE
ci: harden composite action inputs before shell use

### DIFF
--- a/.github/actions/cache-svm-artifacts/action.yml
+++ b/.github/actions/cache-svm-artifacts/action.yml
@@ -30,4 +30,6 @@ runs:
     - name: Unpack restored SVM artifacts
       if: steps.svm-artifacts-cache.outputs.cache-hit == 'true'
       shell: bash
-      run: tar -xf svm-${{ inputs.type }}.tar
+      env:
+        SVM_TYPE: ${{ inputs.type }}
+      run: tar -xf "svm-${SVM_TYPE}.tar"

--- a/.github/actions/generate-svm-artifacts/action.yml
+++ b/.github/actions/generate-svm-artifacts/action.yml
@@ -32,4 +32,5 @@ runs:
       shell: bash
       env:
         CACHE_PATHS: ${{ inputs.path }}
-      run: echo "$CACHE_PATHS" | xargs tar -cf svm-${{ inputs.type }}.tar
+        SVM_TYPE: ${{ inputs.type }}
+      run: echo "$CACHE_PATHS" | xargs tar -cf "svm-${SVM_TYPE}.tar"

--- a/.github/actions/setup-node-if-needed/action.yml
+++ b/.github/actions/setup-node-if-needed/action.yml
@@ -14,8 +14,10 @@ runs:
     - name: Check if Node is installed
       id: check-node
       shell: bash
+      env:
+        NODE_VERSION: ${{ inputs.node_version }}
       run: |
-        if node --version 2>/dev/null | grep -q "v${{ inputs.node_version }}"; then
+        if node --version 2>/dev/null | grep -q "v${NODE_VERSION}"; then
           echo "installed=true" >> "$GITHUB_OUTPUT"
         else
           echo "installed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- CI hygiene for `.github/actions/setup-node-if-needed`, `cache-svm-artifacts`, and `generate-svm-artifacts`.
- Bind free-string inputs (`node_version`, `type`) under `env:` before `run:` script use (quoted `$NODE_VERSION` / `$SVM_TYPE`).
- `with:` / `path:` / `key:` expressions left as-is (not shell script text).
- Mirrors the existing `CACHE_PATHS` env binding in `generate-svm-artifacts`.
- Defense-in-depth for Actions composites — not framed as a vulnerability ticket.

## Test plan
- [ ] Workflow YAML review
- [ ] Existing `pr.yml` / `publish.yml` SVM cache + generate paths still invoke the composites with `type: artifacts` / `verified-test-binaries`

## Note
Supersedes #1511 — same change re-applied with a DCO `Signed-off-by` commit (previous tip lacked sign-off).


Made with [Cursor](https://cursor.com)