### PR TITLE
fix: L03 Native HYPE Bridge Helper Silently Loses Unrepresentable Dust

### DIFF
--- a/contracts/libraries/HyperCoreLib.sol
+++ b/contracts/libraries/HyperCoreLib.sol
@@ -62,6 +62,8 @@ library HyperCoreLib {
     address public constant HYPE_SYSTEM_ADDRESS = 0x2222222222222222222222222222222222222222;
     uint32 public constant HYPE_CORE_INDEX = 150;
     uint32 public constant HYPE_CORE_INDEX_TESTNET = 1105;
+    // HYPE has 18 decimals on HyperEVM and 8 on HyperCore, so only EVM amounts aligned to 1e10 wei are representable
+    int8 public constant HYPE_DECIMAL_DIFF = 10;
 
     // HyperEVM chain ids. The precompiles and CoreWriter below only exist on these chains.
     uint256 public constant HYPEREVM_CHAIN_ID = 999;
@@ -205,12 +207,21 @@ library HyperCoreLib {
     }
 
     /**
-     * @notice Bridges `amountEVM` of native HYPE from this address on HyperEVM to this address on HyperCore.
-     * @dev A native transfer to the HYPE system address credits the sender's spot HYPE on Core.
-     * @param amountEVM The amount of native HYPE to transfer, in EVM wei.
+     * @notice Bridges up to `amountEVM` of native HYPE from this address on HyperEVM to this address on HyperCore.
+     * @dev A native transfer to the HYPE system address credits the sender's spot HYPE on Core. Core only credits
+     *      whole multiples of 1e10 wei and silently drops the remainder, so, like the ERC20 path, this rounds the
+     *      amount down before sending and leaves the dust in the calling contract. Sends nothing if the aligned
+     *      amount is zero.
+     * @param amountEVM The maximum amount of native HYPE to transfer, in EVM wei.
+     * @return amountEVMSent The amount actually sent on HyperEVM, in wei
+     * @return amountCoreToReceive The amount credited on Core, in Core units
      */
-    function transferNativeEVMToSelfOnSpot(uint256 amountEVM) internal {
-        (bool success, ) = HYPE_SYSTEM_ADDRESS.call{ value: amountEVM }("");
+    function transferNativeEVMToSelfOnSpot(
+        uint256 amountEVM
+    ) internal returns (uint256 amountEVMSent, uint64 amountCoreToReceive) {
+        (amountEVMSent, amountCoreToReceive) = maximumEVMSendAmountToAmounts(amountEVM, HYPE_DECIMAL_DIFF);
+        if (amountEVMSent == 0) return (0, 0);
+        (bool success, ) = HYPE_SYSTEM_ADDRESS.call{ value: amountEVMSent }("");
         if (!success) revert NativeTransferFailed();
     }
 

--- a/test/evm/foundry/local/HyperCoreLib.t.sol
+++ b/test/evm/foundry/local/HyperCoreLib.t.sol
@@ -32,8 +32,8 @@ contract HyperCoreLibWrapper {
         return HyperCoreLib.toSystemAddress(erc20CoreIndex);
     }
 
-    function transferNativeEVMToSelfOnSpot(uint256 amountEVM) external {
-        HyperCoreLib.transferNativeEVMToSelfOnSpot(amountEVM);
+    function transferNativeEVMToSelfOnSpot(uint256 amountEVM) external returns (uint256, uint64) {
+        return HyperCoreLib.transferNativeEVMToSelfOnSpot(amountEVM);
     }
 }
 
@@ -238,10 +238,37 @@ contract HyperCoreLibTest is HyperCoreMockHelper {
     function testTransferNativeEVMToSelfOnSpot_CreditsTheHypeSystemAddress() public {
         vm.deal(address(wrapper), 1 ether);
 
-        wrapper.transferNativeEVMToSelfOnSpot(0.4 ether);
+        (uint256 sent, uint64 credited) = wrapper.transferNativeEVMToSelfOnSpot(0.4 ether);
 
+        assertEq(sent, 0.4 ether);
+        assertEq(credited, 0.4e8); // 18 EVM decimals -> 8 Core decimals
         assertEq(HyperCoreLib.HYPE_SYSTEM_ADDRESS.balance, 0.4 ether);
         assertEq(address(wrapper).balance, 0.6 ether);
+    }
+
+    // Core credits amountEVM / 1e10 and drops the remainder, so unaligned wei must stay in the caller, not be lost
+    function testTransferNativeEVMToSelfOnSpot_RoundsDownAndKeepsDust() public {
+        uint256 dust = 1e10 - 1;
+        vm.deal(address(wrapper), 0.4 ether + dust);
+
+        (uint256 sent, uint64 credited) = wrapper.transferNativeEVMToSelfOnSpot(0.4 ether + dust);
+
+        assertEq(sent, 0.4 ether);
+        assertEq(credited, 0.4e8);
+        assertEq(HyperCoreLib.HYPE_SYSTEM_ADDRESS.balance, 0.4 ether);
+        assertEq(address(wrapper).balance, dust);
+    }
+
+    // Below 1e10 wei nothing is representable on Core, so nothing should leave the caller
+    function testTransferNativeEVMToSelfOnSpot_SendsNothingBelowOneCoreUnit() public {
+        vm.deal(address(wrapper), 1 ether);
+
+        (uint256 sent, uint64 credited) = wrapper.transferNativeEVMToSelfOnSpot(1e10 - 1);
+
+        assertEq(sent, 0);
+        assertEq(credited, 0);
+        assertEq(HyperCoreLib.HYPE_SYSTEM_ADDRESS.balance, 0);
+        assertEq(address(wrapper).balance, 1 ether);
     }
 
     function testTransferNativeEVMToSelfOnSpot_RevertsWhenTransferFails() public {


### PR DESCRIPTION
Native HYPE uses 18 decimals on HyperEVM and 8 decimals on HyperCore, so only EVM amounts that are multiples of 1e10 fully convert; any remainder is not representable on Core. The ERC20 bridging path accounts for this: [transferERC20EVMToCore](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L115) runs the requested amount through [maximumEVMSendAmountToAmounts](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L480-L503), which strips the unrepresentable remainder before sending and returns both the aligned EVM amount actually sent and the Core amount it will be credited as.

[transferNativeEVMToSelfOnSpot](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L212-L215) has no equivalent handling. It forwards amountEVM unchanged to HYPE_SYSTEM_ADDRESS in a raw value transfer and only checks whether the call succeeds. HyperCore credits amountEVM / 1e10 and the remainder is not credited back, while the helper neither rejects unaligned amounts nor reports the amount actually credited. An amountEVM below 1e10 wei receives no Core credit at all, and every larger, unaligned amount loses amountEVM % 1e10 wei, up to just under 1e-8 HYPE per call. The call itself still reports success, so the loss is silent.

Consider requiring amountEVM to be a nonzero multiple of 1e10, or rounding it down before the transfer and retaining the remainder in the calling contract, consistent with the ERC20 path. Consider also having transferNativeEVMToSelfOnSpot return the EVM amount sent and the Core amount credited, matching maximumEVMSendAmountToAmounts.