### PR TITLE
fix: L02 handle USDC CoreDepositWallet for HyperEVM testnet

### DIFF
--- a/contracts/libraries/HyperCoreLib.sol
+++ b/contracts/libraries/HyperCoreLib.sol
@@ -89,6 +89,7 @@ library HyperCoreLib {
     error MaximumEVMSendAmountTooLarge();
     error TokenNotBridgeable(uint64 erc20CoreIndex);
     error NativeTransferFailed();
+    error UnsupportedChain();
 
     /**
      * @notice Transfer `amountEVM` from HyperEVM to `to` on HyperCore.
@@ -395,16 +396,14 @@ library HyperCoreLib {
     /**
      * @notice Circle's USDC CoreDepositWallet on the current chain.
      * @dev Differs between mainnet and testnet; the mainnet address has no code on testnet, so using it there
-     *      would revert every USDC bridge and account activation.
+     *      would revert every USDC bridge and account activation. Reverts off HyperEVM rather than defaulting.
      * @return The CoreDepositWallet to approve and deposit USDC through
      */
     function usdcCoreDepositWallet() internal view returns (ICoreDepositWallet) {
-        return
-            ICoreDepositWallet(
-                block.chainid == HYPEREVM_TESTNET_CHAIN_ID
-                    ? USDC_CORE_DEPOSIT_WALLET_ADDRESS_TESTNET
-                    : USDC_CORE_DEPOSIT_WALLET_ADDRESS
-            );
+        if (block.chainid == HYPEREVM_CHAIN_ID) return ICoreDepositWallet(USDC_CORE_DEPOSIT_WALLET_ADDRESS);
+        if (block.chainid == HYPEREVM_TESTNET_CHAIN_ID)
+            return ICoreDepositWallet(USDC_CORE_DEPOSIT_WALLET_ADDRESS_TESTNET);
+        revert UnsupportedChain();
     }
 
     /**

--- a/contracts/libraries/HyperCoreLib.sol
+++ b/contracts/libraries/HyperCoreLib.sol
@@ -53,8 +53,9 @@ library HyperCoreLib {
     address public constant TOKEN_INFO_PRECOMPILE_ADDRESS = 0x000000000000000000000000000000000000080C;
     address public constant CORE_WRITER_PRECOMPILE_ADDRESS = 0x3333333333333333333333333333333333333333;
 
-    // USDC
+    // USDC. Circle's CoreDepositWallet is deployed at a different address on mainnet and testnet.
     address public constant USDC_CORE_DEPOSIT_WALLET_ADDRESS = 0x6B9E773128f453f5c2C60935Ee2DE2CBc5390A24;
+    address public constant USDC_CORE_DEPOSIT_WALLET_ADDRESS_TESTNET = 0x0B80659a4076E9E93C7DbE0f10675A16a3e5C206;
     uint64 public constant USDC_CORE_INDEX = 0;
 
     // Native HYPE. Unlike every other token, HYPE bridges through a fixed system address rather than one
@@ -118,15 +119,12 @@ library HyperCoreLib {
         if (_amountEVMToSend != 0) {
             if (erc20CoreIndex == USDC_CORE_INDEX) {
                 // USDC flow takes care of account creation fee for us, we don't need to reduce `_amountEVMToSend`
-                IERC20(erc20EVMAddress).forceApprove(USDC_CORE_DEPOSIT_WALLET_ADDRESS, _amountEVMToSend);
+                ICoreDepositWallet depositWallet = usdcCoreDepositWallet();
+                IERC20(erc20EVMAddress).forceApprove(address(depositWallet), _amountEVMToSend);
                 if (to == address(this)) {
-                    ICoreDepositWallet(USDC_CORE_DEPOSIT_WALLET_ADDRESS).deposit(_amountEVMToSend, destinationDex);
+                    depositWallet.deposit(_amountEVMToSend, destinationDex);
                 } else {
-                    ICoreDepositWallet(USDC_CORE_DEPOSIT_WALLET_ADDRESS).depositFor(
-                        to,
-                        _amountEVMToSend,
-                        destinationDex
-                    );
+                    depositWallet.depositFor(to, _amountEVMToSend, destinationDex);
                 }
             } else {
                 IERC20(erc20EVMAddress).safeTransfer(toSystemAddress(erc20CoreIndex), _amountEVMToSend);
@@ -267,8 +265,9 @@ library HyperCoreLib {
         uint256 amountEVM
     ) internal {
         if (erc20CoreIndex == USDC_CORE_INDEX) {
-            IERC20(erc20EVMAddress).forceApprove(USDC_CORE_DEPOSIT_WALLET_ADDRESS, amountEVM);
-            ICoreDepositWallet(USDC_CORE_DEPOSIT_WALLET_ADDRESS).depositFor(user, amountEVM, CORE_SPOT_DEX_ID);
+            ICoreDepositWallet depositWallet = usdcCoreDepositWallet();
+            IERC20(erc20EVMAddress).forceApprove(address(depositWallet), amountEVM);
+            depositWallet.depositFor(user, amountEVM, CORE_SPOT_DEX_ID);
         } else {
             IERC20(erc20EVMAddress).safeTransfer(toSystemAddress(erc20CoreIndex), amountEVM);
             // Transfer 1 wei to user on HyperCore to activate account
@@ -391,6 +390,21 @@ library HyperCoreLib {
      */
     function hypeCoreIndex() internal view returns (uint32) {
         return block.chainid == HYPEREVM_TESTNET_CHAIN_ID ? HYPE_CORE_INDEX_TESTNET : HYPE_CORE_INDEX;
+    }
+
+    /**
+     * @notice Circle's USDC CoreDepositWallet on the current chain.
+     * @dev Differs between mainnet and testnet; the mainnet address has no code on testnet, so using it there
+     *      would revert every USDC bridge and account activation.
+     * @return The CoreDepositWallet to approve and deposit USDC through
+     */
+    function usdcCoreDepositWallet() internal view returns (ICoreDepositWallet) {
+        return
+            ICoreDepositWallet(
+                block.chainid == HYPEREVM_TESTNET_CHAIN_ID
+                    ? USDC_CORE_DEPOSIT_WALLET_ADDRESS_TESTNET
+                    : USDC_CORE_DEPOSIT_WALLET_ADDRESS
+            );
     }
 
     /**

--- a/test/evm/foundry/local/HyperCoreLib.t.sol
+++ b/test/evm/foundry/local/HyperCoreLib.t.sol
@@ -192,6 +192,13 @@ contract HyperCoreLibTest is HyperCoreMockHelper {
         assertEq(wrapper.usdcCoreDepositWallet(), HyperCoreLib.USDC_CORE_DEPOSIT_WALLET_ADDRESS_TESTNET);
     }
 
+    // Off HyperEVM there is no CoreDepositWallet at all, so resolving one should fail loudly, not default to mainnet
+    function testUsdcCoreDepositWallet_RevertsOffHyperEVM() public {
+        vm.chainId(1);
+        vm.expectRevert(HyperCoreLib.UnsupportedChain.selector);
+        wrapper.usdcCoreDepositWallet();
+    }
+
     function testIsHype() public {
         vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
         assertTrue(wrapper.isHype(HyperCoreLib.HYPE_CORE_INDEX));

--- a/test/evm/foundry/local/HyperCoreLib.t.sol
+++ b/test/evm/foundry/local/HyperCoreLib.t.sol
@@ -24,6 +24,10 @@ contract HyperCoreLibWrapper {
         return HyperCoreLib.hypeCoreIndex();
     }
 
+    function usdcCoreDepositWallet() external view returns (address) {
+        return address(HyperCoreLib.usdcCoreDepositWallet());
+    }
+
     function isHype(uint32 erc20CoreIndex) external view returns (bool) {
         return HyperCoreLib.isHype(erc20CoreIndex);
     }
@@ -176,6 +180,16 @@ contract HyperCoreLibTest is HyperCoreMockHelper {
 
         vm.chainId(HyperCoreLib.HYPEREVM_TESTNET_CHAIN_ID);
         assertEq(wrapper.hypeCoreIndex(), HyperCoreLib.HYPE_CORE_INDEX_TESTNET);
+    }
+
+    // Circle deployed CoreDepositWallet at different addresses on mainnet and testnet; the mainnet one has no
+    // code on testnet, so a single hardcoded address would revert every USDC deposit there
+    function testUsdcCoreDepositWallet_DiffersOnTestnet() public {
+        vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
+        assertEq(wrapper.usdcCoreDepositWallet(), HyperCoreLib.USDC_CORE_DEPOSIT_WALLET_ADDRESS);
+
+        vm.chainId(HyperCoreLib.HYPEREVM_TESTNET_CHAIN_ID);
+        assertEq(wrapper.usdcCoreDepositWallet(), HyperCoreLib.USDC_CORE_DEPOSIT_WALLET_ADDRESS_TESTNET);
     }
 
     function testIsHype() public {


### PR DESCRIPTION
HyperCoreLib treats HyperEVM mainnet (chain ID 999) and testnet (chain ID 998) as distinct networks, and functions such as [hypeCoreIndex](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L387-L394) already select their return value based on block.chainid. [USDC_CORE_DEPOSIT_WALLET_ADDRESS](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L57), used by [transferERC20EVMToCore](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L119-L130) and [activateCoreAccountFromEVM](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L269-L271) whenever erc20CoreIndex == USDC_CORE_INDEX, is instead a single hardcoded constant, 0x6B9E773128f453f5c2C60935Ee2DE2CBc5390A24, equal to Circle's CoreDepositWallet deployment on HyperEVM mainnet. Per [Circle's developer documentation](https://developers.circle.com/cctp/howtos/transfer-usdc-from-hyperevm-to-hypercore), the HyperEVM testnet deployment of CoreDepositWallet is a different address. On HyperEVM testnet, the hardcoded mainnet address has no contract code, so every deposit and depositFor call made through it reverts, making USDC bridging and USDC-funded account activation unavailable on that network. Transaction atomicity prevents any loss of funds.

Consider resolving USDC_CORE_DEPOSIT_WALLET_ADDRESS through a chain-specific helper, mirroring the existing hypeCoreIndex pattern, returning 0x6B9E773128f453f5c2C60935Ee2DE2CBc5390A24 on HYPEREVM_CHAIN_ID, 0x0B80659a4076E9E93C7DbE0f10675A16a3e5C206 on HYPEREVM_TESTNET_CHAIN_ID, and reverting on any other chain.