### PR TITLE
fix: split beacon interface

### DIFF
--- a/contracts/interfaces/ICounterfactualBeacon.sol
+++ b/contracts/interfaces/ICounterfactualBeacon.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
-import { IBeacon } from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
+import { ICounterfactualBeaconBase } from "./ICounterfactualBeaconBase.sol";
 
 /**
  * @title ICounterfactualBeacon
@@ -15,19 +15,7 @@ import { IBeacon } from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
  * @dev `implementation()` is the **counterfactual** implementation (beacon target), not the registry's own.
  * @custom:security-contact bugs@across.to
  */
-interface ICounterfactualBeacon is IBeacon {
-    /// @notice Emitted when the admin sets the global implementation (the beacon target).
-    event ImplementationSet(address indexed implementation);
-
-    /// @notice Emitted when the admin sets the upgrade-tree root.
-    event UpgradeRootSet(bytes32 indexed upgradeRoot);
-
-    // `implementation()` is inherited from `IBeacon` — the canonical implementation every counterfactual
-    // proxy runs (resolved live by each `BeaconProxy`).
-
-    /// @notice Root of the `(proxy, latestRoot)` merkle tree authorizing per-proxy root updates.
-    function upgradeRoot() external view returns (bytes32);
-
+interface ICounterfactualBeacon is ICounterfactualBeaconBase {
     // --- Chain-specific config (immutable; read by leaf implementations under delegatecall) ---
 
     /// @notice Off-chain signer that authorizes runtime execution fees for every leaf implementation.

--- a/contracts/interfaces/ICounterfactualBeaconBase.sol
+++ b/contracts/interfaces/ICounterfactualBeaconBase.sol
@@ -9,11 +9,10 @@ import { IBeacon } from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
  *         resolves, and the `upgradeRoot()` authorizing best-effort per-proxy root updates. This is what
  *         `CounterfactualBeaconBase` implements and all a consumer of the beacon-as-beacon needs; the
  *         chain-specific configuration lives in a config interface extending this one
- *         (`ICounterfactualBeacon` here; the Across V5 vertical declares its own in `contracts-v5`).
+ *         (`ICounterfactualBeacon` for this repo's beacon).
  * @dev Split out from `ICounterfactualBeacon` deliberately: `CounterfactualBeaconBase` is pure registry
  *      logic and should not inherit an obligation to expose config getters it does not own. Keeping them
- *      apart is also what lets a config surface be declared independently — including out-of-repo — without
- *      dragging this repo's v4 getter set along.
+ *      apart is also what lets a config surface be declared independently of this repo's v4 getter set.
  * @custom:security-contact bugs@across.to
  */
 interface ICounterfactualBeaconBase is IBeacon {

--- a/contracts/interfaces/ICounterfactualBeaconBase.sol
+++ b/contracts/interfaces/ICounterfactualBeaconBase.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import { IBeacon } from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
+
+/**
+ * @title ICounterfactualBeaconBase
+ * @notice The registry/beacon's own surface: the `implementation()` every counterfactual `BeaconProxy`
+ *         resolves, and the `upgradeRoot()` authorizing best-effort per-proxy root updates. This is what
+ *         `CounterfactualBeaconBase` implements and all a consumer of the beacon-as-beacon needs; the
+ *         chain-specific configuration lives in a config interface extending this one
+ *         (`ICounterfactualBeacon` here; the Across V5 vertical declares its own in `contracts-v5`).
+ * @dev Split out from `ICounterfactualBeacon` deliberately: `CounterfactualBeaconBase` is pure registry
+ *      logic and should not inherit an obligation to expose config getters it does not own. Keeping them
+ *      apart is also what lets a config surface be declared independently — including out-of-repo — without
+ *      dragging this repo's v4 getter set along.
+ * @custom:security-contact bugs@across.to
+ */
+interface ICounterfactualBeaconBase is IBeacon {
+    /// @notice Emitted when the admin sets the global implementation (the beacon target).
+    event ImplementationSet(address indexed implementation);
+
+    /// @notice Emitted when the admin sets the upgrade-tree root.
+    event UpgradeRootSet(bytes32 indexed upgradeRoot);
+
+    // `implementation()` is inherited from `IBeacon` — the canonical implementation every counterfactual
+    // proxy runs (resolved live by each `BeaconProxy`).
+
+    /// @notice Root of the `(proxy, latestRoot)` merkle tree authorizing per-proxy root updates.
+    function upgradeRoot() external view returns (bytes32);
+}

--- a/contracts/interfaces/ICounterfactualDeposit.sol
+++ b/contracts/interfaces/ICounterfactualDeposit.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
+import { ICounterfactualBeaconBase } from "./ICounterfactualBeaconBase.sol";
+
 /**
  * @title ICounterfactualDeposit
  * @notice Interface for the merkle-dispatched counterfactual deposit clone.
@@ -9,6 +11,24 @@ pragma solidity ^0.8.0;
 interface ICounterfactualDeposit {
     /// @dev Merkle proof verification failed.
     error InvalidProof();
+
+    /// @dev Merkle proof against the beacon's `(proxy, latestRoot)` upgrade tree failed.
+    error InvalidUpgradeProof();
+
+    /// @dev New root equals the current `activeRoot` (no-op).
+    error RootUnchanged();
+
+    /// @notice Emitted when `activeRoot` is updated via the beacon's upgrade tree.
+    event RootUpdated(bytes32 newRoot);
+
+    /// @notice The per-chain registry/beacon this proxy resolves its implementation from, and the source
+    ///         of the `upgradeRoot` that `updateRoot` proves against.
+    /// @dev Typed to the registry surface only — the dispatcher reads no chain config, so this is
+    ///      `ICounterfactualBeaconBase` rather than a config interface.
+    function BEACON() external view returns (ICounterfactualBeaconBase);
+
+    /// @notice The merkle root authorizing this proxy's deposit routes.
+    function activeRoot() external view returns (bytes32);
 
     /**
      * @notice Execute an implementation by proving its inclusion in the clone's merkle tree.
@@ -44,4 +64,14 @@ interface ICounterfactualDeposit {
         bytes calldata submitterData,
         bytes32[] calldata executeProof
     ) external payable;
+
+    /**
+     * @notice Update `activeRoot` to `newRoot`, proving `(address(this), newRoot)` is in the beacon's
+     *         upgrade tree.
+     * @dev Permissionless. Root updates are best-effort — a proxy keeps its `activeRoot` until someone
+     *      updates it; there is no on-chain version or min-version gate.
+     * @param newRoot The root to bring the proxy to.
+     * @param proof Merkle proof for the (proxy, newRoot) leaf in the beacon's upgrade tree.
+     */
+    function updateRoot(bytes32 newRoot, bytes32[] calldata proof) external;
 }

--- a/contracts/interfaces/ICounterfactualDepositFactory.sol
+++ b/contracts/interfaces/ICounterfactualDepositFactory.sol
@@ -3,80 +3,59 @@ pragma solidity ^0.8.0;
 
 /**
  * @title ICounterfactualDepositFactory
- * @notice Interface for the generic counterfactual deposit factory
- * @dev This factory creates reusable deposit addresses via CREATE2. It is bridge-agnostic:
- *      each implementation defines its own immutables struct, and the factory stores only the hash.
+ * @notice The deterministic deployer for counterfactual `BeaconProxy` instances. A proxy's address is
+ *         `f(salt, initialRoot)`, because the `initialize(initialRoot)` call data sits in the proxy's init
+ *         code — so a depositor can be quoted an address before anything is deployed, and the proxy can be
+ *         created later (or never, if funds are swept by another route).
+ * @dev Implemented by `CounterfactualDepositFactory`. Cross-chain address parity requires the factory and
+ *      the beacon to sit at identical addresses on every chain, and the caller to reuse the same `salt`;
+ *      `salt = 0` is the canonical choice, giving one address per `initialRoot`. Chain-specific variants
+ *      (e.g. `CounterfactualDepositFactoryTron`, for Tron's 0x41 CREATE2 prefix) override prediction only.
  * @custom:security-contact bugs@across.to
  */
 interface ICounterfactualDepositFactory {
-    /// @notice Emitted when a new clone is deployed.
-    event DepositAddressCreated(
-        address indexed depositAddress,
-        address indexed counterfactualDepositImplementation,
-        bytes32 indexed paramsHash,
-        bytes32 salt
-    );
+    /// @notice Emitted when a counterfactual proxy is deployed.
+    event CounterfactualDeployed(address indexed counterfactual, bytes32 initialRoot);
+
+    /// @notice The beacon (the `CounterfactualBeacon`) every deployed proxy points at.
+    function BEACON() external view returns (address);
 
     /**
-     * @notice Predicts the deterministic address of a clone before deployment.
-     * @param counterfactualDepositImplementation Implementation contract address.
-     * @param paramsHash keccak256 hash of the ABI-encoded route parameters.
-     * @param salt Unique salt for address generation.
-     * @return Predicted address.
+     * @notice Predict the proxy address for a given `salt` and `initialRoot`, deployed or not.
+     * @param salt CREATE2 salt; `0` for the canonical address of this `initialRoot`.
+     * @param initialRoot The proxy's initial route tree, bound into its address via the init code.
+     * @return The counterfactual address.
      */
-    function predictDepositAddress(
-        address counterfactualDepositImplementation,
-        bytes32 paramsHash,
-        bytes32 salt
-    ) external view returns (address);
+    function predictAddress(bytes32 salt, bytes32 initialRoot) external view returns (address);
 
     /**
-     * @notice Deploys a counterfactual deposit clone via CREATE2.
-     * @param counterfactualDepositImplementation Implementation contract address.
-     * @param paramsHash keccak256 hash of the ABI-encoded route parameters.
-     * @param salt Unique salt for address generation.
-     * @return depositAddress Address of deployed clone.
+     * @notice Deploy the proxy for `salt` and `initialRoot`, already initialized and resolving its
+     *         implementation live from the beacon. Reverts if it is already deployed.
+     * @return counterfactual The deployed proxy address.
      */
-    function deploy(
-        address counterfactualDepositImplementation,
-        bytes32 paramsHash,
-        bytes32 salt
-    ) external returns (address depositAddress);
+    function deploy(bytes32 salt, bytes32 initialRoot) external returns (address counterfactual);
 
     /**
-     * @notice Forwards calldata to a deployed clone.
-     * @param depositAddress Address of the deployed clone.
-     * @param executeCalldata Calldata to forward (e.g. abi.encodeCall of executeDeposit).
-     */
-    function execute(address depositAddress, bytes calldata executeCalldata) external payable;
-
-    /**
-     * @notice Deploys and executes a deposit in one transaction.
-     * @param counterfactualDepositImplementation Implementation contract address.
-     * @param paramsHash keccak256 hash of the ABI-encoded route parameters.
-     * @param salt Unique salt for address generation.
-     * @param executeCalldata Calldata to forward to the clone.
-     * @return depositAddress Address of deployed clone.
+     * @notice Deploy the proxy, then forward `executeCalldata` to it. Reverts if already deployed.
+     * @dev Any `msg.value` is forwarded with the call; a revert in the proxy is bubbled up verbatim.
+     * @param executeCalldata Calldata for the proxy (e.g. `abi.encodeCall(ICounterfactualDeposit.execute, …)`).
+     * @return counterfactual The deployed proxy address.
      */
     function deployAndExecute(
-        address counterfactualDepositImplementation,
-        bytes32 paramsHash,
         bytes32 salt,
+        bytes32 initialRoot,
         bytes calldata executeCalldata
-    ) external payable returns (address depositAddress);
+    ) external payable returns (address counterfactual);
 
     /**
-     * @notice Deploys (if needed) and executes a deposit in one transaction.
-     * @param counterfactualDepositImplementation Implementation contract address.
-     * @param paramsHash keccak256 hash of the ABI-encoded route parameters.
-     * @param salt Unique salt for address generation.
-     * @param executeCalldata Calldata to forward to the clone.
-     * @return depositAddress Address of deployed clone.
+     * @notice Deploy the proxy if it does not exist yet, then forward `executeCalldata` to it. Idempotent
+     *         in the deployment step, so this is the safe entry point when a proxy may already be live.
+     * @param executeCalldata Calldata for the proxy (e.g. `abi.encodeCall(ICounterfactualDeposit.execute, …)`).
+     * @return counterfactual The proxy address, newly deployed or pre-existing.
      */
     function deployIfNeededAndExecute(
-        address counterfactualDepositImplementation,
-        bytes32 paramsHash,
         bytes32 salt,
+        bytes32 initialRoot,
         bytes calldata executeCalldata
-    ) external payable returns (address depositAddress);
+    ) external payable returns (address counterfactual);
 }

--- a/contracts/periphery/counterfactual/CounterfactualBeacon.sol
+++ b/contracts/periphery/counterfactual/CounterfactualBeacon.sol
@@ -66,7 +66,7 @@ struct CounterfactualChainConfig {
  *      configuration change and is **not subject to audit** — only changes to the base's *logic* are audited.
  * @custom:security-contact bugs@across.to
  */
-contract CounterfactualBeacon is CounterfactualBeaconBase {
+contract CounterfactualBeacon is CounterfactualBeaconBase, ICounterfactualBeacon {
     /// @inheritdoc ICounterfactualBeacon
     address public immutable signer;
     /// @inheritdoc ICounterfactualBeacon

--- a/contracts/periphery/counterfactual/CounterfactualBeaconBase.sol
+++ b/contracts/periphery/counterfactual/CounterfactualBeaconBase.sol
@@ -5,7 +5,7 @@ import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/I
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { IBeacon } from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
-import { ICounterfactualBeacon } from "../../interfaces/ICounterfactualBeacon.sol";
+import { ICounterfactualBeaconBase } from "../../interfaces/ICounterfactualBeaconBase.sol";
 
 /// @dev Minimal view used to verify a candidate beacon target is bound to this beacon — every
 ///      counterfactual implementation embeds its beacon as the immutable `BEACON` (for `updateRoot`).
@@ -21,15 +21,16 @@ interface IBeaconTarget {
  *         lives in the derived `CounterfactualBeacon` as immutables. Splitting it out keeps the audit
  *         boundary clean: this base is the reviewable logic; a config-only change is a new derived contract
  *         that touches no logic here (see `CounterfactualBeacon`).
- * @dev Abstract — the config getters declared in `ICounterfactualBeacon` are implemented by the derived
- *      contract's immutables. A UUPS proxy, so the registry address is permanent (anchoring every
+ * @dev Abstract — the config getters are declared by whichever config interface the derived contract
+ *      implements (`ICounterfactualBeacon` here) and satisfied by its immutables.
+ *      A UUPS proxy, so the registry address is permanent (anchoring every
  *      `BeaconProxy`) while logic/config evolve. `Ownable2Step` admin (no timelock) — it can retarget every
  *      proxy instantly, so use a trusted multisig. `implementation()` is the beacon target, not the
  *      registry's own UUPS implementation.
  * @custom:security-contact bugs@across.to
  */
 abstract contract CounterfactualBeaconBase is
-    ICounterfactualBeacon,
+    ICounterfactualBeaconBase,
     Initializable,
     UUPSUpgradeable,
     Ownable2StepUpgradeable
@@ -72,7 +73,7 @@ abstract contract CounterfactualBeaconBase is
         return _getStorage().implementation;
     }
 
-    /// @inheritdoc ICounterfactualBeacon
+    /// @inheritdoc ICounterfactualBeaconBase
     function upgradeRoot() external view returns (bytes32) {
         return _getStorage().upgradeRoot;
     }

--- a/contracts/periphery/counterfactual/CounterfactualBeaconBase.sol
+++ b/contracts/periphery/counterfactual/CounterfactualBeaconBase.sol
@@ -18,15 +18,14 @@ interface IBeaconTarget {
  * @notice The **logic** of the counterfactual registry/beacon: the mutable `implementation` (beacon target)
  *         every proxy runs, the `upgradeRoot` authorizing per-proxy root updates, UUPS upgradeability and the
  *         `Ownable2Step` admin. The chain-specific configuration (endpoints, tokens, fee signer, fee caps)
- *         lives in the derived `CounterfactualBeacon` as immutables. Splitting it out keeps the audit
- *         boundary clean: this base is the reviewable logic; a config-only change is a new derived contract
- *         that touches no logic here (see `CounterfactualBeacon`).
+ *         lives in a derived contract as immutables. Splitting it out keeps the audit boundary clean: this
+ *         base is the reviewable logic; a config-only change is a new derived contract that touches no logic
+ *         here (see `CounterfactualBeacon`).
  * @dev Abstract — the config getters are declared by whichever config interface the derived contract
- *      implements (`ICounterfactualBeacon` here) and satisfied by its immutables.
- *      A UUPS proxy, so the registry address is permanent (anchoring every
- *      `BeaconProxy`) while logic/config evolve. `Ownable2Step` admin (no timelock) — it can retarget every
- *      proxy instantly, so use a trusted multisig. `implementation()` is the beacon target, not the
- *      registry's own UUPS implementation.
+ *      implements (`ICounterfactualBeacon` for this repo's beacon) and satisfied by its immutables. A UUPS
+ *      proxy, so the registry address is permanent (anchoring every `BeaconProxy`) while logic/config
+ *      evolve. `Ownable2Step` admin (no timelock) — it can retarget every proxy instantly, so use a trusted
+ *      multisig. `implementation()` is the beacon target, not the registry's own UUPS implementation.
  * @custom:security-contact bugs@across.to
  */
 abstract contract CounterfactualBeaconBase is

--- a/contracts/periphery/counterfactual/CounterfactualDeposit.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDeposit.sol
@@ -42,8 +42,9 @@ contract CounterfactualDeposit is Initializable, ICounterfactualDeposit {
     // keccak256(abi.encode(uint256(keccak256("across.counterfactual.upgradeable.storage")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant STORAGE_LOCATION = 0x5b89d334b964a560e5498fb6b9c95b4213116f116bbd1e59c9c85ba952217700;
 
-    /// @notice The `CounterfactualBeacon` — the beacon every counterfactual `BeaconProxy` resolves its
-    ///         implementation from, and the source of the `upgradeRoot` used by `updateRoot`.
+    /// @notice The per-chain registry/beacon every counterfactual `BeaconProxy` resolves its implementation
+    ///         from, and the source of the `upgradeRoot` used by `updateRoot`. Typed to the registry surface
+    ///         only — the dispatcher reads no chain config.
     ICounterfactualBeaconBase public immutable BEACON;
 
     /// @notice Emitted when `activeRoot` is updated via the upgrade tree.

--- a/contracts/periphery/counterfactual/CounterfactualDeposit.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDeposit.sol
@@ -42,18 +42,8 @@ contract CounterfactualDeposit is Initializable, ICounterfactualDeposit {
     // keccak256(abi.encode(uint256(keccak256("across.counterfactual.upgradeable.storage")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant STORAGE_LOCATION = 0x5b89d334b964a560e5498fb6b9c95b4213116f116bbd1e59c9c85ba952217700;
 
-    /// @notice The per-chain registry/beacon every counterfactual `BeaconProxy` resolves its implementation
-    ///         from, and the source of the `upgradeRoot` used by `updateRoot`. Typed to the registry surface
-    ///         only — the dispatcher reads no chain config.
+    /// @inheritdoc ICounterfactualDeposit
     ICounterfactualBeaconBase public immutable BEACON;
-
-    /// @notice Emitted when `activeRoot` is updated via the upgrade tree.
-    event RootUpdated(bytes32 newRoot);
-
-    /// @dev Merkle proof against the registry's `(proxy, latestRoot)` tree failed.
-    error InvalidUpgradeProof();
-    /// @dev New root equals the current `activeRoot` (no-op).
-    error RootUnchanged();
 
     constructor(ICounterfactualBeaconBase beacon) {
         BEACON = beacon;
@@ -70,7 +60,7 @@ contract CounterfactualDeposit is Initializable, ICounterfactualDeposit {
     /// @dev Accept native value sent to the proxy (deposits before/after deployment, refunds).
     receive() external payable {}
 
-    /// @notice The merkle root authorizing this proxy's deposit routes.
+    /// @inheritdoc ICounterfactualDeposit
     function activeRoot() public view returns (bytes32) {
         return _getStorage().activeRoot;
     }
@@ -100,8 +90,7 @@ contract CounterfactualDeposit is Initializable, ICounterfactualDeposit {
         _execute(implementation, params, submitterData, executeProof);
     }
 
-    /// @notice Update `activeRoot`, proving `(address(this), newRoot)` is in the registry's upgrade tree.
-    /// @dev Permissionless. Root updates are best-effort — a proxy keeps its `activeRoot` until updated.
+    /// @inheritdoc ICounterfactualDeposit
     function updateRoot(bytes32 newRoot, bytes32[] calldata proof) external {
         _updateRoot(newRoot, proof);
     }

--- a/contracts/periphery/counterfactual/CounterfactualDeposit.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDeposit.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { MerkleProof } from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
-import { ICounterfactualBeacon } from "../../interfaces/ICounterfactualBeacon.sol";
+import { ICounterfactualBeaconBase } from "../../interfaces/ICounterfactualBeaconBase.sol";
 import { ICounterfactualDeposit } from "../../interfaces/ICounterfactualDeposit.sol";
 import { ICounterfactualImplementation } from "../../interfaces/ICounterfactualImplementation.sol";
 
@@ -44,7 +44,7 @@ contract CounterfactualDeposit is Initializable, ICounterfactualDeposit {
 
     /// @notice The `CounterfactualBeacon` — the beacon every counterfactual `BeaconProxy` resolves its
     ///         implementation from, and the source of the `upgradeRoot` used by `updateRoot`.
-    ICounterfactualBeacon public immutable BEACON;
+    ICounterfactualBeaconBase public immutable BEACON;
 
     /// @notice Emitted when `activeRoot` is updated via the upgrade tree.
     event RootUpdated(bytes32 newRoot);
@@ -54,7 +54,7 @@ contract CounterfactualDeposit is Initializable, ICounterfactualDeposit {
     /// @dev New root equals the current `activeRoot` (no-op).
     error RootUnchanged();
 
-    constructor(ICounterfactualBeacon beacon) {
+    constructor(ICounterfactualBeaconBase beacon) {
         BEACON = beacon;
         _disableInitializers();
     }

--- a/contracts/periphery/counterfactual/CounterfactualDepositCCTP.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDepositCCTP.sol
@@ -6,6 +6,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import { SponsoredCCTPInterface } from "../../interfaces/SponsoredCCTPInterface.sol";
+import { ICounterfactualBeacon } from "../../interfaces/ICounterfactualBeacon.sol";
 import { ICounterfactualImplementation } from "../../interfaces/ICounterfactualImplementation.sol";
 import { CounterfactualImplementationBase } from "./CounterfactualImplementationBase.sol";
 import { BPS_SCALAR } from "./CounterfactualConstants.sol";
@@ -104,8 +105,8 @@ contract CounterfactualDepositCCTP is CounterfactualImplementationBase, EIP712 {
         if (submitterData.executionFee > _resolveBeaconUint(routeParams.maxExecutionFeeGetter))
             revert MaxExecutionFee();
 
-        address srcPeriphery = _requireConfigured(_beacon().cctpSrcPeriphery());
-        address inputToken = _requireConfigured(_beacon().usdc());
+        address srcPeriphery = _requireConfigured(_configBeacon().cctpSrcPeriphery());
+        address inputToken = _requireConfigured(_configBeacon().usdc());
 
         // Fee paid before the periphery call (load-bearing): the local signature binds the route and
         // (nonce, fee, deadline) but not `amount`, so amount-replay protection is the periphery's nonce
@@ -128,6 +129,11 @@ contract CounterfactualDepositCCTP is CounterfactualImplementationBase, EIP712 {
         );
     }
 
+    /// @dev The beacon, viewed through this repo's config surface.
+    function _configBeacon() private view returns (ICounterfactualBeacon) {
+        return ICounterfactualBeacon(_beacon());
+    }
+
     function _verifySignature(bytes32 routeParamsHash, CCTPSubmitterData memory submitterData) private view {
         if (block.timestamp > submitterData.signatureDeadline) revert SignatureExpired();
         bytes32 structHash = keccak256(
@@ -139,8 +145,10 @@ contract CounterfactualDepositCCTP is CounterfactualImplementationBase, EIP712 {
                 submitterData.signatureDeadline
             )
         );
-        if (ECDSA.recover(_hashTypedDataV4(structHash), submitterData.counterfactualSignature) != _beacon().signer())
-            revert InvalidSignature();
+        if (
+            ECDSA.recover(_hashTypedDataV4(structHash), submitterData.counterfactualSignature) !=
+            _configBeacon().signer()
+        ) revert InvalidSignature();
     }
 
     /// @notice Calls `depositForBurn` on the SponsoredCCTPSrcPeriphery with the constructed quote.
@@ -158,7 +166,7 @@ contract CounterfactualDepositCCTP is CounterfactualImplementationBase, EIP712 {
     ) private {
         ISponsoredCCTPSrcPeriphery(srcPeriphery).depositForBurn(
             SponsoredCCTPInterface.SponsoredCCTPQuote({
-                sourceDomain: _beacon().cctpSourceDomain(),
+                sourceDomain: _configBeacon().cctpSourceDomain(),
                 destinationDomain: routeParams.destinationDomain,
                 mintRecipient: routeParams.mintRecipient,
                 amount: depositAmount,

--- a/contracts/periphery/counterfactual/CounterfactualDepositCCTP.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDepositCCTP.sol
@@ -105,8 +105,9 @@ contract CounterfactualDepositCCTP is CounterfactualImplementationBase, EIP712 {
         if (submitterData.executionFee > _resolveBeaconUint(routeParams.maxExecutionFeeGetter))
             revert MaxExecutionFee();
 
-        address srcPeriphery = _requireConfigured(_configBeacon().cctpSrcPeriphery());
-        address inputToken = _requireConfigured(_configBeacon().usdc());
+        ICounterfactualBeacon beacon = ICounterfactualBeacon(_beacon());
+        address srcPeriphery = _requireConfigured(beacon.cctpSrcPeriphery());
+        address inputToken = _requireConfigured(beacon.usdc());
 
         // Fee paid before the periphery call (load-bearing): the local signature binds the route and
         // (nonce, fee, deadline) but not `amount`, so amount-replay protection is the periphery's nonce
@@ -129,11 +130,6 @@ contract CounterfactualDepositCCTP is CounterfactualImplementationBase, EIP712 {
         );
     }
 
-    /// @dev The beacon, viewed through this repo's config surface.
-    function _configBeacon() private view returns (ICounterfactualBeacon) {
-        return ICounterfactualBeacon(_beacon());
-    }
-
     function _verifySignature(bytes32 routeParamsHash, CCTPSubmitterData memory submitterData) private view {
         if (block.timestamp > submitterData.signatureDeadline) revert SignatureExpired();
         bytes32 structHash = keccak256(
@@ -147,7 +143,7 @@ contract CounterfactualDepositCCTP is CounterfactualImplementationBase, EIP712 {
         );
         if (
             ECDSA.recover(_hashTypedDataV4(structHash), submitterData.counterfactualSignature) !=
-            _configBeacon().signer()
+            ICounterfactualBeacon(_beacon()).signer()
         ) revert InvalidSignature();
     }
 
@@ -166,7 +162,7 @@ contract CounterfactualDepositCCTP is CounterfactualImplementationBase, EIP712 {
     ) private {
         ISponsoredCCTPSrcPeriphery(srcPeriphery).depositForBurn(
             SponsoredCCTPInterface.SponsoredCCTPQuote({
-                sourceDomain: _configBeacon().cctpSourceDomain(),
+                sourceDomain: ICounterfactualBeacon(_beacon()).cctpSourceDomain(),
                 destinationDomain: routeParams.destinationDomain,
                 mintRecipient: routeParams.mintRecipient,
                 amount: depositAmount,

--- a/contracts/periphery/counterfactual/CounterfactualDepositFactory.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDepositFactory.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import { CounterfactualDeposit } from "./CounterfactualDeposit.sol";
+import { ICounterfactualDepositFactory } from "../../interfaces/ICounterfactualDepositFactory.sol";
 
 /**
  * @title CounterfactualDepositFactory
@@ -20,12 +21,9 @@ import { CounterfactualDeposit } from "./CounterfactualDeposit.sol";
  *      variants (e.g. Tron's 0x41 CREATE2 prefix) can override prediction.
  * @custom:security-contact bugs@across.to
  */
-contract CounterfactualDepositFactory {
-    /// @notice The beacon (the `CounterfactualBeacon`) every deployed proxy points at.
+contract CounterfactualDepositFactory is ICounterfactualDepositFactory {
+    /// @inheritdoc ICounterfactualDepositFactory
     address public immutable BEACON;
-
-    /// @notice Emitted when a counterfactual proxy is deployed.
-    event CounterfactualDeployed(address indexed counterfactual, bytes32 initialRoot);
 
     constructor(address beacon) {
         BEACON = beacon;

--- a/contracts/periphery/counterfactual/CounterfactualDepositOFT.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDepositOFT.sol
@@ -139,11 +139,6 @@ contract CounterfactualDepositOFT is CounterfactualImplementationBase, EIP712 {
         );
     }
 
-    /// @dev The beacon, viewed through this repo's config surface.
-    function _configBeacon() private view returns (ICounterfactualBeacon) {
-        return ICounterfactualBeacon(_beacon());
-    }
-
     function _verifySignature(bytes32 routeParamsHash, OFTSubmitterData memory submitterData) private view {
         if (block.timestamp > submitterData.signatureDeadline) revert SignatureExpired();
         bytes32 structHash = keccak256(
@@ -157,7 +152,7 @@ contract CounterfactualDepositOFT is CounterfactualImplementationBase, EIP712 {
         );
         if (
             ECDSA.recover(_hashTypedDataV4(structHash), submitterData.counterfactualSignature) !=
-            _configBeacon().signer()
+            ICounterfactualBeacon(_beacon()).signer()
         ) revert InvalidSignature();
     }
 
@@ -175,7 +170,7 @@ contract CounterfactualDepositOFT is CounterfactualImplementationBase, EIP712 {
         ISponsoredOFTSrcPeriphery(oftSrcPeriphery).deposit{ value: msg.value }(
             SponsoredOFTInterface.Quote({
                 signedParams: SponsoredOFTInterface.SignedQuoteParams({
-                    srcEid: _configBeacon().oftSrcEid(),
+                    srcEid: ICounterfactualBeacon(_beacon()).oftSrcEid(),
                     dstEid: routeParams.dstEid,
                     destinationHandler: routeParams.destinationHandler,
                     amountLD: depositAmount,

--- a/contracts/periphery/counterfactual/CounterfactualDepositOFT.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDepositOFT.sol
@@ -6,6 +6,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import { SponsoredOFTInterface } from "../../interfaces/SponsoredOFTInterface.sol";
+import { ICounterfactualBeacon } from "../../interfaces/ICounterfactualBeacon.sol";
 import { ICounterfactualImplementation } from "../../interfaces/ICounterfactualImplementation.sol";
 import { CounterfactualImplementationBase } from "./CounterfactualImplementationBase.sol";
 
@@ -138,6 +139,11 @@ contract CounterfactualDepositOFT is CounterfactualImplementationBase, EIP712 {
         );
     }
 
+    /// @dev The beacon, viewed through this repo's config surface.
+    function _configBeacon() private view returns (ICounterfactualBeacon) {
+        return ICounterfactualBeacon(_beacon());
+    }
+
     function _verifySignature(bytes32 routeParamsHash, OFTSubmitterData memory submitterData) private view {
         if (block.timestamp > submitterData.signatureDeadline) revert SignatureExpired();
         bytes32 structHash = keccak256(
@@ -149,8 +155,10 @@ contract CounterfactualDepositOFT is CounterfactualImplementationBase, EIP712 {
                 submitterData.signatureDeadline
             )
         );
-        if (ECDSA.recover(_hashTypedDataV4(structHash), submitterData.counterfactualSignature) != _beacon().signer())
-            revert InvalidSignature();
+        if (
+            ECDSA.recover(_hashTypedDataV4(structHash), submitterData.counterfactualSignature) !=
+            _configBeacon().signer()
+        ) revert InvalidSignature();
     }
 
     /// @notice Calls `deposit` on the SponsoredOFTSrcPeriphery with the constructed quote.
@@ -167,7 +175,7 @@ contract CounterfactualDepositOFT is CounterfactualImplementationBase, EIP712 {
         ISponsoredOFTSrcPeriphery(oftSrcPeriphery).deposit{ value: msg.value }(
             SponsoredOFTInterface.Quote({
                 signedParams: SponsoredOFTInterface.SignedQuoteParams({
-                    srcEid: _beacon().oftSrcEid(),
+                    srcEid: _configBeacon().oftSrcEid(),
                     dstEid: routeParams.dstEid,
                     destinationHandler: routeParams.destinationHandler,
                     amountLD: depositAmount,

--- a/contracts/periphery/counterfactual/CounterfactualDepositSpokePool.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDepositSpokePool.sol
@@ -149,7 +149,7 @@ contract CounterfactualDepositSpokePool is
             _resolveBeaconUint(routeParams.maxExecutionFeeGetter)
         );
 
-        ICounterfactualBeacon beacon = _configBeacon();
+        ICounterfactualBeacon beacon = ICounterfactualBeacon(_beacon());
         address spokePool = _requireConfigured(beacon.spokePool());
 
         // The leaf names a beacon getter; its resolved value decides native (`NATIVE_SENTINEL`) vs ERC-20.
@@ -226,11 +226,6 @@ contract CounterfactualDepositSpokePool is
         if (totalFee > maxFee) revert MaxFee();
     }
 
-    /// @dev The beacon, viewed through this repo's config surface.
-    function _configBeacon() private view returns (ICounterfactualBeacon) {
-        return ICounterfactualBeacon(_beacon());
-    }
-
     function _verifySignature(bytes32 routeParamsHash, SpokePoolSubmitterData memory submitterData) private view {
         bytes32 structHash = keccak256(
             abi.encode(
@@ -248,7 +243,9 @@ contract CounterfactualDepositSpokePool is
                 submitterData.executionFee
             )
         );
-        if (ECDSA.recover(_hashTypedDataV4(structHash), submitterData.signature) != _configBeacon().signer())
-            revert InvalidSignature();
+        if (
+            ECDSA.recover(_hashTypedDataV4(structHash), submitterData.signature) !=
+            ICounterfactualBeacon(_beacon()).signer()
+        ) revert InvalidSignature();
     }
 }

--- a/contracts/periphery/counterfactual/CounterfactualDepositSpokePool.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDepositSpokePool.sol
@@ -149,7 +149,7 @@ contract CounterfactualDepositSpokePool is
             _resolveBeaconUint(routeParams.maxExecutionFeeGetter)
         );
 
-        ICounterfactualBeacon beacon = _beacon();
+        ICounterfactualBeacon beacon = _configBeacon();
         address spokePool = _requireConfigured(beacon.spokePool());
 
         // The leaf names a beacon getter; its resolved value decides native (`NATIVE_SENTINEL`) vs ERC-20.
@@ -226,6 +226,11 @@ contract CounterfactualDepositSpokePool is
         if (totalFee > maxFee) revert MaxFee();
     }
 
+    /// @dev The beacon, viewed through this repo's config surface.
+    function _configBeacon() private view returns (ICounterfactualBeacon) {
+        return ICounterfactualBeacon(_beacon());
+    }
+
     function _verifySignature(bytes32 routeParamsHash, SpokePoolSubmitterData memory submitterData) private view {
         bytes32 structHash = keccak256(
             abi.encode(
@@ -243,7 +248,7 @@ contract CounterfactualDepositSpokePool is
                 submitterData.executionFee
             )
         );
-        if (ECDSA.recover(_hashTypedDataV4(structHash), submitterData.signature) != _beacon().signer())
+        if (ECDSA.recover(_hashTypedDataV4(structHash), submitterData.signature) != _configBeacon().signer())
             revert InvalidSignature();
     }
 }

--- a/contracts/periphery/counterfactual/CounterfactualDepositVanillaCCTP.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDepositVanillaCCTP.sol
@@ -6,6 +6,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import { ITokenMessengerV2 } from "../../external/interfaces/CCTPInterfaces.sol";
+import { ICounterfactualBeacon } from "../../interfaces/ICounterfactualBeacon.sol";
 import { ICounterfactualImplementation } from "../../interfaces/ICounterfactualImplementation.sol";
 import { CounterfactualImplementationBase } from "./CounterfactualImplementationBase.sol";
 import { CounterfactualNonces } from "./CounterfactualNonces.sol";
@@ -121,8 +122,8 @@ contract CounterfactualDepositVanillaCCTP is CounterfactualImplementationBase, C
             (depositAmount * _resolveBeaconUint(routeParams.cctpMaxFeeBpsGetter)) / BPS_SCALAR
         ) revert MaxCctpFee();
 
-        ITokenMessengerV2 tokenMessenger = ITokenMessengerV2(_requireConfigured(_beacon().cctpTokenMessenger()));
-        address inputToken = _requireConfigured(_beacon().usdc());
+        ITokenMessengerV2 tokenMessenger = ITokenMessengerV2(_requireConfigured(_configBeacon().cctpTokenMessenger()));
+        address inputToken = _requireConfigured(_configBeacon().usdc());
 
         if (submitterData.executionFee > 0)
             IERC20(inputToken).safeTransfer(submitterData.executionFeeRecipient, submitterData.executionFee);
@@ -162,6 +163,11 @@ contract CounterfactualDepositVanillaCCTP is CounterfactualImplementationBase, C
         );
     }
 
+    /// @dev The beacon, viewed through this repo's config surface.
+    function _configBeacon() private view returns (ICounterfactualBeacon) {
+        return ICounterfactualBeacon(_beacon());
+    }
+
     function _verifySignature(bytes32 routeParamsHash, VanillaCCTPSubmitterData memory submitterData) private view {
         if (block.timestamp > submitterData.signatureDeadline) revert SignatureExpired();
         bytes32 structHash = keccak256(
@@ -176,7 +182,9 @@ contract CounterfactualDepositVanillaCCTP is CounterfactualImplementationBase, C
                 submitterData.signatureDeadline
             )
         );
-        if (ECDSA.recover(_hashTypedDataV4(structHash), submitterData.counterfactualSignature) != _beacon().signer())
-            revert InvalidSignature();
+        if (
+            ECDSA.recover(_hashTypedDataV4(structHash), submitterData.counterfactualSignature) !=
+            _configBeacon().signer()
+        ) revert InvalidSignature();
     }
 }

--- a/contracts/periphery/counterfactual/CounterfactualDepositVanillaCCTP.sol
+++ b/contracts/periphery/counterfactual/CounterfactualDepositVanillaCCTP.sol
@@ -122,8 +122,9 @@ contract CounterfactualDepositVanillaCCTP is CounterfactualImplementationBase, C
             (depositAmount * _resolveBeaconUint(routeParams.cctpMaxFeeBpsGetter)) / BPS_SCALAR
         ) revert MaxCctpFee();
 
-        ITokenMessengerV2 tokenMessenger = ITokenMessengerV2(_requireConfigured(_configBeacon().cctpTokenMessenger()));
-        address inputToken = _requireConfigured(_configBeacon().usdc());
+        ICounterfactualBeacon beacon = ICounterfactualBeacon(_beacon());
+        ITokenMessengerV2 tokenMessenger = ITokenMessengerV2(_requireConfigured(beacon.cctpTokenMessenger()));
+        address inputToken = _requireConfigured(beacon.usdc());
 
         if (submitterData.executionFee > 0)
             IERC20(inputToken).safeTransfer(submitterData.executionFeeRecipient, submitterData.executionFee);
@@ -163,11 +164,6 @@ contract CounterfactualDepositVanillaCCTP is CounterfactualImplementationBase, C
         );
     }
 
-    /// @dev The beacon, viewed through this repo's config surface.
-    function _configBeacon() private view returns (ICounterfactualBeacon) {
-        return ICounterfactualBeacon(_beacon());
-    }
-
     function _verifySignature(bytes32 routeParamsHash, VanillaCCTPSubmitterData memory submitterData) private view {
         if (block.timestamp > submitterData.signatureDeadline) revert SignatureExpired();
         bytes32 structHash = keccak256(
@@ -184,7 +180,7 @@ contract CounterfactualDepositVanillaCCTP is CounterfactualImplementationBase, C
         );
         if (
             ECDSA.recover(_hashTypedDataV4(structHash), submitterData.counterfactualSignature) !=
-            _configBeacon().signer()
+            ICounterfactualBeacon(_beacon()).signer()
         ) revert InvalidSignature();
     }
 }

--- a/contracts/periphery/counterfactual/CounterfactualImplementationBase.sol
+++ b/contracts/periphery/counterfactual/CounterfactualImplementationBase.sol
@@ -2,13 +2,14 @@
 pragma solidity ^0.8.0;
 
 import { ERC1967Utils } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
-import { ICounterfactualBeacon } from "../../interfaces/ICounterfactualBeacon.sol";
 import { ICounterfactualImplementation } from "../../interfaces/ICounterfactualImplementation.sol";
 
 /**
  * @title CounterfactualImplementationBase
- * @notice Shared base for leaf implementations: resolves the per-chain `CounterfactualBeacon` to read
- *         chain-specific config (endpoints, fee signer, tokens) at runtime.
+ * @notice Shared base for leaf implementations: resolves the per-chain registry/beacon that leaves read
+ *         chain-specific config (endpoints, fee signer, tokens) from at runtime. Config-agnostic — it
+ *         hands back a plain `address`, so each leaf views the beacon through whichever config interface
+ *         it needs.
  * @dev Leaves run under delegatecall from the `BeaconProxy`, so `address(this)` is the proxy and the beacon
  *      sits in its ERC-1967 beacon slot. Reading config there means a leaf holds **no immutables of its
  *      own** and is byte-identical across chains (one CREATE2 address everywhere).
@@ -20,8 +21,8 @@ abstract contract CounterfactualImplementationBase is ICounterfactualImplementat
     error RouteNotConfigured();
 
     /// @dev The per-chain registry that anchors this proxy (resolved from the ERC-1967 beacon slot).
-    function _beacon() internal view returns (ICounterfactualBeacon) {
-        return ICounterfactualBeacon(ERC1967Utils.getBeacon());
+    function _beacon() internal view returns (address) {
+        return ERC1967Utils.getBeacon();
     }
 
     /// @dev Resolve an address from a no-arg `() -> address` beacon getter named by `getter`'s selector
@@ -29,7 +30,7 @@ abstract contract CounterfactualImplementationBase is ICounterfactualImplementat
     ///      `address(0)`, which callers treat as `RouteNotConfigured`. The selector is merkle-committed (and
     ///      where applicable signature-bound), so trusted; a bad selector can only revert here or downstream.
     function _resolveBeaconAddress(bytes4 getter) internal view returns (address) {
-        (bool ok, bytes memory ret) = address(_beacon()).staticcall(abi.encodeWithSelector(getter));
+        (bool ok, bytes memory ret) = _beacon().staticcall(abi.encodeWithSelector(getter));
         if (!ok || ret.length != 32) return address(0);
         return abi.decode(ret, (address));
     }
@@ -38,7 +39,7 @@ abstract contract CounterfactualImplementationBase is ICounterfactualImplementat
     ///      in the leaf, e.g. `beacon.usdcCctpMaxExecutionFee.selector`). Reverts `RouteNotConfigured` if the
     ///      getter doesn't exist; a configured value of 0 is valid and returned as-is. Merkle/signature-bound.
     function _resolveBeaconUint(bytes4 getter) internal view returns (uint256) {
-        (bool ok, bytes memory ret) = address(_beacon()).staticcall(abi.encodeWithSelector(getter));
+        (bool ok, bytes memory ret) = _beacon().staticcall(abi.encodeWithSelector(getter));
         if (!ok || ret.length != 32) revert RouteNotConfigured();
         return abi.decode(ret, (uint256));
     }

--- a/script/counterfactual/DeployCounterfactualBeacon.s.sol
+++ b/script/counterfactual/DeployCounterfactualBeacon.s.sol
@@ -29,7 +29,7 @@ import { CounterfactualBeaconBootstrap } from "../../contracts/periphery/counter
 //      pointing it at the chain-specific impl. A proxy already on a real impl keeps that impl (no upgrade);
 //      the dispatcher wiring in steps 4-5 still runs so an interrupted deploy is completed.
 //      The bootstrap already consumed the initializer slot, so pass empty calldata (no re-init).
-//   4. The dispatcher `new CounterfactualDeposit(ICounterfactualBeacon(proxy))` via CREATE2 (proxy is
+//   4. The dispatcher `new CounterfactualDeposit(ICounterfactualBeaconBase(proxy))` via CREATE2 (proxy is
 //      chain-invariant => dispatcher is same address everywhere). Skipped when already deployed.
 //   5. `setImplementation(dispatcher)` on the proxy so every counterfactual proxy resolves the dispatcher.
 //   6. Optionally `transferOwnership(ownerAndDirectWithdrawer)` (Ownable2Step; new owner accepts out of band).

--- a/test/evm/foundry/local/CounterfactualDeposit.t.sol
+++ b/test/evm/foundry/local/CounterfactualDeposit.t.sol
@@ -325,7 +325,7 @@ contract CounterfactualDepositTest is CounterfactualTestBase {
         bytes32[] memory proof = _setUpgradeTree(proxy, newRoot);
 
         vm.expectEmit(address(proxy));
-        emit CounterfactualDeposit.RootUpdated(newRoot);
+        emit ICounterfactualDeposit.RootUpdated(newRoot);
         CounterfactualDeposit(payable(proxy)).updateRoot(newRoot, proof);
         assertEq(CounterfactualDeposit(payable(proxy)).activeRoot(), newRoot);
     }
@@ -338,7 +338,7 @@ contract CounterfactualDepositTest is CounterfactualTestBase {
         // Prove a root other than the one committed for this proxy.
         bytes32[] memory bad = new bytes32[](1);
         bad[0] = keccak256("garbage");
-        vm.expectRevert(CounterfactualDeposit.InvalidUpgradeProof.selector);
+        vm.expectRevert(ICounterfactualDeposit.InvalidUpgradeProof.selector);
         CounterfactualDeposit(payable(proxy)).updateRoot(keccak256("attacker-root"), bad);
     }
 
@@ -349,7 +349,7 @@ contract CounterfactualDepositTest is CounterfactualTestBase {
         // Upgrade tree authorizes proxyA only; proxyB tries to use A's proof.
         bytes32[] memory proofA = _setUpgradeTree(proxyA, newRoot);
 
-        vm.expectRevert(CounterfactualDeposit.InvalidUpgradeProof.selector);
+        vm.expectRevert(ICounterfactualDeposit.InvalidUpgradeProof.selector);
         CounterfactualDeposit(payable(proxyB)).updateRoot(newRoot, proofA);
     }
 
@@ -361,7 +361,7 @@ contract CounterfactualDepositTest is CounterfactualTestBase {
         address proxy = factory.deploy(bytes32(0), root);
 
         bytes32[] memory proof = _setUpgradeTree(proxy, root); // same as activeRoot
-        vm.expectRevert(CounterfactualDeposit.RootUnchanged.selector);
+        vm.expectRevert(ICounterfactualDeposit.RootUnchanged.selector);
         CounterfactualDeposit(payable(proxy)).updateRoot(root, proof);
     }
 


### PR DESCRIPTION
Splits the beacon interface in two: ICounterfactualBeaconBase now holds just the registry surface (implementation(), upgradeRoot()), and ICounterfactualBeacon extends it with this repo's chain-config getters. 

The base contract, the dispatcher, and CounterfactualImplementationBase now depend only on the registry half, so using the beacon as a beacon no longer drags in the v4 config surface — which is what lets the V5 beacon in contracts-v5 extend the base and declare its own config interface. 

This is a pure refactor with no behavior change: all ten counterfactual contracts compile to bytecode byte-identical to master, so every deployed address is unaffected.

Claude report that bytecode is unchanged:
https://claude.ai/code/artifact/181aaa4e-aa33-4be8-b877-2c12eb72a8bd