### PR TITLE
fix: N06 hypeCoreIndex Silently Defaults To Mainnet Off HyperEVM Instead Of Reverting

### DIFF
--- a/contracts/libraries/HyperCoreLib.sol
+++ b/contracts/libraries/HyperCoreLib.sol
@@ -88,6 +88,7 @@ library HyperCoreLib {
     error MaximumEVMSendAmountTooLarge();
     error TokenNotBridgeable(uint64 erc20CoreIndex);
     error NativeTransferFailed();
+    error UnsupportedChain();
 
     /**
      * @notice Transfer `amountEVM` from HyperEVM to `to` on HyperCore.
@@ -386,11 +387,14 @@ library HyperCoreLib {
 
     /**
      * @notice The Core index of native HYPE on the current chain.
-     * @dev Differs between mainnet and testnet, so it cannot be a plain constant at the call site.
+     * @dev Differs between mainnet and testnet, so it cannot be a plain constant at the call site. Reverts off
+     *      HyperEVM rather than defaulting, since the index has no meaning there.
      * @return The HyperCore index id of native HYPE
      */
     function hypeCoreIndex() internal view returns (uint32) {
-        return block.chainid == HYPEREVM_TESTNET_CHAIN_ID ? HYPE_CORE_INDEX_TESTNET : HYPE_CORE_INDEX;
+        if (block.chainid == HYPEREVM_CHAIN_ID) return HYPE_CORE_INDEX;
+        if (block.chainid == HYPEREVM_TESTNET_CHAIN_ID) return HYPE_CORE_INDEX_TESTNET;
+        revert UnsupportedChain();
     }
 
     /**

--- a/test/evm/foundry/local/HyperCoreLib.t.sol
+++ b/test/evm/foundry/local/HyperCoreLib.t.sol
@@ -178,6 +178,13 @@ contract HyperCoreLibTest is HyperCoreMockHelper {
         assertEq(wrapper.hypeCoreIndex(), HyperCoreLib.HYPE_CORE_INDEX_TESTNET);
     }
 
+    // Off HyperEVM the index has no meaning, so resolving it should fail loudly, not default to mainnet
+    function testHypeCoreIndex_RevertsOffHyperEVM() public {
+        vm.chainId(1);
+        vm.expectRevert(HyperCoreLib.UnsupportedChain.selector);
+        wrapper.hypeCoreIndex();
+    }
+
     function testIsHype() public {
         vm.chainId(HyperCoreLib.HYPEREVM_CHAIN_ID);
         assertTrue(wrapper.isHype(HyperCoreLib.HYPE_CORE_INDEX));


### PR DESCRIPTION
[HyperCoreLib.hypeCoreIndex](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L387-L394), which backs [isHype](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L396-L403) and the HYPE branch of [toSystemAddress](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L432-L441), resolves the native HYPE Core index with a two-way ternary: the testnet index on HYPEREVM_TESTNET_CHAIN_ID, and the mainnet index on every other block.chainid. HyperCoreLib separately defines [isHyperEVMChain](https://github.com/across-protocol/contracts/blob/6e7a99497c051a45bd7e72615be3f68b244c070f/contracts/libraries/HyperCoreLib.sol#L378-L385), which correctly recognizes only HYPEREVM_CHAIN_ID and HYPEREVM_TESTNET_CHAIN_ID as valid, but hypeCoreIndex never calls it. If the library is ever exercised on a chain that is neither HyperEVM mainnet nor testnet, for example a misconfigured deployment or a fork test that omits vm.chainid, hypeCoreIndex still returns the mainnet HYPE index instead of reverting, and isHype/toSystemAddress proceed to treat that index as bridgeable to HYPE_SYSTEM_ADDRESS without ever reaching a precompile call that would fail loudly on the wrong chain.

Consider having hypeCoreIndex, or its callers isHype and toSystemAddress, revert when isHyperEVMChain returns false, so that use of the library off HyperEVM fails immediately rather than silently defaulting to mainnet behavior.