### PR TITLE
fix: Pass gateway arg to Ethereum_SpokePool in Tron periphery test

### DIFF
--- a/test/evm/foundry/local/Tron_SpokePoolPeriphery.t.sol
+++ b/test/evm/foundry/local/Tron_SpokePoolPeriphery.t.sol
@@ -56,7 +56,12 @@ contract Tron_SpokePoolPeripheryTest is Test {
         multicall3 = new Multicall3();
         periphery = new Tron_SpokePoolPeriphery(permit2, address(multicall3));
 
-        Ethereum_SpokePool impl = new Ethereum_SpokePool(address(weth), FILL_DEADLINE_BUFFER, FILL_DEADLINE_BUFFER);
+        Ethereum_SpokePool impl = new Ethereum_SpokePool(
+            address(weth),
+            FILL_DEADLINE_BUFFER,
+            FILL_DEADLINE_BUFFER,
+            address(0)
+        );
         spokePool = Ethereum_SpokePool(
             payable(new ERC1967Proxy(address(impl), abi.encodeCall(Ethereum_SpokePool.initialize, (0, owner))))
         );


### PR DESCRIPTION
## Problem

`master` has failed to compile since #1502 merged. The only failing check is **Upload EVM artifacts** (`forge build`); `Build TypeScript` and `EVM Tests` then skip because they consume its artifacts. Every PR opened since inherits the failure — e.g. #1523.

```
Error (6160): Wrong argument count for function call: 3 arguments given but expected 4.
  --> test/evm/foundry/local/Tron_SpokePoolPeriphery.t.sol:59:35
```

## Cause

A semantic merge conflict — neither PR was wrong in isolation:

- #1481 (`feat: v5 + Spoke`, merged 2026-08-05) added a fourth `_gateway` parameter to the `Ethereum_SpokePool` constructor.
- #1502 (`improve: add Tron variants for SpokePoolPeriphery and SwapProxy`, merged 2026-08-13) added `Tron_SpokePoolPeriphery.t.sol`, which constructs `Ethereum_SpokePool` with three arguments.

#1502 branched from master at `4d67daed` (2026-07-30), six days before #1481 landed, and was never rebased — its head commit does not contain `b032205a`. Its own CI was fully green against that stale base, so nothing flagged the incompatibility until the merge landed on `master`.

Timeline: `db91f503` green → `50263367` (#1502) red → still red at `ef3feca3`.

## Fix

Pass `address(0)` for the gateway, matching the three other `new Ethereum_SpokePool(...)` call sites in the test suite (`Ethereum_SpokePool.t.sol`, `SpokePoolVerifier.t.sol`, `MultiCallerUpgradeable.t.sol`). One line; no production code touched.

## Verification

- Reproduced the exact error on clean `master` @ `ef3feca3`.
- `forge build` after the fix: compiles clean, zero errors.
- `FOUNDRY_PROFILE=local-test forge test --match-contract Tron_SpokePoolPeriphery`: **4 passed, 0 failed**.
- Prettier-clean under the repo's `.prettierrc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)