### PR TITLE
fix: N07 unused error

### DIFF
--- a/contracts/libraries/HyperCoreLib.sol
+++ b/contracts/libraries/HyperCoreLib.sol
@@ -85,7 +85,6 @@ library HyperCoreLib {
     error TokenInfoPrecompileCallFailed();
     error SpotPxPrecompileCallFailed();
     error InsufficientAmountForAccountActivation();
-    error MaximumEVMSendAmountTooLarge();
     error TokenNotBridgeable(uint64 erc20CoreIndex);
     error NativeTransferFailed();
 


### PR DESCRIPTION
In HyperCoreLib.sol, the [MaximumEVMSendAmountTooLarge error](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L88) is unused.

To improve the overall clarity, intentionality, and readability of the codebase, consider either using or removing any currently unused errors.