### PR TITLE
fix(script): grant DEFAULT_ADMIN_ROLE to intended admin before deployer renounces it

### DIFF
--- a/script/hub-pool/DeployPermissionSplitterProxy.s.sol
+++ b/script/hub-pool/DeployPermissionSplitterProxy.s.sol
@@ -34,8 +34,16 @@ contract DeployPermissionSplitterProxy is Script, Test {
         permissionSplitter.grantRole(PAUSE_ROLE, defaultAdmin);
         // Grant anyone with the pause role the ability to call setPaused.
         permissionSplitter.__setRoleForSelector(PAUSE_SELECTOR, PAUSE_ROLE);
+        // Grant the intended admin the default admin role BEFORE the deployer renounces it. Without this the
+        // proxy is left with zero DEFAULT_ADMIN_ROLE holders, and because _isAllowedToCall resolves any
+        // selector with no explicit role mapping to DEFAULT_ADMIN_ROLE, every admin function except
+        // setPaused (__setTarget, __setRoleForSelector, further grantRole calls, ...) becomes permanently
+        // uncallable — AccessControl provides no way to re-create a role's admin once no holder remains.
+        permissionSplitter.grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin);
         // Revoke the deployer's default admin role.
         permissionSplitter.renounceRole(DEFAULT_ADMIN_ROLE, deployer);
+
+        vm.stopBroadcast();
 
         // Sanity check.
         assertTrue(permissionSplitter.hasRole(PAUSE_ROLE, defaultAdmin));


### PR DESCRIPTION
`DeployPermissionSplitterProxy` granted `defaultAdmin` only `PAUSE_ROLE`, then had the deployer `renounceRole(DEFAULT_ADMIN_ROLE, deployer)` — without ever granting `DEFAULT_ADMIN_ROLE` to `defaultAdmin`. The constructor grants `DEFAULT_ADMIN_ROLE` only to `msg.sender` (the deployer), so the script leaves the proxy with **zero** `DEFAULT_ADMIN_ROLE` holders.

Because `_isAllowedToCall` resolves any selector with no explicit role mapping to `DEFAULT_ADMIN_ROLE`, such a proxy can forward only `setPaused(bool)`; `__setTarget`, `__setRoleForSelector` and further `grantRole` calls are permanently uncallable (OZ AccessControl provides no path to re-create a role's admin once no holder remains). The script's own final `assertTrue(hasRole(DEFAULT_ADMIN_ROLE, defaultAdmin))` is therefore unreachable-true.

Fix: grant `DEFAULT_ADMIN_ROLE` to `defaultAdmin` before the deployer renounces it, and add the missing `vm.stopBroadcast()`.

`forge build` on the script compiles cleanly.

Note: this fixes the script for future deployments; whether any already-deployed PermissionSplitterProxy instance is affected is an operational question to confirm separately.