### PR TITLE
fix(counterfactual): consume signedWithdrawToUser EIP-712 digests

### DIFF
--- a/contracts/periphery/counterfactual/AdminWithdrawManager.sol
+++ b/contracts/periphery/counterfactual/AdminWithdrawManager.sol
@@ -27,6 +27,7 @@ contract AdminWithdrawManager is Ownable, EIP712 {
     error Unauthorized();
     error InvalidSignature();
     error SignatureExpired();
+    error SignatureAlreadyUsed();
 
     /// @notice EIP-712 typehash for signed withdraw messages.
     bytes32 public constant SIGNED_WITHDRAW_TYPEHASH =
@@ -37,6 +38,9 @@ contract AdminWithdrawManager is Ownable, EIP712 {
 
     /// @notice Address whose EIP-712 signature authorizes `signedWithdrawToUser` calls.
     address public signer;
+
+    /// @notice Consumed EIP-712 digests for `signedWithdrawToUser` (one authorization, one use).
+    mapping(bytes32 => bool) public usedSignatures;
 
     constructor(
         address _owner,
@@ -92,7 +96,12 @@ contract AdminWithdrawManager is Ownable, EIP712 {
         if (block.timestamp > deadline) revert SignatureExpired();
 
         bytes32 structHash = keccak256(abi.encode(SIGNED_WITHDRAW_TYPEHASH, depositAddress, token, amount, deadline));
-        if (ECDSA.recover(_hashTypedDataV4(structHash), signature) != signer) revert InvalidSignature();
+        bytes32 digest = _hashTypedDataV4(structHash);
+        if (usedSignatures[digest]) revert SignatureAlreadyUsed();
+        if (ECDSA.recover(digest, signature) != signer) revert InvalidSignature();
+        // Consume before the external call so a reentrant success path cannot reuse the same authorization
+        // after the clone is re-funded within the same deadline window.
+        usedSignatures[digest] = true;
 
         address to = abi.decode(params, (WithdrawParams)).user;
         ICounterfactualDeposit(depositAddress).execute(implementation, params, abi.encode(token, to, amount), proof);

--- a/test/evm/foundry/local/AdminWithdrawManager.t.sol
+++ b/test/evm/foundry/local/AdminWithdrawManager.t.sol
@@ -173,6 +173,45 @@ contract AdminWithdrawManagerTest is CounterfactualTestBase {
         );
     }
 
+    function testSignedWithdrawToUserReplayAfterRefund() public {
+        // Drain the full setUp balance so a later mint is unambiguously a re-fund.
+        uint256 amount = 100e6;
+        uint256 deadline = block.timestamp + 3600;
+        bytes memory sig = _signWithdraw(depositAddress, address(token), amount, deadline);
+
+        manager.signedWithdrawToUser(
+            depositAddress,
+            address(withdrawImpl),
+            withdrawParams,
+            address(token),
+            amount,
+            withdrawProof,
+            deadline,
+            sig
+        );
+        assertEq(token.balanceOf(user), amount);
+        assertEq(token.balanceOf(depositAddress), 0);
+
+        // Counterfactual clones can be re-funded; the same signed authorization must not drain again.
+        uint256 refund = 50e6;
+        token.mint(depositAddress, refund);
+
+        vm.expectRevert(AdminWithdrawManager.SignatureAlreadyUsed.selector);
+        manager.signedWithdrawToUser(
+            depositAddress,
+            address(withdrawImpl),
+            withdrawParams,
+            address(token),
+            amount,
+            withdrawProof,
+            deadline,
+            sig
+        );
+
+        assertEq(token.balanceOf(depositAddress), refund);
+        assertEq(token.balanceOf(user), amount);
+    }
+
     // --- Owner functions ---
 
     function testSetDirectWithdrawer() public {


### PR DESCRIPTION
## Summary

- `AdminWithdrawManager.signedWithdrawToUser` verified deadline + signer recovery but never consumed the authorization.
- The same EIP-712 signature could therefore be replayed against a re-funded counterfactual deposit clone until `deadline`.
- This PR records `usedSignatures[digest] = true` after recovery and before the external `execute` call, and reverts with `SignatureAlreadyUsed` on reuse. TYPEHASH is unchanged (one-shot digests; new withdrawals use a new deadline).

## Impact if unsolved

Anyone holding a valid signed-withdraw authorization (or observing one on-chain) can drain subsequent deposits to the same clone for the same `(token, amount)` while the deadline remains open. Recipient stays forced to the leaf `user`, so this is repeated user payout / grief of re-deposited funds rather than theft to an attacker address, but it breaks the one-authorization-one-use expectation of a deadline-bound signed withdraw.

## Test plan

- [x] New `testSignedWithdrawToUserReplayAfterRefund`: drain → re-fund → same sig reverts `SignatureAlreadyUsed`.
- [x] `AdminWithdrawManagerTest` 11/11 pass (`forge test --match-contract AdminWithdrawManagerTest`).

Reported via Elacity CodeRED Amber review.

Made with [Cursor](https://cursor.com)