### PR TITLE
fix(ci): pin Foundry and HyperEVM test fork

### DIFF
--- a/.github/actions/cache-evm-artifacts/action.yml
+++ b/.github/actions/cache-evm-artifacts/action.yml
@@ -23,7 +23,7 @@ runs:
         # The job that generates the artifacts is responsible for archiving them to the cache tarball. This avoids any
         # conflicts with other caching actions that might have cleaned some of cached contents.
         path: evm-artifacts.tar
-        key: evm-artifacts-${{ runner.os }}-node-${{ steps.resolved-node.outputs.version }}-${{ hashFiles('yarn.lock', 'foundry.toml', 'contracts/**/*.sol') }}
+        key: evm-artifacts-${{ runner.os }}-node-${{ steps.resolved-node.outputs.version }}-${{ hashFiles('yarn.lock', 'foundry.toml', 'contracts/**/*.sol', '.github/actions/generate-evm-artifacts/action.yml') }}
     - name: Unpack restored EVM artifacts
       if: steps.evm-artifacts-cache.outputs.cache-hit == 'true'
       shell: bash

--- a/.github/actions/generate-evm-artifacts/action.yml
+++ b/.github/actions/generate-evm-artifacts/action.yml
@@ -18,6 +18,8 @@ runs:
       run: yarn install --frozen-lockfile
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: v1.7.1
     - name: Install forge dependencies
       shell: bash
       run: forge install

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -205,6 +205,8 @@ jobs:
         run: yarn install --frozen-lockfile --ignore-optional
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
       - name: Install forge dependencies
         run: forge install
       - name: Inspect storage layouts

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ yarn build # Will build all code. Compile solidity & rust (local toolchain), gen
 yarn build-verified # Will build all code. Compile solidity & rust (verified docker build), generate ts outputs
 ```
 
+EVM CI builds and tests use Foundry **v1.7.1**. Run `foundryup --install v1.7.1` to match CI locally.
+Keep the version pins in `.github/actions/generate-evm-artifacts/action.yml` and `.github/workflows/pr.yml` in sync.
+
 ## Test
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ yarn test-svm # Only test SVM code (local toolchain build)
 yarn test-svm-solana-verify # Only test SVM code (verified docker build)
 ```
 
+HyperEVM simulator tests fork EVM state at block **44,686,920** to avoid races when the public RPC reports a new
+block before all backends can serve it. The simulator's explicit HyperCore precompile calls still use live data.
+
 ## Lint
 
 ```shell

--- a/test/evm/foundry/local/external/hyper-evm-lib/test/BaseSimulatorTest.sol
+++ b/test/evm/foundry/local/external/hyper-evm-lib/test/BaseSimulatorTest.sol
@@ -33,7 +33,9 @@ abstract contract BaseSimulatorTest is Test {
 
     function setUp() public virtual {
         string memory hyperliquidRpc = "https://rpc.hyperliquid.xyz/evm";
-        vm.createSelectFork(hyperliquidRpc);
+        // Pin EVM state to avoid latest-block races across the public RPC's backends.
+        // The simulator's explicit HyperCore precompile calls still read live data.
+        vm.createSelectFork(hyperliquidRpc, 44_686_920);
 
         hyperCore = CoreSimulatorLib.init();
 


### PR DESCRIPTION
Two independent issues make master's EVM CI fail: the unpinned Foundry installation moved from v1.7.1 to v1.8.1 and triggered Solidity 0.8.30's `Tag too large for reserved space` compiler error; HyperEVM simulator setup also races the public RPC's latest block and fails with `invalid block height`.

Pin both CI build and test installations to v1.7.1, the version used by [master's last successful build](https://github.com/across-protocol/contracts/actions/runs/32507876728). Include the build action in the artifact cache key so changing the toolchain pin invalidates cached artifacts, and document how to match CI locally.

Pin the simulator's EVM fork to block 44,686,920, whose availability was checked against the public RPC. Its explicit HyperCore precompile reads remain live. This changes only the test fixture; production contract sources and compiler configuration remain unchanged.

Validation: formatting and diff checks pass, and all 45 tests across the three affected simulator suites pass with the pinned fork. The Foundry pin restored successful EVM artifact generation in CI; the same isolated v1.8.1 build fails with dynamic test linking enabled and passes with it disabled. All checks now pass on commit 2081ee9786599278928db2d07a53aacb29a26cc5 in [CI run 34253659880](https://github.com/across-protocol/contracts/actions/runs/34253659880). The TypeScript job required one diagnostic rerun after GitHub's internal artifact ListArtifacts API returned an intermediary 403; both artifact downloads and compilation then passed without code or permission changes.
