### PR TITLE
fix: L04 Bridge Safety Check Can Revert Instead Of Returning False, Disabling HyperEVM Fallback On Fills

### DIFF
--- a/contracts/libraries/HyperCoreLib.sol
+++ b/contracts/libraries/HyperCoreLib.sol
@@ -394,15 +394,6 @@ library HyperCoreLib {
     }
 
     /**
-     * @notice Whether `erc20CoreIndex` is native HYPE on the current chain.
-     * @param erc20CoreIndex The HyperCore index id of the token
-     * @return True if the index is native HYPE, false otherwise
-     */
-    function isHype(uint32 erc20CoreIndex) internal view returns (bool) {
-        return erc20CoreIndex == hypeCoreIndex();
-    }
-
-    /**
      * @notice Checks if an amount is safe to bridge from HyperEVM to HyperCore
      * @dev Verifies that the asset bridge has sufficient balance to cover the amount plus a buffer
      * @param erc20CoreIndex The HyperCore index id of the token

--- a/contracts/libraries/HyperCoreLib.sol
+++ b/contracts/libraries/HyperCoreLib.sol
@@ -415,8 +415,9 @@ library HyperCoreLib {
         uint64 coreAmount,
         uint64 coreBufferAmount
     ) internal view returns (bool) {
-        address bridgeAddress = toSystemAddress(erc20CoreIndex);
-        uint64 currentBridgeBalance = spotBalance(bridgeAddress, erc20CoreIndex);
+        // Deliberately not `toSystemAddress`: this is a predicate, and an unlinked token's system address simply
+        // holds nothing, so it evaluates to false instead of reverting a fill that has a HyperEVM fallback.
+        uint64 currentBridgeBalance = spotBalance(toSystemAddressNoRevert(erc20CoreIndex), erc20CoreIndex);
 
         // Return true if currentBridgeBalance >= coreAmount + coreBufferAmount
         return currentBridgeBalance >= coreAmount + coreBufferAmount;
@@ -434,9 +435,24 @@ library HyperCoreLib {
         // linkage resolves via tokenInfo, declared `tokenInfo(uint32)` in canonical L1Read.sol — an id
         // beyond that domain (spotBalance's uint64 also carries encoded outcome asset ids) can't be resolved.
         if (erc20CoreIndex > type(uint32).max) revert TokenNotBridgeable(erc20CoreIndex);
-        uint32 index = uint32(erc20CoreIndex);
-        if (isHype(index)) return HYPE_SYSTEM_ADDRESS; // must precede the linkage check: HYPE has no evmContract
-        if (tokenInfo(index).evmContract == address(0)) revert TokenNotBridgeable(erc20CoreIndex);
+        address systemAddress = toSystemAddressNoRevert(erc20CoreIndex);
+        // HYPE skips the linkage check: it has no evmContract
+        if (systemAddress != HYPE_SYSTEM_ADDRESS && tokenInfo(uint32(erc20CoreIndex)).evmContract == address(0)) {
+            revert TokenNotBridgeable(erc20CoreIndex);
+        }
+        return systemAddress;
+    }
+
+    /**
+     * @notice `toSystemAddress` without the linkage check: HYPE's fixed address, else the index-derived one.
+     * @dev For reads such as bridge-balance lookups. Anything that sends to the result must use `toSystemAddress`,
+     *      since a send to an unlinked token's derived address strands the funds.
+     * @param erc20CoreIndex The core token index id to convert
+     * @return The system address for the index on HyperCore
+     */
+    function toSystemAddressNoRevert(uint64 erc20CoreIndex) internal view returns (address) {
+        // A uint64 above the uint32 domain can never equal the uint32 HYPE index, so no range check is needed
+        if (erc20CoreIndex == hypeCoreIndex()) return HYPE_SYSTEM_ADDRESS;
         return address(uint160(BASE_ASSET_BRIDGE_ADDRESS_UINT256 + erc20CoreIndex));
     }
 

--- a/contracts/libraries/HyperCoreLib.sol
+++ b/contracts/libraries/HyperCoreLib.sol
@@ -408,7 +408,7 @@ library HyperCoreLib {
     ) internal view returns (bool) {
         // A predicate answers rather than reverts: an unbridgeable token is simply not safe to bridge, so the fill
         // path keeps its HyperEVM fallback instead of failing.
-        (address systemAddress, bool bridgeable) = toSystemAddressIfBridgeable(erc20CoreIndex);
+        (address systemAddress, bool bridgeable) = tryToSystemAddress(erc20CoreIndex);
         if (!bridgeable) return false;
 
         // Return true if currentBridgeBalance >= coreAmount + coreBufferAmount
@@ -420,12 +420,12 @@ library HyperCoreLib {
      *         a transfer to it credits the sender's spot balance on HyperCore; on HyperCore, a spot send to it
      *         credits the sender's balance on HyperEVM.
      * @dev Reverts if the token is not bridgeable, since a send to such an address would strand the funds. For a
-     *      non-reverting answer, use `toSystemAddressIfBridgeable`.
+     *      non-reverting answer, use `tryToSystemAddress`.
      * @param erc20CoreIndex The core token index id to convert
      * @return The token's system address, valid as a destination on either chain
      */
     function toSystemAddress(uint64 erc20CoreIndex) internal view returns (address) {
-        (address systemAddress, bool bridgeable) = toSystemAddressIfBridgeable(erc20CoreIndex);
+        (address systemAddress, bool bridgeable) = tryToSystemAddress(erc20CoreIndex);
         if (!bridgeable) revert TokenNotBridgeable(erc20CoreIndex);
         return systemAddress;
     }
@@ -439,9 +439,7 @@ library HyperCoreLib {
      * @return systemAddress The token's system address, valid as a destination on either chain
      * @return bridgeable False if a send to `systemAddress` would not be credited on the other side
      */
-    function toSystemAddressIfBridgeable(
-        uint64 erc20CoreIndex
-    ) internal view returns (address systemAddress, bool bridgeable) {
+    function tryToSystemAddress(uint64 erc20CoreIndex) internal view returns (address systemAddress, bool bridgeable) {
         // A uint64 above the uint32 domain can never equal the uint32 HYPE index, so no range check is needed
         if (erc20CoreIndex == hypeCoreIndex()) return (HYPE_SYSTEM_ADDRESS, true);
         systemAddress = address(uint160(BASE_ASSET_BRIDGE_ADDRESS_UINT256 + erc20CoreIndex));

--- a/contracts/libraries/HyperCoreLib.sol
+++ b/contracts/libraries/HyperCoreLib.sol
@@ -406,45 +406,49 @@ library HyperCoreLib {
         uint64 coreAmount,
         uint64 coreBufferAmount
     ) internal view returns (bool) {
-        // Deliberately not `toSystemAddress`: this is a predicate, and an unlinked token's system address simply
-        // holds nothing, so it evaluates to false instead of reverting a fill that has a HyperEVM fallback.
-        uint64 currentBridgeBalance = spotBalance(toSystemAddressNoRevert(erc20CoreIndex), erc20CoreIndex);
+        // A predicate answers rather than reverts: an unbridgeable token is simply not safe to bridge, so the fill
+        // path keeps its HyperEVM fallback instead of failing.
+        (address systemAddress, bool bridgeable) = toSystemAddressIfBridgeable(erc20CoreIndex);
+        if (!bridgeable) return false;
 
         // Return true if currentBridgeBalance >= coreAmount + coreBufferAmount
-        return currentBridgeBalance >= coreAmount + coreBufferAmount;
+        return spotBalance(systemAddress, erc20CoreIndex) >= coreAmount + coreBufferAmount;
     }
 
     /**
-     * @notice Converts a core index id to the address that bridges it back to the same address on HyperEVM
-     * @dev Native HYPE uses a fixed system address; every other token derives one from its Core index. An index
-     *      with no linked HyperEVM contract has no EVM side to credit, so a send to it would strand the funds.
+     * @notice Resolves a core index id to its system address, the bridge account shared by both chains. On HyperEVM,
+     *         a transfer to it credits the sender's spot balance on HyperCore; on HyperCore, a spot send to it
+     *         credits the sender's balance on HyperEVM.
+     * @dev Reverts if the token is not bridgeable, since a send to such an address would strand the funds. For a
+     *      non-reverting answer, use `toSystemAddressIfBridgeable`.
      * @param erc20CoreIndex The core token index id to convert
-     * @return The system address to send to on HyperCore
+     * @return The token's system address, valid as a destination on either chain
      */
     function toSystemAddress(uint64 erc20CoreIndex) internal view returns (address) {
-        // Only linked tokens convert between Core and EVM (docs: "HyperCore <> HyperEVM transfers"), and
-        // linkage resolves via tokenInfo, declared `tokenInfo(uint32)` in canonical L1Read.sol — an id
-        // beyond that domain (spotBalance's uint64 also carries encoded outcome asset ids) can't be resolved.
-        if (erc20CoreIndex > type(uint32).max) revert TokenNotBridgeable(erc20CoreIndex);
-        address systemAddress = toSystemAddressNoRevert(erc20CoreIndex);
-        // HYPE skips the linkage check: it has no evmContract
-        if (systemAddress != HYPE_SYSTEM_ADDRESS && tokenInfo(uint32(erc20CoreIndex)).evmContract == address(0)) {
-            revert TokenNotBridgeable(erc20CoreIndex);
-        }
+        (address systemAddress, bool bridgeable) = toSystemAddressIfBridgeable(erc20CoreIndex);
+        if (!bridgeable) revert TokenNotBridgeable(erc20CoreIndex);
         return systemAddress;
     }
 
     /**
-     * @notice `toSystemAddress` without the linkage check: HYPE's fixed address, else the index-derived one.
-     * @dev For reads such as bridge-balance lookups. Anything that sends to the result must use `toSystemAddress`,
-     *      since a send to an unlinked token's derived address strands the funds.
+     * @notice `toSystemAddress` that reports bridgeability instead of reverting on it.
+     * @dev Native HYPE uses a fixed system address and is always bridgeable; every other token derives one from
+     *      its Core index and is bridgeable only if linked to a HyperEVM contract. Still reverts if the tokenInfo
+     *      precompile call itself fails, like every other precompile read in this library.
      * @param erc20CoreIndex The core token index id to convert
-     * @return The system address for the index on HyperCore
+     * @return systemAddress The token's system address, valid as a destination on either chain
+     * @return bridgeable False if a send to `systemAddress` would not be credited on the other side
      */
-    function toSystemAddressNoRevert(uint64 erc20CoreIndex) internal view returns (address) {
+    function toSystemAddressIfBridgeable(
+        uint64 erc20CoreIndex
+    ) internal view returns (address systemAddress, bool bridgeable) {
         // A uint64 above the uint32 domain can never equal the uint32 HYPE index, so no range check is needed
-        if (erc20CoreIndex == hypeCoreIndex()) return HYPE_SYSTEM_ADDRESS;
-        return address(uint160(BASE_ASSET_BRIDGE_ADDRESS_UINT256 + erc20CoreIndex));
+        if (erc20CoreIndex == hypeCoreIndex()) return (HYPE_SYSTEM_ADDRESS, true);
+        systemAddress = address(uint160(BASE_ASSET_BRIDGE_ADDRESS_UINT256 + erc20CoreIndex));
+        // Only linked tokens convert between Core and EVM (docs: "HyperCore <> HyperEVM transfers"), and
+        // linkage resolves via tokenInfo, declared `tokenInfo(uint32)` in canonical L1Read.sol — an id
+        // beyond that domain (spotBalance's uint64 also carries encoded outcome asset ids) can't be resolved.
+        bridgeable = erc20CoreIndex <= type(uint32).max && tokenInfo(uint32(erc20CoreIndex)).evmContract != address(0);
     }
 
     /**

--- a/test/evm/foundry/local/HyperCoreLib.t.sol
+++ b/test/evm/foundry/local/HyperCoreLib.t.sol
@@ -24,10 +24,6 @@ contract HyperCoreLibWrapper {
         return HyperCoreLib.hypeCoreIndex();
     }
 
-    function isHype(uint32 erc20CoreIndex) external view returns (bool) {
-        return HyperCoreLib.isHype(erc20CoreIndex);
-    }
-
     function toSystemAddress(uint64 erc20CoreIndex) external view returns (address) {
         return HyperCoreLib.toSystemAddress(erc20CoreIndex);
     }
@@ -188,17 +184,6 @@ contract HyperCoreLibTest is HyperCoreMockHelper {
 
         vm.chainId(HyperCoreLib.HYPEREVM_TESTNET_CHAIN_ID);
         assertEq(wrapper.hypeCoreIndex(), HyperCoreLib.HYPE_CORE_INDEX_TESTNET);
-    }
-
-    function testIsHype() public {
-        vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
-        assertTrue(wrapper.isHype(HyperCoreLib.HYPE_CORE_INDEX));
-        assertFalse(wrapper.isHype(HyperCoreLib.HYPE_CORE_INDEX_TESTNET));
-        assertFalse(wrapper.isHype(uint32(HyperCoreLib.USDC_CORE_INDEX)));
-
-        vm.chainId(HyperCoreLib.HYPEREVM_TESTNET_CHAIN_ID);
-        assertTrue(wrapper.isHype(HyperCoreLib.HYPE_CORE_INDEX_TESTNET));
-        assertFalse(wrapper.isHype(HyperCoreLib.HYPE_CORE_INDEX));
     }
 
     // ============ toSystemAddress ============

--- a/test/evm/foundry/local/HyperCoreLib.t.sol
+++ b/test/evm/foundry/local/HyperCoreLib.t.sol
@@ -32,6 +32,18 @@ contract HyperCoreLibWrapper {
         return HyperCoreLib.toSystemAddress(erc20CoreIndex);
     }
 
+    function toSystemAddressNoRevert(uint64 erc20CoreIndex) external view returns (address) {
+        return HyperCoreLib.toSystemAddressNoRevert(erc20CoreIndex);
+    }
+
+    function isCoreAmountSafeToBridge(
+        uint64 erc20CoreIndex,
+        uint64 coreAmount,
+        uint64 coreBufferAmount
+    ) external view returns (bool) {
+        return HyperCoreLib.isCoreAmountSafeToBridge(erc20CoreIndex, coreAmount, coreBufferAmount);
+    }
+
     function transferNativeEVMToSelfOnSpot(uint256 amountEVM) external {
         HyperCoreLib.transferNativeEVMToSelfOnSpot(amountEVM);
     }
@@ -231,6 +243,62 @@ contract HyperCoreLibTest is HyperCoreMockHelper {
         vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
         vm.expectRevert(abi.encodeWithSelector(HyperCoreLib.TokenNotBridgeable.selector, outcomeAssetId));
         wrapper.toSystemAddress(outcomeAssetId);
+    }
+
+    // ============ toSystemAddressNoRevert ============
+
+    // The no-revert resolver is for reads: it derives an address for any id, linked or not, without a precompile call
+    function testToSystemAddressNoRevert_NeverReverts() public {
+        uint64 outcomeAssetId = 100_000_000 + uint64(type(uint32).max) * 10 + 1;
+        vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
+
+        // No tokenInfo mock is set: an unlinked index and an out-of-domain id both resolve arithmetically
+        assertEq(
+            wrapper.toSystemAddressNoRevert(42),
+            address(uint160(HyperCoreLib.BASE_ASSET_BRIDGE_ADDRESS_UINT256 + 42))
+        );
+        assertEq(
+            wrapper.toSystemAddressNoRevert(outcomeAssetId),
+            address(uint160(HyperCoreLib.BASE_ASSET_BRIDGE_ADDRESS_UINT256 + outcomeAssetId))
+        );
+        assertEq(wrapper.toSystemAddressNoRevert(HyperCoreLib.HYPE_CORE_INDEX), HyperCoreLib.HYPE_SYSTEM_ADDRESS);
+    }
+
+    // ============ isCoreAmountSafeToBridge ============
+
+    // A predicate must answer, not revert: an unlinked token's bridge address holds nothing, so the answer is
+    // false and the fill path keeps its HyperEVM fallback. No tokenInfo mock is set, proving the check never
+    // consults linkage.
+    function testIsCoreAmountSafeToBridge_ReturnsFalseForUnlinkedTokenInsteadOfReverting() public {
+        vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
+        mockSpotBalanceDefault(0, 0, 0);
+
+        assertFalse(wrapper.isCoreAmountSafeToBridge(42, 1, 0));
+
+        mockSpotBalanceDefault(10e8, 0, 0);
+        assertTrue(wrapper.isCoreAmountSafeToBridge(42, 9e8, 1e8));
+        assertFalse(wrapper.isCoreAmountSafeToBridge(42, 9e8, 1e8 + 1));
+    }
+
+    // HYPE's bridge balance lives at its fixed system address, not the index-derived one
+    function testIsCoreAmountSafeToBridge_ReadsHypeBalanceAtTheFixedSystemAddress() public {
+        vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
+        uint64 hypeIndex = HyperCoreLib.HYPE_CORE_INDEX;
+        HyperCoreLib.SpotBalance memory empty;
+        HyperCoreLib.SpotBalance memory funded = HyperCoreLib.SpotBalance({ total: 10e8, hold: 0, entryNtl: 0 });
+
+        vm.mockCall(
+            HyperCoreLib.SPOT_BALANCE_PRECOMPILE_ADDRESS,
+            abi.encode(address(uint160(HyperCoreLib.BASE_ASSET_BRIDGE_ADDRESS_UINT256 + hypeIndex)), hypeIndex),
+            abi.encode(empty)
+        );
+        vm.mockCall(
+            HyperCoreLib.SPOT_BALANCE_PRECOMPILE_ADDRESS,
+            abi.encode(HyperCoreLib.HYPE_SYSTEM_ADDRESS, hypeIndex),
+            abi.encode(funded)
+        );
+
+        assertTrue(wrapper.isCoreAmountSafeToBridge(hypeIndex, 5e8, 1e8));
     }
 
     // ============ transferNativeEVMToSelfOnSpot ============

--- a/test/evm/foundry/local/HyperCoreLib.t.sol
+++ b/test/evm/foundry/local/HyperCoreLib.t.sol
@@ -28,8 +28,8 @@ contract HyperCoreLibWrapper {
         return HyperCoreLib.toSystemAddress(erc20CoreIndex);
     }
 
-    function toSystemAddressIfBridgeable(uint64 erc20CoreIndex) external view returns (address, bool) {
-        return HyperCoreLib.toSystemAddressIfBridgeable(erc20CoreIndex);
+    function tryToSystemAddress(uint64 erc20CoreIndex) external view returns (address, bool) {
+        return HyperCoreLib.tryToSystemAddress(erc20CoreIndex);
     }
 
     function isCoreAmountSafeToBridge(
@@ -230,48 +230,48 @@ contract HyperCoreLibTest is HyperCoreMockHelper {
         wrapper.toSystemAddress(outcomeAssetId);
     }
 
-    // ============ toSystemAddressIfBridgeable ============
+    // ============ tryToSystemAddress ============
 
-    function testToSystemAddressIfBridgeable_LinkedTokenIsBridgeable() public {
+    function testTryToSystemAddress_LinkedTokenIsBridgeable() public {
         uint32 coreIndex = 42;
         mockTokenInfoDefault(makeAddr("erc20"), "TKN", 8);
         vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
 
-        (address systemAddress, bool bridgeable) = wrapper.toSystemAddressIfBridgeable(coreIndex);
+        (address systemAddress, bool bridgeable) = wrapper.tryToSystemAddress(coreIndex);
         assertEq(systemAddress, address(uint160(HyperCoreLib.BASE_ASSET_BRIDGE_ADDRESS_UINT256 + coreIndex)));
         assertTrue(bridgeable);
     }
 
     // Same derived address as the linked case, but reported unbridgeable instead of reverting
-    function testToSystemAddressIfBridgeable_UnlinkedTokenIsNotBridgeable() public {
+    function testTryToSystemAddress_UnlinkedTokenIsNotBridgeable() public {
         uint32 coreIndex = 42;
         mockTokenInfoDefault(address(0), "TKN", 8);
         vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
 
-        (address systemAddress, bool bridgeable) = wrapper.toSystemAddressIfBridgeable(coreIndex);
+        (address systemAddress, bool bridgeable) = wrapper.tryToSystemAddress(coreIndex);
         assertEq(systemAddress, address(uint160(HyperCoreLib.BASE_ASSET_BRIDGE_ADDRESS_UINT256 + coreIndex)));
         assertFalse(bridgeable);
     }
 
     // Out-of-domain ids are reported unbridgeable before any precompile call — note no tokenInfo mock is set here
-    function testToSystemAddressIfBridgeable_IdBeyondTokenInfoDomainIsNotBridgeable() public {
+    function testTryToSystemAddress_IdBeyondTokenInfoDomainIsNotBridgeable() public {
         uint64 outcomeAssetId = 100_000_000 + uint64(type(uint32).max) * 10 + 1;
         vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
 
-        (address systemAddress, bool bridgeable) = wrapper.toSystemAddressIfBridgeable(outcomeAssetId);
+        (address systemAddress, bool bridgeable) = wrapper.tryToSystemAddress(outcomeAssetId);
         assertEq(systemAddress, address(uint160(HyperCoreLib.BASE_ASSET_BRIDGE_ADDRESS_UINT256 + outcomeAssetId)));
         assertFalse(bridgeable);
     }
 
     // HYPE has no evmContract yet is always bridgeable, via its fixed system address — no tokenInfo mock is set here
-    function testToSystemAddressIfBridgeable_HypeIsAlwaysBridgeable() public {
+    function testTryToSystemAddress_HypeIsAlwaysBridgeable() public {
         vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
-        (address systemAddress, bool bridgeable) = wrapper.toSystemAddressIfBridgeable(HyperCoreLib.HYPE_CORE_INDEX);
+        (address systemAddress, bool bridgeable) = wrapper.tryToSystemAddress(HyperCoreLib.HYPE_CORE_INDEX);
         assertEq(systemAddress, HyperCoreLib.HYPE_SYSTEM_ADDRESS);
         assertTrue(bridgeable);
 
         vm.chainId(HyperCoreLib.HYPEREVM_TESTNET_CHAIN_ID);
-        (systemAddress, bridgeable) = wrapper.toSystemAddressIfBridgeable(HyperCoreLib.HYPE_CORE_INDEX_TESTNET);
+        (systemAddress, bridgeable) = wrapper.tryToSystemAddress(HyperCoreLib.HYPE_CORE_INDEX_TESTNET);
         assertEq(systemAddress, HyperCoreLib.HYPE_SYSTEM_ADDRESS);
         assertTrue(bridgeable);
     }

--- a/test/evm/foundry/local/HyperCoreLib.t.sol
+++ b/test/evm/foundry/local/HyperCoreLib.t.sol
@@ -28,8 +28,8 @@ contract HyperCoreLibWrapper {
         return HyperCoreLib.toSystemAddress(erc20CoreIndex);
     }
 
-    function toSystemAddressNoRevert(uint64 erc20CoreIndex) external view returns (address) {
-        return HyperCoreLib.toSystemAddressNoRevert(erc20CoreIndex);
+    function toSystemAddressIfBridgeable(uint64 erc20CoreIndex) external view returns (address, bool) {
+        return HyperCoreLib.toSystemAddressIfBridgeable(erc20CoreIndex);
     }
 
     function isCoreAmountSafeToBridge(
@@ -230,39 +230,72 @@ contract HyperCoreLibTest is HyperCoreMockHelper {
         wrapper.toSystemAddress(outcomeAssetId);
     }
 
-    // ============ toSystemAddressNoRevert ============
+    // ============ toSystemAddressIfBridgeable ============
 
-    // The no-revert resolver is for reads: it derives an address for any id, linked or not, without a precompile call
-    function testToSystemAddressNoRevert_NeverReverts() public {
+    function testToSystemAddressIfBridgeable_LinkedTokenIsBridgeable() public {
+        uint32 coreIndex = 42;
+        mockTokenInfoDefault(makeAddr("erc20"), "TKN", 8);
+        vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
+
+        (address systemAddress, bool bridgeable) = wrapper.toSystemAddressIfBridgeable(coreIndex);
+        assertEq(systemAddress, address(uint160(HyperCoreLib.BASE_ASSET_BRIDGE_ADDRESS_UINT256 + coreIndex)));
+        assertTrue(bridgeable);
+    }
+
+    // Same derived address as the linked case, but reported unbridgeable instead of reverting
+    function testToSystemAddressIfBridgeable_UnlinkedTokenIsNotBridgeable() public {
+        uint32 coreIndex = 42;
+        mockTokenInfoDefault(address(0), "TKN", 8);
+        vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
+
+        (address systemAddress, bool bridgeable) = wrapper.toSystemAddressIfBridgeable(coreIndex);
+        assertEq(systemAddress, address(uint160(HyperCoreLib.BASE_ASSET_BRIDGE_ADDRESS_UINT256 + coreIndex)));
+        assertFalse(bridgeable);
+    }
+
+    // Out-of-domain ids are reported unbridgeable before any precompile call — note no tokenInfo mock is set here
+    function testToSystemAddressIfBridgeable_IdBeyondTokenInfoDomainIsNotBridgeable() public {
         uint64 outcomeAssetId = 100_000_000 + uint64(type(uint32).max) * 10 + 1;
         vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
 
-        // No tokenInfo mock is set: an unlinked index and an out-of-domain id both resolve arithmetically
-        assertEq(
-            wrapper.toSystemAddressNoRevert(42),
-            address(uint160(HyperCoreLib.BASE_ASSET_BRIDGE_ADDRESS_UINT256 + 42))
-        );
-        assertEq(
-            wrapper.toSystemAddressNoRevert(outcomeAssetId),
-            address(uint160(HyperCoreLib.BASE_ASSET_BRIDGE_ADDRESS_UINT256 + outcomeAssetId))
-        );
-        assertEq(wrapper.toSystemAddressNoRevert(HyperCoreLib.HYPE_CORE_INDEX), HyperCoreLib.HYPE_SYSTEM_ADDRESS);
+        (address systemAddress, bool bridgeable) = wrapper.toSystemAddressIfBridgeable(outcomeAssetId);
+        assertEq(systemAddress, address(uint160(HyperCoreLib.BASE_ASSET_BRIDGE_ADDRESS_UINT256 + outcomeAssetId)));
+        assertFalse(bridgeable);
+    }
+
+    // HYPE has no evmContract yet is always bridgeable, via its fixed system address — no tokenInfo mock is set here
+    function testToSystemAddressIfBridgeable_HypeIsAlwaysBridgeable() public {
+        vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
+        (address systemAddress, bool bridgeable) = wrapper.toSystemAddressIfBridgeable(HyperCoreLib.HYPE_CORE_INDEX);
+        assertEq(systemAddress, HyperCoreLib.HYPE_SYSTEM_ADDRESS);
+        assertTrue(bridgeable);
+
+        vm.chainId(HyperCoreLib.HYPEREVM_TESTNET_CHAIN_ID);
+        (systemAddress, bridgeable) = wrapper.toSystemAddressIfBridgeable(HyperCoreLib.HYPE_CORE_INDEX_TESTNET);
+        assertEq(systemAddress, HyperCoreLib.HYPE_SYSTEM_ADDRESS);
+        assertTrue(bridgeable);
     }
 
     // ============ isCoreAmountSafeToBridge ============
 
-    // A predicate must answer, not revert: an unlinked token's bridge address holds nothing, so the answer is
-    // false and the fill path keeps its HyperEVM fallback. No tokenInfo mock is set, proving the check never
-    // consults linkage.
+    // A predicate must answer, not revert: an unlinked token is reported unsafe even if its bridge address happens
+    // to hold balance, so the fill path keeps its HyperEVM fallback and never reaches the reverting send
     function testIsCoreAmountSafeToBridge_ReturnsFalseForUnlinkedTokenInsteadOfReverting() public {
         vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
-        mockSpotBalanceDefault(0, 0, 0);
+        mockSpotBalanceDefault(10e8, 0, 0);
 
+        mockTokenInfoDefault(address(0), "TKN", 8);
         assertFalse(wrapper.isCoreAmountSafeToBridge(42, 1, 0));
 
-        mockSpotBalanceDefault(10e8, 0, 0);
+        mockTokenInfoDefault(makeAddr("erc20"), "TKN", 8);
         assertTrue(wrapper.isCoreAmountSafeToBridge(42, 9e8, 1e8));
         assertFalse(wrapper.isCoreAmountSafeToBridge(42, 9e8, 1e8 + 1));
+    }
+
+    // Out-of-domain ids are unsafe without any precompile call — no tokenInfo or spotBalance mock is set here
+    function testIsCoreAmountSafeToBridge_ReturnsFalseForIdBeyondTokenInfoDomain() public {
+        vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
+        assertFalse(wrapper.isCoreAmountSafeToBridge(100_000_000 + uint64(type(uint32).max) * 10 + 1, 1, 0));
     }
 
     // HYPE's bridge balance lives at its fixed system address, not the index-derived one


### PR DESCRIPTION
[HyperCoreLib.isCoreAmountSafeToBridge](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L413-L423) reports whether the asset bridge holds enough to cover a transfer, and callers use a false answer to pay the user on HyperEVM instead of bridging. This matters most on the Across fill path: HyperliquidDepositHandler is an [AcrossMessageHandler](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/handlers/HyperliquidDepositHandler.sol#L22) whose [handleV3AcrossMessage](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/handlers/HyperliquidDepositHandler.sol#L128-L133) is invoked by the SpokePool after it has already transferred the tokens to the handler, so something must be done with funds that have arrived. [_depositToHypercore](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/handlers/HyperliquidDepositHandler.sol#L277-L289) runs the check before making any state changes or withdrawals and, on false, transfers the tokens to the user on HyperEVM and emits FallbackToHyperEVM, allowing the fill to succeed. [HyperCoreFlowExecutor](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/periphery/mintburn/HyperCoreFlowExecutor.sol#L571) applies the same pattern through _fallbackHyperEVMFlow, as does [its swap path](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/periphery/mintburn/HyperCoreFlowExecutor.sol#L717).

The check resolved the bridge address through toAssetBridgeAddress, plain arithmetic that could not fail, so it always returned true or false. [Pull request #1530](https://github.com/across-protocol/contracts/pull/1530) repoints [line 418](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L418) to [toSystemAddress](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L432-L441), which reverts when the core index exceeds uint32, when the token's Core entry has no linked HyperEVM contract, or when the tokenInfo precompile call fails. Reverting is correct where toSystemAddress resolves a destination that funds are about to be sent to, since sending to an unlinked token would strand them. However, inherited by a check whose purpose is to return an answer, it changes what happens on the fill path: for a token with no linked HyperEVM contract the handler now reverts, so the SpokePool fill reverts and the intent goes unfilled. Because the condition is permanent rather than transient, every relayer fails identically and the user waits for the origin-chain refund instead of receiving the tokens on HyperEVM.

The handler's other entry point, [depositToHypercore](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/handlers/HyperliquidDepositHandler.sol#L110), performs its own safeTransferFrom, so a revert there simply unwinds and leaves the caller holding the tokens, and an unlinked token is a misconfiguration that arguably should fail loudly rather than silently divert users to HyperEVM.

Consider giving the check a non-reverting way to resolve the address, for example a variant returning a success flag alongside it, and having isCoreAmountSafeToBridge return false when resolution fails, so the fill path keeps its fallback; a token with no HyperEVM side is genuinely not safe to bridge. toSystemAddress should keep reverting for callers that resolve an address in order to send to it. If failing loudly on an unlinked token is intended, consider applying that only to depositToHypercore, where a revert unwinds the caller's own transfer and leaves them holding their tokens, while keeping the HyperEVM fallback on handleV3AcrossMessage, where a revert makes the SpokePool fill fail and the intent go unfilled.