### PR TITLE
fix(mintburn): bind direct-flow funding via in-call pull (not held balance)

### DIFF
--- a/contracts/interfaces/SponsoredCCTPInterface.sol
+++ b/contracts/interfaces/SponsoredCCTPInterface.sol
@@ -41,6 +41,10 @@ interface SponsoredCCTPInterface is SponsoredExecutionModeInterface {
     // Error thrown when the burn token is invalid.
     error InvalidBurnToken();
 
+    // Error thrown when a direct-flow call arrives without the baseToken funding
+    // the quote requires.
+    error InsufficientFunding();
+
     event SponsoredDepositForBurn(
         bytes32 indexed quoteNonce,
         address indexed originSender,

--- a/contracts/periphery/mintburn/sponsored-cctp/SponsoredCCTPDstPeriphery.sol
+++ b/contracts/periphery/mintburn/sponsored-cctp/SponsoredCCTPDstPeriphery.sol
@@ -233,6 +233,12 @@ contract SponsoredCCTPDstPeriphery is BaseModuleHandler, SponsoredCCTPInterface,
         SponsoredCCTPInterface.SponsoredCCTPQuote memory quote
     ) external nonReentrant authorizeFundedFlow onlyRole(DIRECT_CALLER_ROLE) {
         if (quote.burnToken.toAddress() != baseToken) revert InvalidBurnToken();
+        // The CCTP-bridged path proves the mint delivered `amountAfterFees` before
+        // executing; the direct path must prove the same invariant — that the funds
+        // backing this quote are actually held — otherwise a compromised or
+        // malfunctioning DIRECT_CALLER_ROLE holder can execute unfunded quotes and
+        // spend balance belonging to in-flight flows.
+        if (IERC20Metadata(baseToken).balanceOf(address(this)) < quote.amount) revert InsufficientFunding();
         MainStorage storage $ = _getMainStorage();
         if ($.usedNonces[quote.nonce]) revert InvalidNonce();
         $.usedNonces[quote.nonce] = true;

--- a/contracts/periphery/mintburn/sponsored-cctp/SponsoredCCTPDstPeriphery.sol
+++ b/contracts/periphery/mintburn/sponsored-cctp/SponsoredCCTPDstPeriphery.sol
@@ -226,19 +226,19 @@ contract SponsoredCCTPDstPeriphery is BaseModuleHandler, SponsoredCCTPInterface,
 
     /**
      * @notice Direct execution entrypoint for same-chain flows that bypass CCTP transport.
-     * @dev Caller must hold DIRECT_CALLER_ROLE and transfer baseToken funds to this contract before invoking.
+     * @dev Caller must hold DIRECT_CALLER_ROLE and pull-fund `quote.amount` of baseToken into
+     *      this contract in the same call (via allowance). A held-balance check alone is weaker
+     *      than the CCTP minted-delta guard: it would let a compromised DIRECT_CALLER spend
+     *      pre-existing in-flight / orphaned balance that already covers the quote.
      * @param quote The quote that contains the data for the deposit.
      */
     function directReceiveMessage(
         SponsoredCCTPInterface.SponsoredCCTPQuote memory quote
     ) external nonReentrant authorizeFundedFlow onlyRole(DIRECT_CALLER_ROLE) {
         if (quote.burnToken.toAddress() != baseToken) revert InvalidBurnToken();
-        // The CCTP-bridged path proves the mint delivered `amountAfterFees` before
-        // executing; the direct path must prove the same invariant — that the funds
-        // backing this quote are actually held — otherwise a compromised or
-        // malfunctioning DIRECT_CALLER_ROLE holder can execute unfunded quotes and
-        // spend balance belonging to in-flight flows.
-        if (IERC20Metadata(baseToken).balanceOf(address(this)) < quote.amount) revert InsufficientFunding();
+        // Bind funding to this call (CCTP path binds via mint delta in the same tx).
+        if (IERC20Metadata(baseToken).balanceOf(msg.sender) < quote.amount) revert InsufficientFunding();
+        IERC20Metadata(baseToken).safeTransferFrom(msg.sender, address(this), quote.amount);
         MainStorage storage $ = _getMainStorage();
         if ($.usedNonces[quote.nonce]) revert InvalidNonce();
         $.usedNonces[quote.nonce] = true;

--- a/contracts/periphery/mintburn/sponsored-cctp/SponsoredCCTPSrcPeriphery.sol
+++ b/contracts/periphery/mintburn/sponsored-cctp/SponsoredCCTPSrcPeriphery.sol
@@ -93,7 +93,11 @@ contract SponsoredCCTPSrcPeriphery is SponsoredCCTPInterface, Ownable {
             if (!destinationHandler.isContract()) revert InvalidDirectHandler();
 
             address burnToken = quote.burnToken.toAddress();
-            IERC20(burnToken).safeTransferFrom(msg.sender, destinationHandler, quote.amount);
+            // Pull from user into this contract, then let the dst handler pull-fund the quote
+            // in the same call (mirrors CCTP minted-delta binding; avoids spending orphaned
+            // dst balance that merely covers quote.amount).
+            IERC20(burnToken).safeTransferFrom(msg.sender, address(this), quote.amount);
+            IERC20(burnToken).forceApprove(destinationHandler, quote.amount);
             SponsoredCCTPDstPeriphery(payable(destinationHandler)).directReceiveMessage(quote);
 
             emit SponsoredCCTPDirectExecution(

--- a/contracts/periphery/mintburn/sponsored-oft/DstOFTHandler.sol
+++ b/contracts/periphery/mintburn/sponsored-oft/DstOFTHandler.sol
@@ -177,7 +177,9 @@ contract DstOFTHandler is BaseModuleHandler, OFTCoreMath, ILayerZeroComposer, Ar
 
     /**
      * @notice Direct execution entrypoint for same-chain flows that bypass OFT transport.
-     * @dev Caller must hold DIRECT_CALLER_ROLE and transfer baseToken funds to this contract before invoking.
+     * @dev Caller must hold DIRECT_CALLER_ROLE and pull-fund `amountLD` of baseToken into
+     *      this contract in the same call. A held-balance check alone would let a compromised
+     *      DIRECT_CALLER spend pre-existing in-flight / orphaned balance.
      */
     function executeDirect(
         address tokenSent,
@@ -185,10 +187,8 @@ contract DstOFTHandler is BaseModuleHandler, OFTCoreMath, ILayerZeroComposer, Ar
         bytes calldata composeMsg
     ) external nonReentrant authorizeFundedFlow onlyRole(DIRECT_CALLER_ROLE) {
         if (tokenSent != baseToken) revert InvalidDirectToken();
-        // Prove the funds backing this execution are actually held — without this,
-        // a compromised or malfunctioning DIRECT_CALLER_ROLE holder can execute
-        // unfunded flows and spend balance belonging to in-flight messages.
-        if (IERC20(baseToken).balanceOf(address(this)) < amountLD) revert InsufficientFunding();
+        if (IERC20(baseToken).balanceOf(msg.sender) < amountLD) revert InsufficientFunding();
+        IERC20(baseToken).safeTransferFrom(msg.sender, address(this), amountLD);
         if (!composeMsg._isValidComposeMsgBytelength()) revert InvalidComposeMsgFormat();
 
         bytes32 quoteNonce = composeMsg._getNonce();

--- a/contracts/periphery/mintburn/sponsored-oft/DstOFTHandler.sol
+++ b/contracts/periphery/mintburn/sponsored-oft/DstOFTHandler.sol
@@ -81,6 +81,10 @@ contract DstOFTHandler is BaseModuleHandler, OFTCoreMath, ILayerZeroComposer, Ar
     /// @notice Thrown when direct execution is attempted with unsupported token.
     error InvalidDirectToken();
 
+    // Error thrown when a direct-flow call arrives without the baseToken funding
+    // the execution requires.
+    error InsufficientFunding();
+
     constructor(
         address _oftEndpoint,
         address _ioft,
@@ -181,6 +185,10 @@ contract DstOFTHandler is BaseModuleHandler, OFTCoreMath, ILayerZeroComposer, Ar
         bytes calldata composeMsg
     ) external nonReentrant authorizeFundedFlow onlyRole(DIRECT_CALLER_ROLE) {
         if (tokenSent != baseToken) revert InvalidDirectToken();
+        // Prove the funds backing this execution are actually held — without this,
+        // a compromised or malfunctioning DIRECT_CALLER_ROLE holder can execute
+        // unfunded flows and spend balance belonging to in-flight messages.
+        if (IERC20(baseToken).balanceOf(address(this)) < amountLD) revert InsufficientFunding();
         if (!composeMsg._isValidComposeMsgBytelength()) revert InvalidComposeMsgFormat();
 
         bytes32 quoteNonce = composeMsg._getNonce();

--- a/contracts/periphery/mintburn/sponsored-oft/SponsoredOFTSrcPeriphery.sol
+++ b/contracts/periphery/mintburn/sponsored-oft/SponsoredOFTSrcPeriphery.sol
@@ -115,7 +115,9 @@ contract SponsoredOFTSrcPeriphery is Ownable, OFTCoreMath, SponsoredOFTInterface
                 quote.signedParams.actionData
             );
 
-            IERC20(TOKEN).safeTransferFrom(msg.sender, destinationHandler, quote.signedParams.amountLD);
+            // Pull from user into this contract, then let the dst handler pull-fund in-call.
+            IERC20(TOKEN).safeTransferFrom(msg.sender, address(this), quote.signedParams.amountLD);
+            IERC20(TOKEN).forceApprove(destinationHandler, quote.signedParams.amountLD);
             DstOFTHandler(payable(destinationHandler)).executeDirect(TOKEN, quote.signedParams.amountLD, composeMsg);
 
             emit SponsoredOFTDirectExecution(

--- a/test/evm/foundry/local/SponsoredDirectFlow.t.sol
+++ b/test/evm/foundry/local/SponsoredDirectFlow.t.sol
@@ -478,6 +478,23 @@ contract CCTPDirectFlowTest is BaseSimulatorTest {
         dstPeriphery.directReceiveMessage(quote);
     }
 
+    function testDirectReceiveMessage_RevertsOnInsufficientFunding() public {
+        SponsoredCCTPInterface.SponsoredCCTPQuote memory quote = _createDirectQuote(keccak256("cctp-unfunded"));
+
+        // Role granted but dstPeriphery holds nothing: the call must not execute an
+        // unfunded quote. The CCTP-bridged path enforces the same invariant via its
+        // minted-balance-delta check.
+        dstPeriphery.grantRole(dstPeriphery.DIRECT_CALLER_ROLE(), address(this));
+
+        vm.expectRevert(SponsoredCCTPInterface.InsufficientFunding.selector);
+        dstPeriphery.directReceiveMessage(quote);
+
+        // Partial funding below quote.amount must also revert
+        deal(address(usdc), address(dstPeriphery), DEFAULT_AMOUNT - 1);
+        vm.expectRevert(SponsoredCCTPInterface.InsufficientFunding.selector);
+        dstPeriphery.directReceiveMessage(quote);
+    }
+
     function testDirectReceiveMessage_RevertsOnInvalidBurnToken() public {
         SponsoredCCTPInterface.SponsoredCCTPQuote memory quote = _createDirectQuote(keccak256("cctp-bad-token"));
         quote.burnToken = makeAddr("wrongToken").toBytes32();

--- a/test/evm/foundry/local/SponsoredDirectFlow.t.sol
+++ b/test/evm/foundry/local/SponsoredDirectFlow.t.sol
@@ -52,6 +52,8 @@ contract MockDirectDstOFTHandler {
     uint256 public callCount;
 
     function executeDirect(address tokenSent, uint256 amountLD, bytes calldata composeMsg) external {
+        // Mirror production pull-fund: caller must have approved this handler.
+        IERC20(tokenSent).transferFrom(msg.sender, address(this), amountLD);
         lastTokenSent = tokenSent;
         lastAmountLD = amountLD;
         lastComposeMsg = composeMsg;
@@ -481,18 +483,38 @@ contract CCTPDirectFlowTest is BaseSimulatorTest {
     function testDirectReceiveMessage_RevertsOnInsufficientFunding() public {
         SponsoredCCTPInterface.SponsoredCCTPQuote memory quote = _createDirectQuote(keccak256("cctp-unfunded"));
 
-        // Role granted but dstPeriphery holds nothing: the call must not execute an
-        // unfunded quote. The CCTP-bridged path enforces the same invariant via its
-        // minted-balance-delta check.
+        // Role granted but caller holds nothing: must not execute. Orphaned balance on
+        // dst alone must not satisfy the guard (that was the balanceOf residual).
+        dstPeriphery.grantRole(dstPeriphery.DIRECT_CALLER_ROLE(), address(this));
+        deal(address(usdc), address(dstPeriphery), DEFAULT_AMOUNT);
+
+        vm.expectRevert(SponsoredCCTPInterface.InsufficientFunding.selector);
+        dstPeriphery.directReceiveMessage(quote);
+
+        // Partial caller funding below quote.amount must also revert
+        deal(address(usdc), address(this), DEFAULT_AMOUNT - 1);
+        usdc.approve(address(dstPeriphery), type(uint256).max);
+        vm.expectRevert(SponsoredCCTPInterface.InsufficientFunding.selector);
+        dstPeriphery.directReceiveMessage(quote);
+    }
+
+    function testDirectReceiveMessage_PullFundsFromCaller() public {
+        SponsoredCCTPInterface.SponsoredCCTPQuote memory quote = _createDirectQuote(keccak256("cctp-pull"));
         dstPeriphery.grantRole(dstPeriphery.DIRECT_CALLER_ROLE(), address(this));
 
-        vm.expectRevert(SponsoredCCTPInterface.InsufficientFunding.selector);
+        // Orphaned dst balance must not be spendable; caller must pull-fund.
+        uint256 orphaned = DEFAULT_AMOUNT;
+        deal(address(usdc), address(dstPeriphery), orphaned);
+        deal(address(usdc), address(this), DEFAULT_AMOUNT);
+        usdc.approve(address(dstPeriphery), DEFAULT_AMOUNT);
+
+        uint256 callerBefore = usdc.balanceOf(address(this));
         dstPeriphery.directReceiveMessage(quote);
 
-        // Partial funding below quote.amount must also revert
-        deal(address(usdc), address(dstPeriphery), DEFAULT_AMOUNT - 1);
-        vm.expectRevert(SponsoredCCTPInterface.InsufficientFunding.selector);
-        dstPeriphery.directReceiveMessage(quote);
+        assertEq(usdc.balanceOf(address(this)), callerBefore - DEFAULT_AMOUNT, "caller pulled");
+        assertTrue(dstPeriphery.usedNonces(quote.nonce), "nonce used");
+        // Orphaned funds remain; execution consumed the pulled amount, not the orphan.
+        assertGe(usdc.balanceOf(address(dstPeriphery)) + usdc.balanceOf(finalRecipient), orphaned, "orphan preserved or routed");
     }
 
     function testDirectReceiveMessage_RevertsOnInvalidBurnToken() public {
@@ -500,8 +522,9 @@ contract CCTPDirectFlowTest is BaseSimulatorTest {
         quote.burnToken = makeAddr("wrongToken").toBytes32();
         bytes memory sig = _signQuote(quote, signerPk);
 
-        // Fund and grant role
-        deal(address(usdc), address(dstPeriphery), DEFAULT_AMOUNT);
+        // Fund caller (pull path) and grant role
+        deal(address(usdc), address(this), DEFAULT_AMOUNT);
+        usdc.approve(address(dstPeriphery), type(uint256).max);
         dstPeriphery.grantRole(dstPeriphery.DIRECT_CALLER_ROLE(), address(this));
 
         vm.expectRevert(SponsoredCCTPInterface.InvalidBurnToken.selector);


### PR DESCRIPTION
## Summary
- `directReceiveMessage` / `executeDirect` previously spent `quote.amount` / `amountLD` with no proof that this call funded the quote (CCTP `receiveMessage` enforces minted-balance-delta).
- First guard (`balanceOf(this) >= amount`) still let a compromised `DIRECT_CALLER_ROLE` spend pre-existing in-flight / orphaned balance.
- This PR pull-funds from `msg.sender` in the same call (src periphery pulls from the user, approves the dst handler, dst pulls). Funding binds like the CCTP mint delta.

## Test plan
- [x] `forge test --match-contract CCTPDirectFlowTest` (10/10)
- [x] `forge test --match-contract OFTDirectFlowTest` (8/8)
- [x] Residual case: orphaned dst balance alone reverts; caller must fund via allowance